### PR TITLE
Update logger type hint

### DIFF
--- a/src/cbfkit/utils/logger.py
+++ b/src/cbfkit/utils/logger.py
@@ -27,7 +27,7 @@ Examples
 """
 
 import os
-from typing import Dict, Any
+from typing import Dict, Any, List
 import pandas as pd
 
 # Main logger variable
@@ -69,7 +69,7 @@ def write_log(filepath: str) -> None:
     df.to_csv(filepath)
 
 
-def extract_log(key: str) -> None:
+def extract_log(key: str) -> List[Any]:
     """Extracts the key data from the log.
 
     Args:


### PR DESCRIPTION
## Summary
- import `List` in `src/cbfkit/utils/logger.py`
- change `extract_log` return type from `None` to `List[Any]`
