### PR TITLE
Consolidate duplicated matrix utilities

### DIFF
--- a/src/cbfkit/utils/__init__.py
+++ b/src/cbfkit/utils/__init__.py
@@ -1,0 +1,17 @@
+"""Utility helpers exposed at the package level."""
+
+from cbfkit.utils.matrix_vector_operations import (
+    block_diag_matrix,
+    hat,
+    normalize,
+    vee,
+)
+from cbfkit.utils.miscellaneous import tanh_sigmoid_func
+
+__all__ = [
+    "normalize",
+    "hat",
+    "vee",
+    "block_diag_matrix",
+    "tanh_sigmoid_func",
+]

--- a/src/cbfkit/utils/miscellaneous.py
+++ b/src/cbfkit/utils/miscellaneous.py
@@ -1,58 +1,24 @@
-import jax
 import jax.numpy as jnp
-from jax import Array, jit
+
+from cbfkit.utils.matrix_vector_operations import (
+    block_diag_matrix,
+    hat,
+    normalize,
+    vee,
+)
+
+__all__ = ["normalize", "hat", "vee", "block_diag_matrix", "tanh_sigmoid_func"]
 
 
-def normalize(a, axis=-1, order=2):
-    l2 = jnp.atleast_1d(jnp.linalg.norm(a, order, axis))
-    mask = l2 == 0
-    modified_l2 = jax.lax.cond(mask.any(), lambda x: jnp.where(mask, 1, x), lambda x: x, l2)
-
-    return (a / jnp.expand_dims(modified_l2, axis)).reshape(a.shape)
-
-
-def hat(v):
-    return jnp.array([[0.0, -v[2], v[1]], [v[2], 0.0, -v[0]], [-v[1], v[0], 0.0]])
-
-
-def vee(M):
-    m1 = (M[2, 1] - M[1, 2]) / 2
-    m2 = (M[0, 2] - M[2, 0]) / 2
-    m3 = (M[1, 0] - M[0, 1]) / 2
-    return jnp.array([m1, m2, m3])
-
-
-@jit
-def block_diag_matrix(A: Array, B: Array) -> Array:
-    """Creates new block diagonal matrix C = [[A, 0], [0, B]] from two matrices A, B.
-
-    Args:
-        A (Array): matrix 1
-        B (Array): matrix 2
-
-    Returns:
-        Array: block diagonal matrix
-    """
-    m, n = A.shape
-    p, q = B.shape
-
-    C = jnp.zeros((m + p, n + q), dtype=A.dtype)
-    C = C.at[:m, :n].set(A)
-    C = C.at[m:, n:].set(B)
-
-    return C
-
-
-@jit
 def tanh_sigmoid_func(x: float, xbar: float):
-    """Computes the value of the hyperbolic tangent sigmoid function.
+    """Compute the value of the hyperbolic tangent sigmoid function.
 
     Args:
-        x (float): argument to sigmoid
-        xbar (float): maximum value of argument
+        x (float): argument to sigmoid.
+        xbar (float): maximum value of argument.
 
     Returns:
-        float: result
+        float: Result of the smooth saturation function.
     """
     k = 100
     return x * (1 / 2 + 1 / 2 * jnp.tanh(k * x)) + (xbar - x) * (

--- a/tests/test_utils/test_matrix_vector_operations.py
+++ b/tests/test_utils/test_matrix_vector_operations.py
@@ -1,0 +1,49 @@
+import pytest
+
+jax = pytest.importorskip("jax")
+jnp = jax.numpy
+
+from cbfkit.utils import block_diag_matrix, hat, normalize, tanh_sigmoid_func, vee
+from cbfkit.utils import matrix_vector_operations as mvo
+from cbfkit.utils import miscellaneous as misc
+
+
+def test_helpers_are_reexported():
+    assert normalize is mvo.normalize is misc.normalize
+    assert hat is mvo.hat is misc.hat
+    assert vee is mvo.vee is misc.vee
+    assert block_diag_matrix is mvo.block_diag_matrix is misc.block_diag_matrix
+
+
+def test_normalize_behaviour():
+    vec = jnp.array([3.0, 4.0, 0.0])
+    normalized = normalize(vec)
+    assert bool(jnp.allclose(normalized, jnp.array([0.6, 0.8, 0.0])))
+
+
+def test_normalize_handles_zero_vector():
+    vec = jnp.zeros(3)
+    normalized = normalize(vec)
+    assert bool(jnp.allclose(normalized, jnp.zeros(3)))
+
+
+def test_hat_and_vee_are_inverses():
+    vec = jnp.array([1.2, -0.5, 0.3])
+    reconstructed = vee(hat(vec))
+    assert bool(jnp.allclose(reconstructed, vec))
+
+
+def test_block_diag_matrix_constructs_expected_layout():
+    mat1 = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    mat2 = jnp.array([[5.0]])
+    block = block_diag_matrix(mat1, mat2)
+    expected = jnp.array([[1.0, 2.0, 0.0], [3.0, 4.0, 0.0], [0.0, 0.0, 5.0]])
+    assert bool(jnp.allclose(block, expected))
+
+
+def test_tanh_sigmoid_limits():
+    upper = 2.0
+    below = tanh_sigmoid_func(0.0, upper)
+    above = tanh_sigmoid_func(upper, upper)
+    assert below >= 0.0
+    assert jnp.isclose(above, upper, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Summary
- expose shared matrix helper functions through cbfkit.utils and remove duplicate implementations from miscellaneous
- re-export the canonical helpers from the package init for a stable public API
- add unit tests that verify the helpers are aliased consistently and cover key behaviors

## Testing
- uv run pytest tests/test_utils/test_matrix_vector_operations.py
