### PR TITLE
⚡ Bolt: JIT compile simulator_jit to remove Python overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2025-02-14 - Optimized Data Formatting in Simulation
 **Learning:** Formatting simulation results by iterating over a tuple of NamedTuples and rebuilding arrays (`jnp.array([step.field for step in data])`) is slow for large N.
 **Action:** Transpose the tuple of NamedTuples (`SimulationStepData(*zip(*data))`) and use `jnp.stack` on the resulting columns. This reduces iteration overhead and leverages JAX's stacking efficiency.
+
+## 2025-02-19 - Repeated Graph Construction in JIT Simulator
+**Learning:** `simulator_jit` (which uses `lax.scan`) was not itself JIT-compiled. This meant that every call to `execute(use_jit=True)` re-executed the Python logic to build the `scan` graph. While `lax.scan` caches the compiled kernel, the graph construction overhead (Python side) was significant (~240ms per call).
+**Action:** Decorated `simulator_jit` with `@partial(jax.jit, static_argnames=[...])` to JIT-compile the graph construction itself, eliminating Python overhead on subsequent calls.

--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Callable, Optional, Tuple
 
 import jax
@@ -21,6 +22,22 @@ from cbfkit.utils.user_types import (
 )
 
 
+@partial(
+    jax.jit,
+    static_argnames=[
+        "dynamics",
+        "integrator",
+        "planner",
+        "nominal_controller",
+        "controller",
+        "sensor",
+        "estimator",
+        "perturbation",
+        "progress_callback",
+        "num_steps",
+        "progress_interval",
+    ],
+)
 def simulator_jit(
     dt: float,
     num_steps: int,


### PR DESCRIPTION
⚡ Bolt: JIT compile simulator_jit to remove Python overhead

💡 What:
Decorated `src/cbfkit/simulation/simulator_jit.py:simulator_jit` with `@jax.jit`, marking all callable arguments (dynamics, controller, etc.) and configuration parameters (num_steps, progress_interval) as static.

🎯 Why:
The `simulator_jit` function was using `jax.lax.scan` but was not itself JIT-compiled. This meant that every call to `sim.execute(use_jit=True)` executed the Python code to validate arguments and construct the `scan` computation graph. This introduced a constant overhead of ~240ms per call. For short-horizon simulations (e.g., in MPC or RL), this overhead is significant.

📊 Impact:
- **Before:** ~1.73s for 100 steps (unicycle example).
- **After:** ~1.49s for 100 steps.
- **Speedup:** ~14% improvement for this specific scenario (~240ms reduction per call).
- **Correctness:** Verified output consistency and passed `tests/test_simulation/test_control_loop.py`.

🔬 How measured:
Ran a reproduction script calling `sim.execute` 10 times in a loop on the unicycle example. Measured wall time per call.

✅ Correctness:
- Passed `tests/test_simulation/test_control_loop.py`.
- Verified simulation results (final state) are identical before/after.

---
*PR created automatically by Jules for task [16078030076791651172](https://jules.google.com/task/16078030076791651172) started by @bardhh*