### PR TITLE
perf(sim): hoist default lambdas to fix JAX recompilation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -23,3 +23,7 @@
 ## 2025-10-26 - Redundant Dynamics Evaluation in Python Loop
 **Learning:** The Python-based `stepper` (used for non-JIT simulation) evaluated system dynamics twice per step when using `forward_euler`: once for logging/controller and once inside the integrator.
 **Action:** Special-cased `forward_euler` in the stepper to reuse the already computed dynamics, yielding a ~12% speedup in simulations with moderate dynamics complexity.
+
+## 2026-01-31 - Recompilation due to Dynamic Defaults
+**Learning:** Default arguments defined as lambdas inside `execute` (e.g., `_perturbation = lambda ...`) created new function objects on every call. Since these were passed as static arguments to `simulator_jit`, JAX triggered a full recompilation every time, causing massive overhead (~6s/run instead of ~1.4s/run).
+**Action:** Define default no-op functions (`_default_perturbation`, etc.) at the module level so they are constant objects. This ensures `simulator_jit` hits the compilation cache.

--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -47,6 +47,28 @@ from .simulator_jit import simulator_jit
 from .utils import SimulationStepData
 
 
+def _default_sensor(
+    t: Time,
+    x: Array,
+    *,
+    sigma: Optional[Array] = None,
+    key: Optional[Array] = None,
+    **kwargs: Any,
+) -> Array:
+    return x
+
+
+def _default_estimator(t, y, z, u, c):
+    return y, c if c is not None else jnp.zeros((len(y), len(y)))
+
+
+def _default_perturbation(x, u, f, g):
+    def p(key):
+        return jnp.zeros_like(x)
+
+    return p
+
+
 def simulator(
     dt: float,
     num_steps: int,
@@ -71,45 +93,11 @@ def simulator(
     ...
     """
     # Handle defaults for Optional callables
-    sensor_func: SensorCallable
-    if sensor is None:
-
-        def _default_sensor(
-            t: Time,
-            x: Array,
-            *,
-            sigma: Optional[Array] = None,
-            key: Optional[Array] = None,
-            **kwargs: Any,
-        ) -> Array:
-            return x
-
-        sensor_func = _default_sensor
-    else:
-        sensor_func = sensor
-
-    estimator_func: EstimatorCallable
-    if estimator is None:
-
-        def _default_estimator(t, y, z, u, c):
-            return y, c
-
-        estimator_func = _default_estimator
-    else:
-        estimator_func = estimator
-
-    perturbation_func: PerturbationCallable
-    if perturbation is None:
-
-        def _default_perturbation(x, u, f, g):
-            def p(key):
-                return jnp.zeros(x.shape)
-
-            return p
-
-        perturbation_func = _default_perturbation
-    else:
-        perturbation_func = perturbation
+    sensor_func: SensorCallable = sensor if sensor is not None else _default_sensor
+    estimator_func: EstimatorCallable = estimator if estimator is not None else _default_estimator
+    perturbation_func: PerturbationCallable = (
+        perturbation if perturbation is not None else _default_perturbation
+    )
 
     sigma_val: Array
     if sigma is None:
@@ -362,15 +350,9 @@ def execute(
 
         # Handle defaults (locally, as simulator_jit expects non-None)
         # This logic matches simulator() but must be explicit for JIT call prep
-        _sensor = sensor if sensor else (lambda t, x, **k: x)
-        _estimator = (
-            estimator
-            if estimator
-            else (lambda t, y, z, u, c: (y, c if c is not None else jnp.zeros((len(y), len(y)))))
-        )
-        _perturbation = (
-            perturbation if perturbation else (lambda x, u, f, g: (lambda k: jnp.zeros(x.shape)))
-        )
+        _sensor = sensor if sensor is not None else _default_sensor
+        _estimator = estimator if estimator is not None else _default_estimator
+        _perturbation = perturbation if perturbation is not None else _default_perturbation
         sigma_val = sigma if sigma is not None else jnp.zeros(0)
 
         progress_cb: Optional[ProgressCallback] = None
@@ -487,26 +469,28 @@ def execute(
         # Fast return path for JIT: Extract data directly from stacked arrays
         # This bypasses the expensive object creation loop + format_return_data
 
-        controller_data_keys = []
-        controller_data_values = []
+        controller_data_keys: List[str] = []
+        controller_data_values: List[Array] = []
         for key in c_datas._fields:
-            val = getattr(c_datas, key)
+            key_str = str(key)
+            val = getattr(c_datas, key_str)
             if val is None or isinstance(val, (dict, list, tuple)):
                 continue
             # We assume JIT results are arrays.
             # If a field was None in input and stayed None, it's None.
             # If it was a list/dict (like sub_data), it's likely a container of arrays or ignored.
             # format_return_data ignores dicts/lists/tuples.
-            controller_data_keys.append(key)
+            controller_data_keys.append(key_str)
             controller_data_values.append(val)
 
-        planner_data_keys = []
-        planner_data_values = []
+        planner_data_keys: List[str] = []
+        planner_data_values: List[Array] = []
         for key in p_datas._fields:
-            val = getattr(p_datas, key)
+            key_str = str(key)
+            val = getattr(p_datas, key_str)
             if val is None or isinstance(val, (dict, list, tuple)):
                 continue
-            planner_data_keys.append(key)
+            planner_data_keys.append(key_str)
             planner_data_values.append(val)
 
         return (


### PR DESCRIPTION
This PR addresses a significant performance bottleneck in the `cbfkit` simulation loop where the JIT-compiled simulator was being recompiled on every execution due to dynamic default arguments.

### Problem
The `execute` function in `src/cbfkit/simulation/simulator.py` defined default values for `sensor`, `estimator`, and `perturbation` (when `None` was passed) using local `lambda` functions or inner `def`s.
```python
_perturbation = (
    perturbation if perturbation else (lambda x, u, f, g: (lambda k: jnp.zeros(x.shape)))
)
```
These closures are new objects on every call. `simulator_jit` lists these arguments in `static_argnames`. When JAX sees a new object for a static argument, it recompiles the function.

### Solution
I moved these default function definitions to the module level (e.g., `_default_perturbation`).
```python
def _default_perturbation(x, u, f, g):
    def p(key):
        return jnp.zeros_like(x)
    return p
```
Now, when `None` is passed, the same function object is used, allowing JAX to use the cached compilation.

### Impact
Running a benchmark (based on `examples/unicycle/reach_goal/vanilla_cbf_control.py`) with 5 sequential simulation runs:
- **Before:** ~6.25s average per run. (Recompiling every time)
- **After:** ~1.36s average per run. (Compiling once, then fast execution)
- **Speedup:** ~4.6x

### Verification
- **Benchmark:** Ran a custom benchmark script (reproduced in description below).
- **Profile:** Confirmed `backend_compile_and_load` time dropped significantly for sequential runs.
- **Tests:** Ran `tests/test_simulation/` to ensure no regression.
- **Types:** Fixed existing mypy errors in `simulator.py`.

#### Benchmark Script Used
```python
import os
import sys
import time
import jax.numpy as jnp

# Add the project root directory to the python path
sys.path.append(os.getcwd() + "/src")
sys.path.append(os.getcwd())

import cbfkit.simulation.simulator as sim
import cbfkit.systems.unicycle.models.accel_unicycle as unicycle
from cbfkit.certificates import concatenate_certificates, rectify_relative_degree
from cbfkit.certificates.conditions.barrier_conditions import zeroing_barriers
from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller as cbf_controller
from cbfkit.estimators import naive as estimator
from cbfkit.integration import runge_kutta_4 as integrator
from cbfkit.sensors import perfect as sensor
from cbfkit.utils.user_types import PlannerData
from examples.unicycle.common.ellipsoidal_obstacle import cbf as ellipsoid_cbf

def run_benchmark():
    tf = 10.0
    dt = 0.01
    
    init_state = jnp.array([0.0, 0.0, 0.0, jnp.pi / 4])
    desired_state = jnp.array([2.0, 4.0, 0.0, 0.0])
    actuation_constraints = jnp.array([100.0, 100.0])

    unicycle_dynamics = unicycle.plant(lam=1.0)
    unicycle_dynamics.a_max = actuation_constraints[0]
    unicycle_dynamics.omega_max = actuation_constraints[1]
    unicycle_dynamics.v_max = 1.0
    unicycle_dynamics.goal_tol = 0.25

    uniycle_nom_controller = unicycle.controllers.proportional_controller(
        dynamics=unicycle_dynamics,
        Kp_pos=1.0,
        Kp_theta=1.0,
    )

    obstacles = [
        (1, 2.0, 0.0),
        (3.0, 2.0, 0.0),
        (-1.0, 1.0, 0.0),
        (0.5, -1.0, 0.0),
    ] * 5 
    
    ellipsoids = [
        (0.5, 1.5),
        (0.75, 2.0),
        (1.0, 0.75),
        (0.75, 0.5),
    ] * 5

    barriers = [
        rectify_relative_degree(
            function=ellipsoid_cbf(jnp.array(obs), jnp.array(ell)),
            system_dynamics=unicycle_dynamics,
            state_dim=len(init_state),
            form="exponential",
        )(
            certificate_conditions=zeroing_barriers.linear_class_k(5.0),
            obstacle=jnp.array(obs),
            ellipsoid=jnp.array(ell),
        )
        for obs, ell in zip(obstacles, ellipsoids)
    ]

    barrier_packages = concatenate_certificates(*barriers)

    controller = cbf_controller(
        control_limits=actuation_constraints,
        dynamics_func=unicycle_dynamics,
        barriers=barrier_packages,
    )

    print("Warming up...")
    sim.execute(
        x0=init_state,
        dt=dt,
        num_steps=10,
        dynamics=unicycle_dynamics,
        integrator=integrator,
        nominal_controller=uniycle_nom_controller,
        controller=controller,
        sensor=sensor,
        estimator=estimator,
        verbose=False,
        planner_data=PlannerData(
            x_traj=jnp.tile(desired_state.reshape(-1, 1), (1, 11)),
            prev_robustness=None,
        ),
        use_jit=True,
    )

    print("Running benchmark...")
    start_time = time.time()
    n_runs = 5
    for i in range(n_runs):
        sim.execute(
            x0=init_state,
            dt=dt,
            num_steps=int(tf / dt),
            dynamics=unicycle_dynamics,
            integrator=integrator,
            nominal_controller=uniycle_nom_controller,
            controller=controller,
            sensor=sensor,
            estimator=estimator,
            verbose=False,
            planner_data=PlannerData(
                x_traj=jnp.tile(desired_state.reshape(-1, 1), (1, int(tf / dt) + 1)),
                prev_robustness=None,
            ),
            use_jit=True,
        )
    end_time = time.time()
    avg_time = (end_time - start_time) / n_runs
    print(f"Average time per run: {avg_time:.4f}s")

if __name__ == "__main__":
    run_benchmark()
```

---
*PR created automatically by Jules for task [16625911110998877022](https://jules.google.com/task/16625911110998877022) started by @bardhh*