### PR TITLE
⚡ Bolt: Optimize RK4 integration in simulation backend

### DIFF
--- a/src/cbfkit/simulation/backend.py
+++ b/src/cbfkit/simulation/backend.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 from jax import Array, random
 
 from cbfkit.integration import forward_euler
+from cbfkit.integration.runge_kutta import runge_kutta_4
 from cbfkit.simulation.utils import SimulationStepData
 from cbfkit.utils.user_types import (
     Control,
@@ -153,6 +154,20 @@ def stepper(
             # We already computed f, g = dynamics(x) earlier
             dx = f + jnp.matmul(g, u) + p(subkey)
             x = x + dx * dt
+        elif integrator == runge_kutta_4:
+            # Optimization (Bolt): Reuse dynamics for RK4
+            # k1 = f(x, u) which we already have components for
+            k1 = f + jnp.matmul(g, u) + p(subkey)
+
+            def vector_field(s: State) -> Array:
+                f_s, g_s = dynamics(s)
+                return f_s + jnp.matmul(g_s, u) + p(subkey)
+
+            k2 = vector_field(x + 0.5 * dt * k1)
+            k3 = vector_field(x + 0.5 * dt * k2)
+            k4 = vector_field(x + dt * k3)
+
+            x = x + (dt / 6.0) * (k1 + 2 * k2 + 2 * k3 + k4)
         else:
 
             def vector_field(s: State) -> Array:


### PR DESCRIPTION
💡 What: Implemented a specialized path for `runge_kutta_4` in `src/cbfkit/simulation/backend.py` to reuse the dynamics evaluations (`f`, `g`) computed at the start of the step.
🎯 Why: The previous implementation re-evaluated dynamics for the first stage of RK4 ($k_1$), resulting in 5 dynamics calls per step instead of the necessary 4.
📊 Impact: Reduced dynamics function calls by 20% (from 5 to 4 per step) for RK4 simulations in non-JIT mode. Confirmed via benchmark.
🔬 How measured: Benchmarked using `simulator.execute` with `approx_unicycle_dynamics` and counting calls.
✅ Correctness: Verified with existing tests `test_stepper.py` and `test_integrators.py`.

---
*PR created automatically by Jules for task [4619388934623621800](https://jules.google.com/task/4619388934623621800) started by @bardhh*