### PR TITLE
[Aegis] Return NaN on QP Failure to Prevent Unsafe Fallback

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -223,7 +223,9 @@ def cbf_clf_qp_generator(
                 status,
                 # Bolt: Avoid jnp.array copy and reshape (sol is already 1D)
                 lambda _fake: sol[:n_con],
-                lambda _fake: jnp.clip(u_nom[:n_con], -control_limits[:n_con], control_limits[:n_con]),
+                # Aegis: Return NaN if QP fails to make failure mode explicit.
+                # Returning u_nom is unsafe as it likely violates constraints.
+                lambda _fake: jnp.full_like(u_nom[:n_con], jnp.nan),
                 0,
             )
 

--- a/tests/test_controllers/test_cbf_clf_controllers/test_safety_fallback.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_safety_fallback.py
@@ -1,0 +1,82 @@
+
+import unittest
+import jax.numpy as jnp
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.utils.user_types import ControllerData, CertificateCollection
+from cbfkit.controllers.cbf_clf.generate_constraints.zeroing_cbfs import generate_compute_zeroing_cbf_constraints
+from cbfkit.controllers.cbf_clf.generate_constraints.vanilla_clfs import generate_compute_vanilla_clf_constraints
+
+class TestSafetyFallback(unittest.TestCase):
+    """
+    Tests that the controller fails safely (returns NaN) when the QP is infeasible,
+    rather than silently applying unsafe nominal control.
+    """
+
+    def test_infeasible_fallback_is_nan(self):
+        # Setup simple dynamics: x_dot = u
+        def simple_dynamics(x):
+            return jnp.array([0.0]), jnp.array([[1.0]])
+
+        # Barrier: h(x) = -x. Safe if x <= 0.
+        # h_dot = -u
+        # Condition: -u + (-x) >= 0 => u <= -x
+        def simple_barrier(t, x):
+            return jnp.array(-x[0]) # Scalar (shape ())
+
+        def simple_barrier_grad(t, x):
+            return jnp.array([-1.0]) # Shape (1,)
+
+        def simple_barrier_hess(t, x):
+            return jnp.array([[0.0]])
+
+        def simple_barrier_dt(t, x):
+            return jnp.array(0.0)
+
+        def simple_class_k(h):
+            return h
+
+        # Setup
+        control_limits = jnp.array([1.0]) # u in [-1, 1]
+
+        # Barrier Collection
+        barriers = CertificateCollection(
+            functions=[simple_barrier],
+            jacobians=[simple_barrier_grad],
+            hessians=[simple_barrier_hess],
+            partials=[simple_barrier_dt],
+            conditions=[simple_class_k]
+        )
+
+        # Generate Controller
+        controller_gen = cbf_clf_qp_generator(
+            generate_compute_zeroing_cbf_constraints,
+            generate_compute_vanilla_clf_constraints
+        )
+
+        controller = controller_gen(
+            control_limits=control_limits,
+            dynamics_func=simple_dynamics,
+            barriers=barriers,
+            relaxable_cbf=False # Hard constraint
+        )
+
+        # Scenario: x = 2.0 (Unsafe). h = -2.0.
+        # Condition: u <= -2.0
+        # Limits: u in [-1, 1]
+        # Result: Infeasible.
+
+        t = 0.0
+        x = jnp.array([2.0])
+        u_nom = jnp.array([1.0])
+        key = jnp.array([0, 0], dtype=jnp.uint32)
+        data = ControllerData()
+
+        # Run
+        u, new_data = controller(t, x, u_nom, key, data)
+
+        # Assertions
+        self.assertTrue(new_data.error, "Controller should report error on infeasibility")
+        self.assertTrue(jnp.isnan(u).all(), "Controller should return NaN on infeasibility to prevent unsafe actuation")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Aegis: Correctness Fix for QP Failure Handling

## The Issue
Previously, when the QP solver failed (e.g., due to infeasible safety constraints), the controller would silently fallback to the nominal control (`u_nom`), clipped to actuation limits. This behavior is dangerous because `u_nom` is often the source of the safety violation that the QP was trying to prevent. Applying it when the QP fails effectively bypasses the safety filter precisely when it is needed most.

## The Fix
The fallback logic in `cbf_clf_qp_generator.py` has been updated to return a vector of `NaN`s (using `jnp.full_like(u_nom, jnp.nan)`) when the QP solver reports failure.

## Why this is better
- **Explicit Failure:** Returning `NaN` guarantees that the failure is detected immediately (e.g., by the simulator stopping or plotting libraries breaking) rather than silently continuing with unsafe control.
- **Safety:** It prevents the robot from accelerating into an obstacle when the safety filter "gives up".
- **Provable Behavior:** We can now assert that the system never applies `u_nom` when constraints are violated.

## Verification
- A new test file `tests/test_controllers/test_cbf_clf_controllers/test_safety_fallback.py` was added.
- The test constructs a provably infeasible scenario (safe set violated, required control exceeds limits).
- It asserts that the controller returns `NaN` and sets the `error` flag.
- Existing tests pass.


---
*PR created automatically by Jules for task [6575207948149926091](https://jules.google.com/task/6575207948149926091) started by @bardhh*