### PR TITLE
Simplify Nominal Controller API with Adapter Utility

### DIFF
--- a/src/cbfkit/controllers/__init__.py
+++ b/src/cbfkit/controllers/__init__.py
@@ -5,5 +5,6 @@ based controllers, as well as MPPI-based controllers.
 """
 
 from . import cbf_clf, mppi
+from .utils import setup_nominal_controller
 
-__all__ = ["cbf_clf", "mppi"]
+__all__ = ["cbf_clf", "mppi", "setup_nominal_controller"]

--- a/src/cbfkit/controllers/utils.py
+++ b/src/cbfkit/controllers/utils.py
@@ -1,0 +1,98 @@
+"""Controller utilities.
+
+This module provides utility functions for creating and managing controllers.
+"""
+
+import inspect
+from typing import Callable, Optional, Tuple, Any
+
+from jax import Array
+import jax.numpy as jnp
+
+from cbfkit.utils.user_types import (
+    ControllerData,
+    Key,
+    NominalControllerCallable,
+    State,
+    Time,
+)
+
+
+def setup_nominal_controller(
+    controller_func: Callable[..., Any],
+) -> NominalControllerCallable:
+    """Adapts a simple controller function into a NominalControllerCallable.
+
+    This helper allows users to define nominal controllers with simpler signatures,
+    such as `f(t, x)` or `f(t, x, ref)`, and automatically handles the additional arguments
+    required by the simulator (key, ControllerData wrapping).
+
+    Args:
+        controller_func: A callable with one of the following signatures:
+            - (t, x) -> u
+            - (t, x, ref) -> u
+            - (t, x, key, ref) -> u (wraps return value only)
+
+    Returns
+    -------
+        A NominalControllerCallable that can be passed to the simulator.
+
+    Raises
+    ------
+        ValueError: If the function signature is not supported.
+    """
+    try:
+        sig = inspect.signature(controller_func)
+        num_args = len(sig.parameters)
+    except ValueError:
+        # Fallback for objects that don't support signature
+        # We assume 2 arguments as the default simple case.
+        num_args = 2
+
+    if num_args == 2:
+
+        def nominal_controller_2(
+            t: Time,
+            x: State,
+            key: Key,
+            ref: Optional[State] = None,
+        ) -> Tuple[Array, ControllerData]:
+            u = controller_func(t, x)
+            return u, ControllerData(u_nom=u)
+
+        return nominal_controller_2
+
+    elif num_args == 3:
+
+        def nominal_controller_3(
+            t: Time,
+            x: State,
+            key: Key,
+            ref: Optional[State] = None,
+        ) -> Tuple[Array, ControllerData]:
+            u = controller_func(t, x, ref)
+            return u, ControllerData(u_nom=u)
+
+        return nominal_controller_3
+
+    elif num_args == 4:
+
+        def nominal_controller_4(
+            t: Time,
+            x: State,
+            key: Key,
+            ref: Optional[State] = None,
+        ) -> Tuple[Array, ControllerData]:
+            ret = controller_func(t, x, key, ref)
+            if isinstance(ret, tuple) and len(ret) == 2:
+                # Assume it's (u, data)
+                return ret  # type: ignore
+            return ret, ControllerData(u_nom=ret)
+
+        return nominal_controller_4
+
+    else:
+        raise ValueError(
+            f"Unsupported nominal controller signature with {num_args} arguments. "
+            "Expected (t, x), (t, x, ref), or (t, x, key, ref)."
+        )

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -142,6 +142,20 @@ ControllerCallable = Callable[
 ]
 
 NominalControllerCallable = Callable[[Time, State, Key, Optional[State]], ControllerCallableReturns]
+"""Callable for nominal controllers.
+
+Args:
+    t: Current time.
+    x: Current state.
+    key: PRNG key for randomization.
+    reference: Optional reference state (from planner).
+
+Returns:
+    A tuple containing the control input and controller data.
+
+See Also:
+    cbfkit.controllers.setup_nominal_controller: Helper to adapt simple functions.
+"""
 
 
 # Planner Callables

--- a/tests/test_controllers/test_nominal_controller_utils.py
+++ b/tests/test_controllers/test_nominal_controller_utils.py
@@ -1,0 +1,72 @@
+import jax.numpy as jnp
+from jax import random
+import pytest
+from cbfkit.controllers.utils import setup_nominal_controller
+from cbfkit.utils.user_types import ControllerData
+
+def test_setup_nominal_controller_2_args():
+    def simple_ctrl(t, x):
+        return -x
+
+    nominal_ctrl = setup_nominal_controller(simple_ctrl)
+
+    t = 0.0
+    x = jnp.array([1.0, 2.0])
+    key = random.PRNGKey(0)
+
+    u, data = nominal_ctrl(t, x, key, None)
+
+    assert jnp.allclose(u, -x)
+    assert jnp.allclose(data.u_nom, -x)
+
+def test_setup_nominal_controller_3_args():
+    def tracking_ctrl(t, x, ref):
+        if ref is not None:
+            return ref - x
+        return -x
+
+    nominal_ctrl = setup_nominal_controller(tracking_ctrl)
+
+    t = 0.0
+    x = jnp.array([1.0, 2.0])
+    key = random.PRNGKey(0)
+    ref = jnp.array([2.0, 4.0])
+
+    u, data = nominal_ctrl(t, x, key, ref)
+
+    assert jnp.allclose(u, ref - x)
+    assert jnp.allclose(data.u_nom, ref - x)
+
+    # Test with None ref
+    # If the user function handles None, it should work
+    u_none, _ = nominal_ctrl(t, x, key, None)
+    assert jnp.allclose(u_none, -x)
+
+def test_setup_nominal_controller_4_args():
+    def complex_ctrl(t, x, key, ref):
+        return x, ControllerData(u_nom=x)
+
+    nominal_ctrl = setup_nominal_controller(complex_ctrl)
+
+    t = 0.0
+    x = jnp.array([1.0, 2.0])
+    key = random.PRNGKey(0)
+
+    u, data = nominal_ctrl(t, x, key, None)
+    assert jnp.allclose(u, x)
+
+    # Test 4 args returning only array
+    def complex_ctrl_array(t, x, key, ref):
+        return x
+
+    nominal_ctrl_arr = setup_nominal_controller(complex_ctrl_array)
+    u_arr, data_arr = nominal_ctrl_arr(t, x, key, None)
+    assert jnp.allclose(u_arr, x)
+    assert jnp.allclose(data_arr.u_nom, x)
+
+def test_unsupported_signature():
+    def bad_ctrl(t):
+        return t
+
+    with pytest.raises(ValueError):
+        setup_nominal_controller(bad_ctrl)


### PR DESCRIPTION
Simplified the creation of nominal controllers by providing a utility that automatically handles the `NominalControllerCallable` signature requirements. Users can now pass simple functions `(t, x)` or `(t, x, ref)` to `setup_nominal_controller` to generate a simulator-compatible controller. This addresses the common confusion where users provided simple functions that caused runtime errors due to argument mismatch.

---
*PR created automatically by Jules for task [2767186720026813049](https://jules.google.com/task/2767186720026813049) started by @bardhh*