### PR TITLE
Improve CertificateCollection composability with `__add__` operator

### DIFF
--- a/src/cbfkit/certificates/packager.py
+++ b/src/cbfkit/certificates/packager.py
@@ -138,28 +138,18 @@ def certificate_package(
 
 
 def concatenate_certificates(*tuples: CertificateCollection) -> CertificateCollection:
-    """_summary_
+    """Concatenates multiple CertificateCollections into one.
 
-    Returns
-    -------
-        _type_: _description_
+    Note:
+        You can also use the `+` operator to concatenate CertificateCollections directly.
+
+    Args:
+        *tuples: Variable number of CertificateCollection objects.
+
+    Returns:
+        CertificateCollection: A single collection containing all certificate functions and derivatives.
     """
     if not tuples:
         return EMPTY_CERTIFICATE_COLLECTION
 
-    # Initialize empty lists for each component of CertificateCollection
-    v_list = []
-    j_list = []
-    h_list = []
-    t_list = []
-    c_list = []
-
-    # Iterate through the tuples and extend the lists
-    for tup in tuples:
-        v_list.extend(tup[0])
-        j_list.extend(tup[1])
-        h_list.extend(tup[2])
-        t_list.extend(tup[3])
-        c_list.extend(tup[4])
-
-    return CertificateCollection(v_list, j_list, h_list, t_list, c_list)
+    return sum(tuples, EMPTY_CERTIFICATE_COLLECTION)

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -97,6 +97,17 @@ class CertificateCollection(NamedTuple):
     partials: List[CertificatePartialCallable]
     conditions: List[CertificateConditionsCallable]
 
+    def __add__(self, other: "CertificateCollection") -> "CertificateCollection":
+        if not isinstance(other, CertificateCollection):
+            return NotImplemented
+        return CertificateCollection(
+            self.functions + other.functions,
+            self.jacobians + other.jacobians,
+            self.hessians + other.hessians,
+            self.partials + other.partials,
+            self.conditions + other.conditions,
+        )
+
 
 # Default empty collection
 EMPTY_CERTIFICATE_COLLECTION = CertificateCollection([], [], [], [], [])

--- a/tests/test_utils/test_user_types.py
+++ b/tests/test_utils/test_user_types.py
@@ -1,0 +1,41 @@
+import pytest
+from cbfkit.utils.user_types import CertificateCollection, EMPTY_CERTIFICATE_COLLECTION
+from cbfkit.certificates.packager import concatenate_certificates
+
+def test_certificate_collection_addition():
+    c1 = CertificateCollection([1], [2], [3], [4], [5])
+    c2 = CertificateCollection([6], [7], [8], [9], [10])
+
+    c3 = c1 + c2
+
+    assert isinstance(c3, CertificateCollection)
+    assert c3.functions == [1, 6]
+    assert c3.jacobians == [2, 7]
+    assert c3.hessians == [3, 8]
+    assert c3.partials == [4, 9]
+    assert c3.conditions == [5, 10]
+
+def test_certificate_collection_sum():
+    c1 = CertificateCollection([1], [], [], [], [])
+    c2 = CertificateCollection([2], [], [], [], [])
+    c3 = CertificateCollection([3], [], [], [], [])
+
+    # Using sum
+    c_sum = sum([c1, c2, c3], EMPTY_CERTIFICATE_COLLECTION)
+
+    assert isinstance(c_sum, CertificateCollection)
+    assert c_sum.functions == [1, 2, 3]
+
+def test_concatenate_certificates_compatibility():
+    c1 = CertificateCollection([1], [], [], [], [])
+    c2 = CertificateCollection([2], [], [], [], [])
+
+    c_concat = concatenate_certificates(c1, c2)
+
+    assert isinstance(c_concat, CertificateCollection)
+    assert c_concat.functions == [1, 2]
+
+def test_addition_invalid_type():
+    c1 = CertificateCollection([], [], [], [], [])
+    with pytest.raises(TypeError):
+        _ = c1 + "invalid"


### PR DESCRIPTION
This PR improves the usability and safety of `CertificateCollection` in `cbfkit`.

**Changes:**
1.  **`CertificateCollection` Update:**
    -   Added `__add__` method to `CertificateCollection` in `src/cbfkit/utils/user_types.py`.
    -   This allows users to combine certificate collections using `c1 + c2`.
    -   Crucially, this prevents the default `NamedTuple` behavior where `c1 + c2` would result in a single large tuple (concatenation of fields), which causes runtime errors later.

2.  **`concatenate_certificates` Refactor:**
    -   Updated `src/cbfkit/certificates/packager.py` to use `sum(tuples, EMPTY_CERTIFICATE_COLLECTION)` instead of manual list extension.
    -   The function is now a thin wrapper around the new `+` operator.

3.  **Tests:**
    -   Added `tests/test_utils/test_user_types.py` to verify addition, summation, and type safety.

**Impact:**
-   **Cleaner User Code:** Users can now use `+` to compose barriers/Lyapunov functions.
-   **Safer Abstraction:** Removes the "tuple concatenation" footgun.
-   **Maintainability:** Simplified `concatenate_certificates` logic.

---
*PR created automatically by Jules for task [16603757003749860012](https://jules.google.com/task/16603757003749860012) started by @bardhh*