### PR TITLE
Improve error message for u_nom shape mismatch in CBF-CLF controllers

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -202,6 +202,12 @@ def cbf_clf_qp_generator(
             """
             nonlocal complete
 
+            if u_nom.shape[0] != n_con:
+                raise ValueError(
+                    f"Nominal control input 'u_nom' has shape {u_nom.shape}, "
+                    f"but expected ({n_con},) based on 'control_limits'."
+                )
+
             if n_bfs > 0:
                 if "tunable_class_k" in kwargs and kwargs["tunable_class_k"]:
                     u_nom = jnp.hstack([u_nom, jnp.ones((n_bfs,))])


### PR DESCRIPTION
Improved developer experience by adding input validation to `cbf_clf_qp_generator`. The controller now checks if `u_nom.shape[0]` matches the number of control inputs (`n_con`) derived from `control_limits`. If not, it raises a descriptive `ValueError`. This prevents confusing JAX shape errors downstream. Verified with a reproduction script and existing tests. One pre-existing test failure was noted (unrelated to this change).

---
*PR created automatically by Jules for task [3486135378351305551](https://jules.google.com/task/3486135378351305551) started by @bardhh*