### PR TITLE
feat(certificates): add input_style to certificate_package

### DIFF
--- a/src/cbfkit/certificates/packager.py
+++ b/src/cbfkit/certificates/packager.py
@@ -58,6 +58,7 @@ def certificate_package(
     func_grad: Optional[Callable[..., Callable[[Array], Array]]] = None,
     func_hess: Optional[Callable[..., Callable[[Array], Array]]] = None,
     n: int = 0,
+    input_style: str = "concatenated",
 ) -> Callable[..., CertificateCollection]:
     """Function for packaging and later creating CBF executables.
 
@@ -68,6 +69,10 @@ def certificate_package(
         func_hess (Callable, optional): certificate hessian matrix function factory.
             If None, computed automatically using jax.hessian.
         n (int): state dimension
+        input_style (str): expected signature of the certificate function.
+            - "concatenated" (default): func returns f(xt) where xt is [x, t].
+            - "separated": func returns f(t, x).
+            - "state": func returns f(x).
 
     Returns
     -------
@@ -90,6 +95,18 @@ def certificate_package(
             BarrierTuple: _description_
         """
         v_func = func(**kwargs)
+
+        if input_style == "separated":
+            _orig_v_sep = v_func
+
+            def v_func(xt):
+                return _orig_v_sep(xt[-1], xt[:-1])
+
+        elif input_style == "state":
+            _orig_v_state = v_func
+
+            def v_func(xt):
+                return _orig_v_state(xt[:-1])
 
         if func_grad is None:
             # Auto-differentiate

--- a/tests/test_certificates/test_packager.py
+++ b/tests/test_certificates/test_packager.py
@@ -1,0 +1,81 @@
+
+import unittest
+import jax.numpy as jnp
+from cbfkit.certificates import certificate_package
+
+class TestCertificatePackager(unittest.TestCase):
+    def test_default_concatenated(self):
+        # Default behavior: h(xt)
+        def cbf_factory(**kwargs):
+            def func(xt):
+                return xt[0] - 1.0 # x[0] >= 1.0
+            return func
+
+        # Use simple lambda for conditions
+        dummy_conditions = lambda x: x
+
+        pkg = certificate_package(cbf_factory, n=1)
+        collection = pkg(certificate_conditions=dummy_conditions)
+
+        # Check barrier value
+        # h(x) = x[0] - 1.
+        # x = [2.], t = 0. -> h = 1.
+        # Collection functions take (t, x)
+        h_val = collection.functions[0](0.0, jnp.array([2.0]))
+        self.assertAlmostEqual(float(h_val), 1.0)
+
+    def test_separated_signature(self):
+        # New behavior: h(t, x)
+        def cbf_factory(**kwargs):
+            def func(t, x):
+                return x[0] - t # x[0] >= t
+            return func
+
+        dummy_conditions = lambda x: x
+
+        # Pass input_style="separated"
+        pkg = certificate_package(cbf_factory, n=1, input_style="separated")
+        collection = pkg(certificate_conditions=dummy_conditions)
+
+        # x = [2.], t = 1. -> h = 2 - 1 = 1.
+        h_val = collection.functions[0](1.0, jnp.array([2.0]))
+        self.assertAlmostEqual(float(h_val), 1.0)
+
+        # Check gradient
+        # h = x - t
+        # grad_x = [1.]
+        # partial_t = -1.
+        grad_val = collection.jacobians[0](1.0, jnp.array([2.0]))
+        self.assertTrue(jnp.allclose(grad_val, jnp.array([1.0])))
+
+        partial_t_val = collection.partials[0](1.0, jnp.array([2.0]))
+        self.assertAlmostEqual(float(partial_t_val), -1.0)
+
+    def test_state_signature(self):
+        # New behavior: h(x)
+        def cbf_factory(**kwargs):
+            def func(x):
+                return x[0] * 2.0
+            return func
+
+        dummy_conditions = lambda x: x
+
+        # Pass input_style="state"
+        pkg = certificate_package(cbf_factory, n=1, input_style="state")
+        collection = pkg(certificate_conditions=dummy_conditions)
+
+        # x = [2.] -> h = 4.
+        h_val = collection.functions[0](0.0, jnp.array([2.0]))
+        self.assertAlmostEqual(float(h_val), 4.0)
+
+        # Check gradient
+        # grad_x = [2.]
+        grad_val = collection.jacobians[0](0.0, jnp.array([2.0]))
+        self.assertTrue(jnp.allclose(grad_val, jnp.array([2.0])))
+
+        # partial_t should be 0
+        partial_t_val = collection.partials[0](0.0, jnp.array([2.0]))
+        self.assertAlmostEqual(float(partial_t_val), 0.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds an `input_style` argument to `certificate_package` to allow users to define certificate functions with natural signatures like `(t, x)` or `(x)`, instead of the mandatory concatenated `(xt)` vector. This reduces boilerplate and cognitive load for users defining barrier functions. The default behavior is preserved.

---
*PR created automatically by Jules for task [2102618282820723401](https://jules.google.com/task/2102618282820723401) started by @bardhh*