### PR TITLE
Fix numerical discontinuity in QP constraint normalization

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -245,10 +245,10 @@ def cbf_clf_qp_generator(
             h_vec = jnp.hstack([h_vec_u, h_vec_c])
 
             # Bolt: Normalize constraint rows to improve numerical stability
-            # Janus: Avoid normalizing noise vectors. If norm < tol, do NOT scale up.
+            # Janus: smooth normalization clamping (max(norm, eps)) prevents discontinuities.
             if auto_p_mat:
                 row_norms = jnp.linalg.norm(g_mat, axis=1)
-                safe_norms = jnp.where(row_norms > 1e-8, row_norms, 1.0)
+                safe_norms = jnp.maximum(row_norms, 1e-8)
                 g_mat = g_mat / safe_norms[:, None]
                 h_vec = h_vec / safe_norms
 


### PR DESCRIPTION
Improved numerical stability in `cbf_clf_qp_generator.py` by fixing a discontinuous normalization logic.

Previously, constraint rows with norms below `1e-8` were not normalized, while those slightly above were fully normalized. This caused a jump of order $10^8$ in the constraint values effectively seen by the solver when crossing this threshold.

The fix replaces the conditional logic with `safe_norms = jnp.maximum(row_norms, 1e-8)`, which ensures a smooth transition:
- Norms > 1e-8 are normalized to 1.0.
- Norms < 1e-8 are scaled as if they were 1e-8 (avoiding division by zero or huge amplification of noise), but continuously.

This change prevents numerical "popping" of constraints in the QP solver.

---
*PR created automatically by Jules for task [12095788066738081276](https://jules.google.com/task/12095788066738081276) started by @bardhh*