### PR TITLE
Fix: prevent QP controller from amplifying noise constraints

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -235,11 +235,8 @@ def cbf_clf_qp_generator(
 
             # Bolt: Optimize normalization. Input constraints (box limits) are already normalized (row norm = 1).
             # Only normalize CBF/CLF constraints, then stack.
-            if auto_p_mat:
-                row_norms_c = jnp.linalg.norm(g_mat_c, axis=1)
-                row_norms_c = jnp.maximum(row_norms_c, 1e-8)
-                g_mat_c = g_mat_c / row_norms_c[:, None]
-                h_vec_c = h_vec_c / row_norms_c
+            # Aegis: Removed aggressive pre-normalization of CBF/CLF constraints that amplified noise vectors.
+            # Normalization is now handled uniformly by the "Janus" block below which respects a noise floor.
 
             g_mat = jnp.vstack([g_mat_u, g_mat_c])
             h_vec = jnp.hstack([h_vec_u, h_vec_c])

--- a/tests/test_controllers/test_noise_amplification.py
+++ b/tests/test_controllers/test_noise_amplification.py
@@ -1,0 +1,72 @@
+
+import jax
+import jax.numpy as jnp
+import pytest
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.utils.user_types import ControllerData
+
+def test_noise_amplification():
+    """
+    Verifies that numerical noise in barrier gradients is not amplified into
+    active constraints by aggressive normalization.
+    """
+    # Mock constraints generator
+    def mock_generate_cbf(control_limits, dynamics, barriers, lyapunovs, **kwargs):
+        def compute(t, x):
+            # A row of noise: norm 1e-10.
+            # Constraint: 0*u1 + 1e-10*u2 <= 1e-10
+            # If amplified, this becomes u2 <= 1.
+            # If not amplified, it is 1e-10*u2 <= 1e-10, which for u=10 is 1e-9 <= 1e-10 (violated by 9e-10).
+            # However, standard QP solvers have tolerances > 1e-9.
+            # So unnormalized constraint should be ignored (treated as satisfied).
+            # Normalized constraint (u2 <= 1) will be enforced.
+
+            g_mat_c = jnp.array([[0.0, 1.0e-10]])
+            h_vec_c = jnp.array([1.0e-10])
+            return g_mat_c, h_vec_c, {"complete": True}
+        return compute
+
+    def mock_generate_clf(control_limits, dynamics, barriers, lyapunovs, **kwargs):
+        def compute(t, x):
+            return jnp.zeros((0, 2)), jnp.zeros((0,)), {}
+        return compute
+
+    # Setup controller
+    generator = cbf_clf_qp_generator(mock_generate_cbf, mock_generate_clf)
+
+    control_limits = jnp.array([100.0, 100.0]) # Large limits
+
+    # Create controller
+    controller = generator(
+        control_limits=control_limits,
+        dynamics_func=lambda t, x: (jnp.zeros(2), jnp.eye(2)), # Dummy
+        barriers=([], [], [], [], []),
+        lyapunovs=([], [], [], [], []),
+    )
+
+    # Run controller
+    t = 0.0
+    x = jnp.array([0.0, 0.0])
+    key = jax.random.PRNGKey(0)
+    u_nom = jnp.array([10.0, 10.0])
+
+    data = ControllerData(
+        error=False,
+        error_data=0,
+        complete=False,
+        sol=jnp.zeros(0),
+        u=jnp.zeros(2),
+        u_nom=jnp.zeros(2),
+        sub_data={"solver_params": None}
+    )
+
+    # JIT compile and run
+    u_computed, _ = controller(t, x, u_nom, key, data)
+
+    # Check if u2 stays near 10.0 (unnormalized behavior)
+    # If it was clamped to 1.0, this assertion would fail.
+    assert u_computed[1] > 2.0, f"Control was clamped by noise constraint! u={u_computed}"
+    assert jnp.abs(u_computed[1] - 10.0) < 1e-1, f"Control deviated significantly! u={u_computed}"
+
+if __name__ == "__main__":
+    test_noise_amplification()


### PR DESCRIPTION
Fixes a critical numerical issue where the CBF/CLF QP controller would amplify numerical noise in barrier gradients into hard constraints.

### Problem
The `cbf_clf_qp_generator` included a normalization step that scaled all constraint rows by `1 / max(norm, 1e-8)`. This meant that a constraint vector consisting of pure numerical noise (e.g., norm `1e-15`) was scaled up by `1e8`, creating a phantom constraint of order 1. This could force the controller to deviate significantly from the nominal control to satisfy a non-existent constraint.

### Solution
Removed the aggressive "Bolt" normalization block. The code now relies on the existing downstream "Janus" normalization logic (`safe_norms = where(row_norms > 1e-8, row_norms, 1.0)`), which leaves noise vectors unscaled, allowing the QP solver to treat them as satisfied within tolerance.

### Verification
- Added `tests/test_controllers/test_noise_amplification.py`: Reproduces the issue by creating a barrier with `1e-10` gradient and verifying that the controller ignores it (returns nominal control) rather than clamping it.
- Verified existing tests `tests/test_controllers/test_cbf_clf_controllers/test_cbf_clf_qp_controllers.py` and `tests/test_optimization/test_infeasible_qp.py` pass.

---
*PR created automatically by Jules for task [5943403634862967628](https://jules.google.com/task/5943403634862967628) started by @bardhh*