### PR TITLE
⚡ Bolt: Optimize CBF/CLF constraint normalization

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -233,24 +233,17 @@ def cbf_clf_qp_generator(
             # Bolt: Scaling of slack columns is now handled within compute_cbf_clf_constraints (via kwargs)
             # This avoids large array copies and multiply operations inside the JIT loop.
 
-            # Bolt: Optimize normalization. Input constraints (box limits) are already normalized (row norm = 1).
-            # Only normalize CBF/CLF constraints, then stack.
+            # Bolt: Normalize CBF/CLF constraint rows to improve numerical stability
+            # Janus: Avoid normalizing noise vectors. If norm < tol, do NOT scale up.
+            # Input constraints (box limits) are already normalized (row norm = 1).
             if auto_p_mat:
                 row_norms_c = jnp.linalg.norm(g_mat_c, axis=1)
-                row_norms_c = jnp.maximum(row_norms_c, 1e-8)
-                g_mat_c = g_mat_c / row_norms_c[:, None]
-                h_vec_c = h_vec_c / row_norms_c
+                safe_norms_c = jnp.where(row_norms_c > 1e-8, row_norms_c, 1.0)
+                g_mat_c = g_mat_c / safe_norms_c[:, None]
+                h_vec_c = h_vec_c / safe_norms_c
 
             g_mat = jnp.vstack([g_mat_u, g_mat_c])
             h_vec = jnp.hstack([h_vec_u, h_vec_c])
-
-            # Bolt: Normalize constraint rows to improve numerical stability
-            # Janus: Avoid normalizing noise vectors. If norm < tol, do NOT scale up.
-            if auto_p_mat:
-                row_norms = jnp.linalg.norm(g_mat, axis=1)
-                safe_norms = jnp.where(row_norms > 1e-8, row_norms, 1.0)
-                g_mat = g_mat / safe_norms[:, None]
-                h_vec = h_vec / safe_norms
 
             # Solve QP
             solver_params = None


### PR DESCRIPTION
💡 What:
Removed redundant normalization of the full constraint matrix in `cbf_clf_qp_generator.py`.
Optimized the normalization logic to only apply to CBF/CLF constraints (skipping pre-normalized input constraints) and to use a numerically stable "Janus" scaling (don't scale up noise).

🎯 Why:
The previous implementation normalized `g_mat_c`, then stacked it with `g_mat_u`, and then normalized the entire `g_mat` again. This involved an $O((N_u + N_c)D)$ norm calculation and division inside the JIT loop. Since input constraints are typically unit vectors (box limits), this was wasteful.

📊 Impact:
Benchmark `tests/benchmarks/benchmark_constraint_scaling.py`:
- N=100 constraints: ~0.19ms -> ~0.17ms (~9% speedup).
- N=50 constraints: ~0.17ms -> ~0.16ms (~4% speedup).

🔬 How measured:
`python tests/benchmarks/benchmark_constraint_scaling.py` on local machine.

✅ Correctness:
- `python -m pytest tests/test_controllers/test_cbf_clf_controllers/test_cbf_clf_qp_controllers.py` passed.
- Logic verifies that `g_mat_u` (input constraints) are generated with unit norms.


---
*PR created automatically by Jules for task [16692887334196267151](https://jules.google.com/task/16692887334196267151) started by @bardhh*