### PR TITLE
DX: Enforce dynamics shape contract in CBF-CLF-QP controller

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -26,7 +26,7 @@ Examples
 >>> )
 """
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import jax.numpy as jnp
 from jax import Array, jit, lax
@@ -97,6 +97,31 @@ def cbf_clf_qp_generator(
         complete = False
         n_con = len(control_limits)
 
+        def verified_dynamics_func(x: State) -> Tuple[Array, Array]:
+            f, g = dynamics_func(x)
+            if f.ndim != 1:
+                raise ValueError(
+                    f"Dynamics drift term 'f' must be a 1D array of shape (n_states,), "
+                    f"but got shape {f.shape}. Ensure your dynamics function returns a flat array, "
+                    f"not a column vector."
+                )
+            if g.ndim != 2:
+                raise ValueError(
+                    f"Dynamics control term 'g' must be a 2D array of shape (n_states, n_controls), "
+                    f"but got shape {g.shape}. If you have 1 control input, ensure 'g' is (n, 1)."
+                )
+            if f.shape[0] != g.shape[0]:
+                raise ValueError(
+                    f"State dimension mismatch: drift 'f' has {f.shape[0]} states, "
+                    f"but control matrix 'g' has {g.shape[0]} states."
+                )
+            if g.shape[1] != n_con:
+                raise ValueError(
+                    f"Control dimension mismatch: 'control_limits' implies {n_con} inputs, "
+                    f"but 'g' has {g.shape[1]} columns."
+                )
+            return f, g
+
         # Ensure barriers and lyapunovs are not None
         if barriers is None:
             barriers = EMPTY_CERTIFICATE_COLLECTION
@@ -166,7 +191,7 @@ def cbf_clf_qp_generator(
             generate_compute_cbf_constraints,
             generate_compute_clf_constraints,
             control_limits,
-            dynamics_func,
+            verified_dynamics_func,
             barriers,
             lyapunovs,
             **kwargs,

--- a/tests/test_controllers/test_cbf_clf_controllers/test_dynamics_shape_validation.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_dynamics_shape_validation.py
@@ -1,0 +1,101 @@
+
+import pytest
+import jax.numpy as jnp
+from jax import random
+
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.controllers.cbf_clf.generate_constraints.zeroing_cbfs import generate_compute_zeroing_cbf_constraints
+from cbfkit.controllers.cbf_clf.generate_constraints.vanilla_clfs import generate_compute_vanilla_clf_constraints
+from cbfkit.utils.user_types import CertificateCollection, ControllerData
+
+class TestDynamicsShapeValidation:
+
+    @pytest.fixture
+    def controller_gen(self):
+        return cbf_clf_qp_generator(
+            generate_compute_zeroing_cbf_constraints,
+            generate_compute_vanilla_clf_constraints
+        )
+
+    @pytest.fixture
+    def barriers(self):
+        def h(t, x): return x[0]
+        def grad_h(t, x): return jnp.array([1.0, 0.0])
+        def hess_h(t, x): return jnp.zeros((2, 2))
+        def partial_h(t, x): return 0.0
+        def class_k(h): return h
+        return CertificateCollection(
+            [h], [grad_h], [hess_h], [partial_h], [class_k]
+        )
+
+    def test_bad_f_shape(self, controller_gen, barriers):
+        """Test that f as column vector (n, 1) raises ValueError."""
+        def bad_dynamics_f_shape(x):
+            f = jnp.array([[x[1]], [0.0]]) # (2, 1) - BAD
+            g = jnp.array([[0.0], [1.0]])  # (2, 1) - OK
+            return f, g
+
+        control_limits = jnp.array([1.0])
+        controller = controller_gen(control_limits, bad_dynamics_f_shape, barriers)
+
+        t, x = 0.0, jnp.array([1.0, 0.0])
+        u_nom = jnp.array([0.0])
+        key = random.PRNGKey(0)
+        data = ControllerData(error=False, error_data=0)
+
+        with pytest.raises(ValueError, match="Dynamics drift term 'f' must be a 1D array"):
+            controller(t, x, u_nom, key, data)
+
+    def test_bad_g_shape(self, controller_gen, barriers):
+        """Test that g as 1D array (n,) raises ValueError."""
+        def bad_dynamics_g_shape(x):
+            f = jnp.array([x[1], 0.0])    # (2,) - OK
+            g = jnp.array([0.0, 1.0])     # (2,) - BAD (should be 2D)
+            return f, g
+
+        control_limits = jnp.array([1.0])
+        controller = controller_gen(control_limits, bad_dynamics_g_shape, barriers)
+
+        t, x = 0.0, jnp.array([1.0, 0.0])
+        u_nom = jnp.array([0.0])
+        key = random.PRNGKey(0)
+        data = ControllerData(error=False, error_data=0)
+
+        with pytest.raises(ValueError, match="Dynamics control term 'g' must be a 2D array"):
+            controller(t, x, u_nom, key, data)
+
+    def test_mismatched_state_dims(self, controller_gen, barriers):
+        """Test that f and g with different state dims raises ValueError."""
+        def bad_dynamics_mismatch(x):
+            f = jnp.array([x[1], 0.0])          # 2 states
+            g = jnp.array([[0.0], [1.0], [0.0]]) # 3 states
+            return f, g
+
+        control_limits = jnp.array([1.0])
+        controller = controller_gen(control_limits, bad_dynamics_mismatch, barriers)
+
+        t, x = 0.0, jnp.array([1.0, 0.0])
+        u_nom = jnp.array([0.0])
+        key = random.PRNGKey(0)
+        data = ControllerData(error=False, error_data=0)
+
+        with pytest.raises(ValueError, match="State dimension mismatch"):
+            controller(t, x, u_nom, key, data)
+
+    def test_mismatched_control_dims(self, controller_gen, barriers):
+        """Test that g columns != n_controls raises ValueError."""
+        def bad_dynamics_control_mismatch(x):
+            f = jnp.array([x[1], 0.0])
+            g = jnp.array([[0.0, 0.0], [1.0, 1.0]]) # 2 controls
+            return f, g
+
+        control_limits = jnp.array([1.0]) # Expects 1 control
+        controller = controller_gen(control_limits, bad_dynamics_control_mismatch, barriers)
+
+        t, x = 0.0, jnp.array([1.0, 0.0])
+        u_nom = jnp.array([0.0])
+        key = random.PRNGKey(0)
+        data = ControllerData(error=False, error_data=0)
+
+        with pytest.raises(ValueError, match="Control dimension mismatch"):
+            controller(t, x, u_nom, key, data)


### PR DESCRIPTION
Improved developer experience for the CBF-CLF-QP controller by adding explicit shape validation for user-provided dynamics functions. This catches common errors (like returning column vectors for drift terms) early with clear error messages, preventing obscure JAX compilation failures. Includes new regression tests covering various shape mismatch scenarios.

---
*PR created automatically by Jules for task [14503145232120455157](https://jules.google.com/task/14503145232120455157) started by @bardhh*