### PR TITLE
Refactor certificate_package input_style to use Enum and strict validation

### DIFF
--- a/src/cbfkit/certificates/packager.py
+++ b/src/cbfkit/certificates/packager.py
@@ -37,7 +37,7 @@ Examples
 
 """
 
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 import jax.numpy as jnp
 from jax import Array, grad, hessian, jit
@@ -48,6 +48,7 @@ from cbfkit.utils.user_types import (
     CertificateCollection,
     CertificateConditionsCallable,
     CertificateHessianCallable,
+    CertificateInputStyle,
     CertificateJacobianCallable,
     CertificatePartialCallable,
 )
@@ -58,7 +59,7 @@ def certificate_package(
     func_grad: Optional[Callable[..., Callable[[Array], Array]]] = None,
     func_hess: Optional[Callable[..., Callable[[Array], Array]]] = None,
     n: int = 0,
-    input_style: str = "concatenated",
+    input_style: Union[str, CertificateInputStyle] = CertificateInputStyle.CONCATENATED,
 ) -> Callable[..., CertificateCollection]:
     """Function for packaging and later creating CBF executables.
 
@@ -69,7 +70,7 @@ def certificate_package(
         func_hess (Callable, optional): certificate hessian matrix function factory.
             If None, computed automatically using jax.hessian.
         n (int): state dimension
-        input_style (str): expected signature of the certificate function.
+        input_style (str | CertificateInputStyle): expected signature of the certificate function.
             - "concatenated" (default): func returns f(xt) where xt is [x, t].
             - "separated": func returns f(t, x).
             - "state": func returns f(x).
@@ -78,6 +79,15 @@ def certificate_package(
     -------
         CertificateCollection: _description_
     """
+    # Validate input_style
+    if isinstance(input_style, str):
+        try:
+            input_style = CertificateInputStyle(input_style)
+        except ValueError:
+            valid_styles = [e.value for e in CertificateInputStyle]
+            raise ValueError(
+                f"Invalid input_style '{input_style}'. Must be one of {valid_styles}"
+            ) from None
 
     def package(
         certificate_conditions: CertificateConditionsCallable,
@@ -96,13 +106,13 @@ def certificate_package(
         """
         v_func = func(**kwargs)
 
-        if input_style == "separated":
+        if input_style == CertificateInputStyle.SEPARATED:
             _orig_v_sep = v_func
 
             def v_func(xt):
                 return _orig_v_sep(xt[-1], xt[:-1])
 
-        elif input_style == "state":
+        elif input_style == CertificateInputStyle.STATE:
             _orig_v_state = v_func
 
             def v_func(xt):

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -42,6 +42,7 @@ Examples
 >>> x: State = jnp.array([1, 2, 2.4])
 """
 
+from enum import Enum
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Protocol, Tuple, Union
 
 from jax import Array, random
@@ -81,6 +82,14 @@ class PlannerData(NamedTuple):
 
 
 # Certificate (Barrier, Lyapunov, Barrier-Lyapunov, etc.) Function Callables
+class CertificateInputStyle(str, Enum):
+    """Enumeration for certificate function input styles."""
+
+    CONCATENATED = "concatenated"
+    SEPARATED = "separated"
+    STATE = "state"
+
+
 CertificateCallable = Callable[[Time, State], Array]
 CertificateJacobianCallable = Callable[[Time, State], Array]
 CertificateHessianCallable = Callable[[Time, State], Array]

--- a/tests/test_certificates/test_input_style_validation.py
+++ b/tests/test_certificates/test_input_style_validation.py
@@ -1,0 +1,46 @@
+
+import unittest
+import jax.numpy as jnp
+from cbfkit.certificates import certificate_package
+from cbfkit.utils.user_types import CertificateInputStyle
+
+class TestInputStyleValidation(unittest.TestCase):
+    def test_invalid_string_input(self):
+        """Test that passing an invalid string raises ValueError."""
+        def dummy_factory(**kwargs):
+            def func(x):
+                return x[0]
+            return func
+
+        with self.assertRaises(ValueError) as cm:
+            certificate_package(dummy_factory, n=1, input_style="invalid_style")
+
+        self.assertIn("Invalid input_style 'invalid_style'", str(cm.exception))
+        self.assertIn("concatenated", str(cm.exception))
+
+    def test_valid_string_input(self):
+        """Test that passing valid strings works correctly."""
+        def dummy_factory(**kwargs):
+            def func(x):
+                return x[0]
+            return func
+
+        # Should not raise
+        certificate_package(dummy_factory, n=1, input_style="concatenated")
+        certificate_package(dummy_factory, n=1, input_style="separated")
+        certificate_package(dummy_factory, n=1, input_style="state")
+
+    def test_enum_input(self):
+        """Test that passing Enum members works correctly."""
+        def dummy_factory(**kwargs):
+            def func(x):
+                return x[0]
+            return func
+
+        # Should not raise
+        certificate_package(dummy_factory, n=1, input_style=CertificateInputStyle.CONCATENATED)
+        certificate_package(dummy_factory, n=1, input_style=CertificateInputStyle.SEPARATED)
+        certificate_package(dummy_factory, n=1, input_style=CertificateInputStyle.STATE)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a structural improvement to the `certificate_package` function in `src/cbfkit/certificates/packager.py`.

**Problem:**
Previously, the `input_style` argument relied on string literals ("concatenated", "separated", "state"). If a user provided an invalid string (e.g., a typo like "stat"), the function silently defaulted to the "concatenated" behavior (`f([x, t])`). This could lead to confusing runtime errors (e.g., shape mismatches) or incorrect calculations if dimensions happened to align, acting as a "footgun".

**Solution:**
1.  Defined a `CertificateInputStyle` Enum in `src/cbfkit/utils/user_types.py` with members `CONCATENATED`, `SEPARATED`, and `STATE`.
2.  Updated `certificate_package` to validate the `input_style` argument. It now converts string inputs to the Enum, raising a descriptive `ValueError` if the string is invalid.
3.  Updated the internal logic to check against Enum members.

**Benefits:**
-   **Safety:** eliminating silent defaults prevents subtle bugs.
-   **Clarity:** using an Enum makes valid options explicit and discoverable.
-   **Backward Compatibility:** existing code using valid strings continues to work unchanged.

**Testing:**
-   Added `tests/test_certificates/test_input_style_validation.py` to verify validation logic and Enum usage.
-   Verified no regressions in existing `tests/test_certificates/test_packager.py` and `tests/test_certificates/test_certificate_package.py`.

---
*PR created automatically by Jules for task [10237560186744231729](https://jules.google.com/task/10237560186744231729) started by @bardhh*