### PR TITLE
Fix CLF relaxation singularity at origin

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/vanilla_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/vanilla_clfs.py
@@ -50,8 +50,10 @@ def generate_compute_vanilla_clf_constraints(
             a_clf = a_clf.at[:, :n_con].set(jnp.matmul(lj_x, dyn_g))
             b_clf = b_clf.at[:].set(-dlf_t - jnp.matmul(lj_x, dyn_f) + lc_x)
             if relaxable:
-                a_clf = a_clf.at[:, -n_lfs:].set(-lc_x * scale_clf)
-                b_clf = b_clf.at[:].set(-dlf_t - jnp.matmul(lj_x, dyn_f))
+                # Janus: Use additive relaxation (-scale_clf) instead of multiplicative (-lc_x * scale_clf).
+                # Multiplicative relaxation vanishes at V=0, causing loss of authority and ill-conditioning.
+                a_clf = a_clf.at[:, -n_lfs:].set(-scale_clf)
+                # Keep b_clf as is (with lc_x), realizing additive relaxation: V_dot <= lc_x + delta
 
             # Treat goal reached when Lyapunov value is sufficiently small
             complete = lax.cond(


### PR DESCRIPTION
Switched vanilla CLF relaxation from multiplicative to additive to prevent singularity at V=0. Verified with reproduction script and existing tests.

---
*PR created automatically by Jules for task [14633469431239088030](https://jules.google.com/task/14633469431239088030) started by @bardhh*