### PR TITLE
DX: decode solver status codes in simulator output

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -47,6 +47,30 @@ from .simulator_jit import simulator_jit
 from .utils import SimulationStepData
 
 
+SOLVER_STATUS_MAP = {
+    0: "UNSOLVED (Likely Infeasible)",
+    1: "SOLVED",
+    2: "MAX_ITER_REACHED",
+    3: "PRIMAL_INFEASIBLE",
+    4: "DUAL_INFEASIBLE",
+}
+
+
+def _format_error_status(status_code: Any) -> str:
+    """Formats a solver status code into a human-readable string."""
+    if isinstance(status_code, (int, float, jnp.ndarray, np.ndarray)):
+        # Handle scalar arrays or ints
+        try:
+            code = int(status_code)
+            if code in SOLVER_STATUS_MAP:
+                return f"{SOLVER_STATUS_MAP[code]} (Status: {code})"
+            else:
+                return f"Status: {code}"
+        except (ValueError, TypeError):
+            pass
+    return str(status_code)
+
+
 def _check_simulation_status(
     controller_data_keys: List[str],
     controller_data_values: List[Array],
@@ -69,7 +93,7 @@ def _check_simulation_status(
                 error_data = controller_data_values[idx_data]
                 # Get status at the point of failure
                 status = error_data[first_error_idx].item()
-                status_msg = f" (Status: {status})"
+                status_msg = f" ({_format_error_status(status)})"
 
             print(
                 f"Warning: Simulation stopped early due to controller error at step {first_error_idx}{status_msg}."
@@ -257,7 +281,7 @@ def simulator(
 
             if controller_data.error:
                 err_msg = (
-                    controller_data.error_data
+                    _format_error_status(controller_data.error_data)
                     if controller_data.error_data is not None
                     else "Unknown error"
                 )

--- a/tests/test_simulation/test_error_reporting.py
+++ b/tests/test_simulation/test_error_reporting.py
@@ -1,0 +1,11 @@
+import pytest
+from cbfkit.simulation.simulator import _format_error_status
+
+def test_format_error_status():
+    assert _format_error_status(0) == "UNSOLVED (Likely Infeasible) (Status: 0)"
+    assert _format_error_status(1) == "SOLVED (Status: 1)"
+    assert _format_error_status(2) == "MAX_ITER_REACHED (Status: 2)"
+    assert _format_error_status(3) == "PRIMAL_INFEASIBLE (Status: 3)"
+    assert _format_error_status(4) == "DUAL_INFEASIBLE (Status: 4)"
+    assert _format_error_status(999) == "Status: 999"
+    assert _format_error_status("Unknown") == "Unknown"


### PR DESCRIPTION
Improved developer experience by translating obscure integer solver status codes into descriptive error messages in the simulator output. This helps users diagnose issues like infeasibility or max iterations without consulting source code or documentation.

---
*PR created automatically by Jules for task [13352133634319727234](https://jules.google.com/task/13352133634319727234) started by @bardhh*