### PR TITLE
🔧 Forge: Fix pyproject.toml build backend and separate dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,14 +17,8 @@ dependencies = [
     "jaxlib>=0.4.23",
     "cvxopt>=1.3.2,<2.0",
     "kvxopt>=1.3.2.0,<2.0",
-    "cmake>=3.28.1,<4.0",
-    "cython>=3.0.8,<4.0",
     "pyyaml>=6.0.1,<7.0",
-    "setuptools>=69.0.3,<70.0",
-    "black>=23.12.1,<24.0",
-    "mypy>=1.8.0,<2.0",
     "jaxopt>=0.8.3,<0.9",
-    "jupyter>=1.0.0,<2.0",
     "control>=0.9.4,<1.0",
     "matplotlib>=3.8.2,<4.0",
     "pandas>=2.1.4,<3.0",
@@ -33,6 +27,23 @@ dependencies = [
     "casadi>=3.6.4,<4.0",
     "tqdm>=4.66.2,<5.0"
 ]
+
+[project.optional-dependencies]
+dev = [
+    "black>=23.12.1,<24.0",
+    "mypy>=1.8.0,<2.0",
+    "cmake>=3.28.1,<4.0",
+    "cython>=3.0.8,<4.0",
+    "setuptools>=69.0.3,<70.0",
+    "jupyter>=1.0.0,<2.0",
+    "pytest>=8.0.2",
+    "ruff>=0.3.4",
+    "python-dotenv>=1.2.1",
+]
+
+[build-system]
+requires = ["setuptools>=69.0.3", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
Improved packaging by adding a standard `[build-system]` and separating development dependencies from runtime dependencies in `pyproject.toml`. This allows for lighter weight installations for end users while preserving a complete development environment via `pip install .[dev]`.

---
*PR created automatically by Jules for task [4020457094848529964](https://jules.google.com/task/4020457094848529964) started by @bardhh*