### PR TITLE
🧾 Piper: Use Literal for input_style typing in certificate_package

### DIFF
--- a/src/cbfkit/certificates/packager.py
+++ b/src/cbfkit/certificates/packager.py
@@ -37,7 +37,7 @@ Examples
 
 """
 
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Literal, Optional, Union
 
 import jax.numpy as jnp
 from jax import Array, grad, hessian, jit
@@ -54,12 +54,17 @@ from cbfkit.utils.user_types import (
 )
 
 
+CertificateInputStyleName = Literal["concatenated", "separated", "state"]
+
+
 def certificate_package(
     func: Callable[..., Callable[[Array], Array]],
     func_grad: Optional[Callable[..., Callable[[Array], Array]]] = None,
     func_hess: Optional[Callable[..., Callable[[Array], Array]]] = None,
     n: int = 0,
-    input_style: Union[str, CertificateInputStyle] = CertificateInputStyle.CONCATENATED,
+    input_style: Union[
+        CertificateInputStyleName, CertificateInputStyle
+    ] = CertificateInputStyle.CONCATENATED,
 ) -> Callable[..., CertificateCollection]:
     """Function for packaging and later creating CBF executables.
 


### PR DESCRIPTION
Piper typing improvement: Narrow `input_style` argument in `certificate_package` to use `Literal` instead of broad `str`, enabling static verification of configuration strings.

---
*PR created automatically by Jules for task [15516194518193131972](https://jules.google.com/task/15516194518193131972) started by @bardhh*