### PR TITLE
🔮 Oracle: Align MPPI docstring and comments with implementation

### DIFF
--- a/src/cbfkit/controllers/mppi/mppi_source.py
+++ b/src/cbfkit/controllers/mppi/mppi_source.py
@@ -73,7 +73,7 @@ def setup_mppi(
     def weighted_sum(U, perturbation, costs):
         """
         Args:
-            U: control input trajectory of all samples
+            U: Nominal control input trajectory
             perturbation: random perturbation trajectory of all samples
             costs: cost of each sampled trajectory
         """
@@ -200,7 +200,7 @@ def setup_mppi(
             subkey, shape=(samples, horizon, robot_control_dim)
         ) * std
 
-        perturbation = jnp.clip(perturbation, -3.0, 3.0)  # 0.3
+        perturbation = jnp.clip(perturbation, -3.0, 3.0)
         perturbed_control = U + perturbation
 
         perturbed_control = jnp.clip(perturbed_control, -control_bound, control_bound)


### PR DESCRIPTION
This PR aligns the MPPI controller documentation and comments with the actual implementation. 
The `weighted_sum` function expects a nominal trajectory `U` of shape `(horizon, control_dim)`, but the docstring claimed it was "trajectory of all samples".
Additionally, a comment `# 0.3` next to a `jnp.clip(..., -3.0, 3.0)` call was removed as it was contradictory and likely outdated.
Verified with a reproduction script that confirms `U` must be `(H, m)` and that `(S, H, m)` causes shape errors.
Ran existing controller tests (`tests/test_controllers/`) which passed.

---
*PR created automatically by Jules for task [9586448215815747990](https://jules.google.com/task/9586448215815747990) started by @bardhh*