### PR TITLE
⚡ Bolt: Filter solver_params from simulator trajectory

### DIFF
--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -207,8 +207,19 @@ def simulator_jit(
         # Pack carry
         new_carry = (key, t_next, x_next, u, z, c, controller_data, planner_data)
 
+        # Bolt: Filter solver_params from output to save memory/bandwidth
+        controller_data_log = controller_data
+        if (
+            controller_data.sub_data is not None
+            and "solver_params" in controller_data.sub_data
+        ):
+            new_sub_data = {
+                k: v for k, v in controller_data.sub_data.items() if k != "solver_params"
+            }
+            controller_data_log = controller_data._replace(sub_data=new_sub_data)
+
         # Output (trajectory)
-        output = (x, u, z, c, controller_data, planner_data)
+        output = (x, u, z, c, controller_data_log, planner_data)
 
         return new_carry, output
 


### PR DESCRIPTION
- 💡 What: Modified `simulator_jit.py` to remove `solver_params` (QP solution history) from the logged `controller_data` output.
- 🎯 Why: `solver_params` (e.g., `KKTSolution`) was being stored for every time step in the trajectory. For long simulations, this consumes unnecessary memory and bandwidth, while only being needed for warm-starting the *next* step (which is handled by `carry`, not `output`).
- 📊 Impact: Verified with reproduction script. `solver_params` is absent from output `c_datas`, reducing memory footprint proportional to `N_STEPS * (N_VARS + N_CONSTRAINTS)`. Time overhead is negligible/neutral.
- 🔬 How measured: Reproduction script `reproduce_issue.py` confirmed presence before and absence after. Unit tests `test_simulator_jit_rk4.py` and `test_cbf_clf_qp_controllers.py` passed.
- ✅ Correctness: Simulation logic is unchanged; `solver_params` is still preserved in the `carry` for warm-starting. Existing tests pass.

---
*PR created automatically by Jules for task [9431515731449091910](https://jules.google.com/task/9431515731449091910) started by @bardhh*