### PR TITLE
⏱️ Chronos: Add regression test for QP solver safety on max iterations

### DIFF
--- a/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
@@ -1,0 +1,79 @@
+
+import unittest
+from unittest.mock import patch
+import jax.numpy as jnp
+import jax
+from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+from cbfkit.utils.user_types import ControllerData, EMPTY_CERTIFICATE_COLLECTION
+
+class TestQPSolverSafety(unittest.TestCase):
+    def test_max_iter_safety(self):
+        """
+        Regression test: Ensure that if the QP solver hits MAX_ITER_REACHED (status 2),
+        the controller returns NaN instead of a potentially unsafe non-converged solution.
+        """
+
+        # 1. Setup simple controller
+        control_limits = jnp.array([10.0, 10.0])
+
+        def dynamics(x):
+            return jnp.zeros((2,)), jnp.eye(2)
+
+        # We need to construct the controller inside the test or use the pre-generated one.
+        # vanilla_cbf_clf_qp_controller is a generator function.
+        # It imports solve_qp from cbf_clf_qp_generator module.
+
+        # 2. Define the mock solver
+        def mock_solve(p_mat, q_vec, g_mat, h_vec, init_params=None):
+            # Return dummy solution (zeros), status 2 (MAX_ITER), and None params
+            # Solution size must match q_vec (which is n_controls + slacks)
+            n_vars = q_vec.shape[0]
+            # status=2 means MAX_ITER_REACHED
+            return jnp.zeros((n_vars,)), jnp.array(2, dtype=jnp.int32), None
+
+        # 3. Patch solve_qp in the module where it is used
+        with patch('cbfkit.controllers.cbf_clf.cbf_clf_qp_generator.solve_qp', side_effect=mock_solve):
+
+            # Generate the controller *while patched* so it captures the mock?
+            # cbf_clf_qp_generator returns a function `generate_cbf_clf_controller`.
+            # That function returns `controller`.
+            # `controller` uses `solve_qp` from global scope.
+            # So patching the global in the module should work even if generator was imported earlier.
+
+            controller = vanilla_cbf_clf_qp_controller(
+                control_limits=control_limits,
+                dynamics_func=dynamics,
+                barriers=EMPTY_CERTIFICATE_COLLECTION,
+                lyapunovs=EMPTY_CERTIFICATE_COLLECTION
+            )
+
+            # 4. Run the controller
+            t = 0.0
+            x = jnp.array([0.0, 0.0])
+            u_nom = jnp.array([1.0, 1.0])
+            key = jax.random.PRNGKey(0)
+            data = ControllerData(
+                error=False,
+                error_data=0,
+                complete=False,
+                sol=jnp.array([]),
+                u=jnp.zeros(2),
+                u_nom=jnp.zeros(2),
+                sub_data={}
+            )
+
+            # JIT compilation happens here
+            u, new_data = controller(t, x, u_nom, key, data)
+
+            # 5. Assertions
+            # The controller must return NaNs if status is not 1 (SOLVED)
+            self.assertTrue(jnp.isnan(u).all(), f"Controller returned values {u} despite MAX_ITER status!")
+
+            # Error flag should be True
+            self.assertTrue(new_data.error, "Controller did not report error!")
+
+            # Error data should capture the status code 2
+            self.assertEqual(new_data.error_data, 2, f"Controller reported wrong status: {new_data.error_data}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added a regression test to ensure safety when the QP solver hits max iterations.

**Context:**
The `cbf_clf_qp_generator` logic handles solver status codes. Currently, it strictly accepts only status `1` (SOLVED). Status `2` (MAX_ITER_REACHED) must be treated as a failure (returning NaNs) to ensure safety. This test locks in this behavior.

**Changes:**
- Added `tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py`.
- The test mocks `cbfkit.controllers.cbf_clf.cbf_clf_qp_generator.solve_qp` to return status `2` and asserts that the controller output is `NaN`.

**Verification:**
- Ran the test successfully.
- Verified that modifying the code to accept status `2` causes the test to fail.


---
*PR created automatically by Jules for task [3085069473258709483](https://jules.google.com/task/3085069473258709483) started by @bardhh*