### PR TITLE
🏗️ Atlas: Introduce SimulationResults for clearer simulation output

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -37,6 +37,7 @@ from cbfkit.utils.user_types import (
     PlannerCallable,
     PlannerData,
     SensorCallable,
+    SimulationResults,
     State,
     Time,
 )
@@ -326,7 +327,7 @@ def execute(
     use_jit: bool = False,
     jit_progress: bool = False,
     jit_progress_interval: int = 50,
-) -> Tuple[Array, Array, Array, Array, List[str], List[Array], List[str], List[Array]]:
+) -> SimulationResults:
     """Executes a complete simulation of the dynamical system.
 
     This function runs the simulation for `num_steps` starting from `x0`.
@@ -366,7 +367,7 @@ def execute(
 
     Returns
     -------
-        Tuple containing:
+        SimulationResults object containing:
             - states (Array): Trajectory of states (num_steps x state_dim).
             - controls (Array): Trajectory of control inputs.
             - estimates (Array): Trajectory of state estimates.
@@ -564,7 +565,7 @@ def execute(
                 planner_data_values,
             )
 
-        return (
+        return SimulationResults(
             xs,
             us,
             zs,
@@ -627,10 +628,10 @@ def execute(
 
 def format_return_data(
     data: Tuple[SimulationStepData, ...],
-) -> Tuple[Array, Array, Array, Array, List[str], List[Array], List[str], List[Array]]:
+) -> SimulationResults:
     """Extracts simulation data into JAX arrays."""
     if not data:
-        return (
+        return SimulationResults(
             jnp.array([]),
             jnp.array([]),
             jnp.array([]),
@@ -696,7 +697,7 @@ def format_return_data(
             data[0].planner_keys, transposed.planner_values
         )
 
-    return (
+    return SimulationResults(
         states,
         controls,
         estimates,

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -81,6 +81,29 @@ class PlannerData(NamedTuple):
     sampled_x_traj: Optional[Array] = None
 
 
+class SimulationResults(NamedTuple):
+    """Results from a simulation execution."""
+
+    states: State
+    controls: Control
+    estimates: Estimate
+    covariances: Covariance
+    controller_keys: List[str]
+    controller_values: List[Array]
+    planner_keys: List[str]
+    planner_values: List[Array]
+
+    @property
+    def controller_data(self) -> Dict[str, Array]:
+        """Returns controller data as a dictionary."""
+        return dict(zip(self.controller_keys, self.controller_values))
+
+    @property
+    def planner_data(self) -> Dict[str, Array]:
+        """Returns planner data as a dictionary."""
+        return dict(zip(self.planner_keys, self.planner_values))
+
+
 # Certificate (Barrier, Lyapunov, Barrier-Lyapunov, etc.) Function Callables
 class CertificateInputStyle(str, Enum):
     """Enumeration for certificate function input styles."""

--- a/tests/test_utils/test_user_types.py
+++ b/tests/test_utils/test_user_types.py
@@ -39,3 +39,43 @@ def test_addition_invalid_type():
     c1 = CertificateCollection([], [], [], [], [])
     with pytest.raises(TypeError):
         _ = c1 + "invalid"
+
+def test_simulation_results():
+    import jax.numpy as jnp
+    from cbfkit.utils.user_types import SimulationResults
+
+    # Mock data
+    states = jnp.zeros((10, 2))
+    controls = jnp.zeros((10, 1))
+    estimates = jnp.zeros((10, 2))
+    covariances = jnp.zeros((10, 2, 2))
+    c_keys = ["error"]
+    c_vals = [jnp.zeros((10,))]
+    p_keys = ["cost"]
+    p_vals = [jnp.zeros((10,))]
+
+    res = SimulationResults(
+        states, controls, estimates, covariances,
+        c_keys, c_vals, p_keys, p_vals
+    )
+
+    # Test unpacking (8 elements)
+    x, u, z, p, ck, cv, pk, pv = res
+    assert x is states
+    assert u is controls
+    assert ck is c_keys
+
+    # Test property access
+    assert res.states is states
+    assert res.controls is controls
+
+    # Test dictionary properties
+    c_data = res.controller_data
+    assert isinstance(c_data, dict)
+    assert "error" in c_data
+    assert c_data["error"] is c_vals[0]
+
+    p_data = res.planner_data
+    assert isinstance(p_data, dict)
+    assert "cost" in p_data
+    assert p_data["cost"] is p_vals[0]


### PR DESCRIPTION
Replaced the confusing 8-element tuple return of `sim.execute` with a named `SimulationResults` object.
- **Before:** `x, u, z, p, ck, cv, pk, pv = sim.execute(...)` (prone to order errors)
- **After:** `res = sim.execute(...); res.states` or `res.controller_data["error"]`
- **Backward Compatibility:** `SimulationResults` is a `NamedTuple`, so existing unpacking code continues to work without changes.
- **Composability Win:** Added `.controller_data` and `.planner_data` properties to return dictionaries, avoiding manual zip/unpacking of keys and values.

---
*PR created automatically by Jules for task [6138583269443925646](https://jules.google.com/task/6138583269443925646) started by @bardhh*