### PR TITLE
📦 Archivist: Make Adaptive CVaR CBF uncertainty generation deterministic

### DIFF
--- a/src/cbfkit/controllers/adaptive_cvar_cbf.py
+++ b/src/cbfkit/controllers/adaptive_cvar_cbf.py
@@ -3,7 +3,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import casadi as ca
 import jax.numpy as jnp
 import numpy as np
-from jax import Array
+from jax import Array, random
+from numpy.random import Generator
 
 from cbfkit.utils.uncertainty import generate_uncertainty_pmf
 from cbfkit.utils.user_types import (
@@ -72,14 +73,20 @@ class AdaptiveCVaRBarrierSolver:
         return self.A @ x + self.B @ u
 
     def solve(
-        self, t: float, x: np.ndarray, u_nom: np.ndarray
+        self,
+        t: float,
+        x: np.ndarray,
+        u_nom: np.ndarray,
+        rng: Optional[Generator] = None,
     ) -> Tuple[np.ndarray, Dict[str, Any]]:
         """
         Solves the optimization problem.
         """
         # 1. Update PMF based on current state and nominal input
         # For self (robot)
-        pmf, wu_samples, wx_samples = generate_uncertainty_pmf(u_nom, x, self.noise_params, self.S)
+        pmf, wu_samples, wx_samples = generate_uncertainty_pmf(
+            u_nom, x, self.noise_params, self.S, rng=rng
+        )
 
         # For obstacles (assuming they have their own noise params or similar)
         # Simplified: use same noise for obs for now, or extract from obs if available
@@ -91,7 +98,7 @@ class AdaptiveCVaRBarrierSolver:
             # Assuming obs has .noise attribute
             obs_noise = getattr(obs, "noise", [[0.01] * 4, [0.01] * 4])
             o_pmf, o_wu, o_wx = generate_uncertainty_pmf(
-                obs.velocity_xy, obs.x_curr, obs_noise, self.S
+                obs.velocity_xy, obs.x_curr, obs_noise, self.S, rng=rng
             )
             obs_pmfs.append(o_pmf)
             obs_wu_samples.append(o_wu)
@@ -371,11 +378,15 @@ def adaptive_cvar_cbf_controller(
         x_np = np.array(x)
         u_nom_np = np.array(u_nom) if u_nom is not None else np.zeros(solver.m)
 
+        # Seed random number generator
+        seed = int(random.randint(key, (), 0, 2**31 - 1))
+        rng = np.random.default_rng(seed)
+
         # Solve
         # CasADi expects float time
         t_float = float(t) if isinstance(t, (float, int)) else float(t[0]) if t.shape else 0.0
 
-        u_opt, log_info = solver.solve(t_float, x_np, u_nom_np)
+        u_opt, log_info = solver.solve(t_float, x_np, u_nom_np, rng=rng)
 
         # Return
         u_jax = jnp.array(u_opt).flatten()

--- a/src/cbfkit/utils/uncertainty.py
+++ b/src/cbfkit/utils/uncertainty.py
@@ -1,6 +1,7 @@
-from typing import List, Tuple
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
+from numpy.random import Generator
 from scipy.stats import norm
 
 
@@ -12,7 +13,11 @@ def _pdf_or_ones(values, std):
 
 
 def generate_uncertainty_pmf(
-    control_input: np.ndarray, state: np.ndarray, noise_params: List[List[float]], S: int
+    control_input: np.ndarray,
+    state: np.ndarray,
+    noise_params: List[List[float]],
+    S: int,
+    rng: Optional[Union[Generator, Any]] = None,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Generates Probability Mass Function (PMF) and samples for uncertainty.
@@ -24,6 +29,8 @@ def generate_uncertainty_pmf(
                       noise[0] = [std_px, std_py, std_vx, std_vy] (state noise stds)
                       noise[1] = [std_ux_ux, std_ux_uy, std_uy_ux, std_uy_uy] (control dependent noise)
         S: Number of samples
+        rng: Optional random number generator (numpy.random.Generator) or numpy.random module.
+             If None, uses global numpy.random state.
 
     Returns:
         pmf: Probability mass function values (S, 1)
@@ -54,12 +61,15 @@ def generate_uncertainty_pmf(
     std_ux = np.sqrt(std_ux_ux * (u[0, 0] ** 2) + std_ux_uy * (u[1, 0] ** 2))
     std_uy = np.sqrt(std_uy_ux * (u[0, 0] ** 2) + std_uy_uy * (u[1, 0] ** 2))
 
+    if rng is None:
+        rng = np.random
+
     # Sample Control Noise
     # samples_u shape: (S, 2, 1)
     # Note: Using np.random directly here. Ideally should use a passed RNG or cbfkit's randomness,
     # but for now maintaining parity with original logic which used a class-level RNG.
     # We'll use global np.random for simplicity in this utility, or user can seed globally.
-    samples_u = np.random.normal(loc=[[0], [0]], scale=[[std_ux], [std_uy]], size=(S, 2, 1))
+    samples_u = rng.normal(loc=[[0], [0]], scale=[[std_ux], [std_uy]], size=(S, 2, 1))
 
     pdf_ux = _pdf_or_ones(samples_u[:, 0], std_ux)
     pdf_uy = _pdf_or_ones(samples_u[:, 1], std_uy)
@@ -70,14 +80,14 @@ def generate_uncertainty_pmf(
         if std_px <= 1e-5 and std_py <= 1e-5:
             std_px = 0.001
             std_py = 0.001
-        samples_x = np.random.normal(loc=[[0], [0]], scale=[[std_px], [std_py]], size=(S, 2, 1))
+        samples_x = rng.normal(loc=[[0], [0]], scale=[[std_px], [std_py]], size=(S, 2, 1))
         pdf_px = _pdf_or_ones(samples_x[:, 0], std_px)
         pdf_py = _pdf_or_ones(samples_x[:, 1], std_py)
         joint_pdf = pdf_ux * pdf_uy * pdf_px * pdf_py
 
     else:
         # 4D state
-        samples_x = np.random.normal(
+        samples_x = rng.normal(
             loc=[[0], [0], [0], [0]], scale=[[std_px], [std_py], [std_vx], [std_vy]], size=(S, 4, 1)
         )
         pdf_px = _pdf_or_ones(samples_x[:, 0], std_px)

--- a/tests/test_uncertainty_determinism.py
+++ b/tests/test_uncertainty_determinism.py
@@ -1,0 +1,94 @@
+import numpy as np
+import pytest
+from cbfkit.utils.uncertainty import generate_uncertainty_pmf
+
+def test_uncertainty_determinism():
+    u_nom = np.array([1.0, 0.5])
+    x = np.array([0.0, 0.0, 1.0, 0.0])
+    noise_params = [[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1]]
+    S = 10
+
+    # Test 1: Implicit randomness (should be different)
+    # Note: We rely on the global state changing.
+    _, wu1, _ = generate_uncertainty_pmf(u_nom, x, noise_params, S)
+    _, wu2, _ = generate_uncertainty_pmf(u_nom, x, noise_params, S)
+    # Note: This might flaky-fail if random chance produces same numbers, but extremely unlikely for float arrays
+    assert not np.allclose(wu1, wu2), "Implicit randomness should be non-deterministic"
+
+    # Test 2: Explicit seeding (should be identical)
+    seed = 42
+    rng1 = np.random.default_rng(seed)
+    rng2 = np.random.default_rng(seed)
+
+    _, wu3, _ = generate_uncertainty_pmf(u_nom, x, noise_params, S, rng=rng1)
+    _, wu4, _ = generate_uncertainty_pmf(u_nom, x, noise_params, S, rng=rng2)
+
+    assert np.allclose(wu3, wu4), "Explicit seeding should produce identical results"
+
+def test_different_seeds():
+    u_nom = np.array([1.0, 0.5])
+    x = np.array([0.0, 0.0, 1.0, 0.0])
+    noise_params = [[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1]]
+    S = 10
+
+    rng1 = np.random.default_rng(42)
+    rng2 = np.random.default_rng(43)
+
+    _, wu1, _ = generate_uncertainty_pmf(u_nom, x, noise_params, S, rng=rng1)
+    _, wu2, _ = generate_uncertainty_pmf(u_nom, x, noise_params, S, rng=rng2)
+
+    assert not np.allclose(wu1, wu2), "Different seeds should produce different results"
+
+
+from cbfkit.controllers.adaptive_cvar_cbf import adaptive_cvar_cbf_controller
+from cbfkit.utils.user_types import ControllerData
+import jax.numpy as jnp
+from jax import random
+
+class DummyObstacle:
+    def __init__(self):
+        self.x_curr = np.array([5.0, 5.0, 0.0, 0.0])
+        self.velocity_xy = np.array([0.0, 0.0])
+        self.radius = 0.5
+        self.noise = [[0.01]*4, [0.01]*4]
+
+def test_controller_determinism():
+    # Setup
+    dynamics_model = {
+        "dt": 0.1,
+        "A": np.eye(4),
+        "B": np.zeros((4, 2)),
+        "u_min": -1.0,
+        "u_max": 1.0,
+        "radius": 0.5
+    }
+    # Populate B properly for double integrator or similar
+    dynamics_model["A"][0, 2] = 1.0
+    dynamics_model["A"][1, 3] = 1.0
+    dynamics_model["B"][2, 0] = 1.0
+    dynamics_model["B"][3, 1] = 1.0
+
+    obstacles = [DummyObstacle()]
+
+    controller = adaptive_cvar_cbf_controller(dynamics_model, obstacles, params={"S": 5})
+
+    t = 0.0
+    x = jnp.array([0.0, 0.0, 1.0, 0.0])
+    u_nom = jnp.array([1.0, 0.5])
+    data = ControllerData()
+
+    key = random.PRNGKey(42)
+
+    # Run 1
+    u1, _ = controller(t, x, u_nom, key, data)
+
+    # Run 2 (Same key)
+    u2, _ = controller(t, x, u_nom, key, data)
+
+    # Check equality
+    assert jnp.allclose(u1, u2), "Controller should be deterministic with same key"
+
+    # Run 3 (Different key)
+    key_diff = random.PRNGKey(43)
+    u3, _ = controller(t, x, u_nom, key_diff, data)
+    # Just verify it runs without error


### PR DESCRIPTION
This PR addresses non-determinism in the `AdaptiveCVaRBarrierSolver` caused by the use of global `numpy.random` state in `generate_uncertainty_pmf`.

Changes:
1.  **`src/cbfkit/utils/uncertainty.py`**:
    *   Updated `generate_uncertainty_pmf` to accept an optional `rng` argument of type `numpy.random.Generator`.
    *   If `rng` is provided, it is used for sampling; otherwise, it falls back to the global `numpy.random` module (maintaining backward compatibility).

2.  **`src/cbfkit/controllers/adaptive_cvar_cbf.py`**:
    *   Updated `AdaptiveCVaRBarrierSolver.solve` to accept an `rng` argument and pass it to `generate_uncertainty_pmf`.
    *   Updated `adaptive_cvar_cbf_controller` (the factory wrapper) to:
        *   Extract a deterministic integer seed from the passed JAX `key`.
        *   Instantiate a `numpy.random.default_rng(seed)`.
        *   Pass this `rng` to the solver.
    *   Ensured the seed generation uses a safe integer range (`2**31 - 1`) to avoid overflow issues on systems where standard integer types are 32-bit.

3.  **Tests**:
    *   Added `tests/test_uncertainty_determinism.py` which validates:
        *   Implicit randomness remains non-deterministic (legacy behavior).
        *   Explicit seeding produces identical results.
        *   Different seeds produce different results.
        *   The `adaptive_cvar_cbf_controller` is deterministic when called with the same JAX key.

This fulfills the goal of making runs repeatable and results auditable for this controller.

---
*PR created automatically by Jules for task [17592910345224867333](https://jules.google.com/task/17592910345224867333) started by @bardhh*