### PR TITLE
🧹 Curator: Remove mypy and jupyter from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,7 @@ dependencies = [
     "pyyaml>=6.0.1,<7.0",
     "setuptools>=69.0.3,<70.0",
     "black>=23.12.1,<24.0",
-    "mypy>=1.8.0,<2.0",
     "jaxopt>=0.8.3,<0.9",
-    "jupyter>=1.0.0,<2.0",
     "control>=0.9.4,<1.0",
     "matplotlib>=3.8.2,<4.0",
     "pandas>=2.1.4,<3.0",
@@ -63,4 +61,5 @@ dev = [
     "pytest>=9.0.2",
     "python-dotenv>=1.2.1",
     "ruff>=0.14.14",
+    "jupyter>=1.0.0",
 ]


### PR DESCRIPTION
This change removes `mypy` and `jupyter` from the runtime `dependencies` list in `pyproject.toml`. These are development/interactive tools that bloat the installation for users who only need the `cbfkit` library for control. `mypy` was already duplicated in `dependency-groups.dev`, and `jupyter` has been added to `dependency-groups.dev` to support tutorial execution during development. Validated by verifying installation, import, and core tests in a clean environment.

---
*PR created automatically by Jules for task [2437790539072662676](https://jules.google.com/task/2437790539072662676) started by @bardhh*