### PR TITLE
🚨 Sentinel: Explicit QP failure handling and NaN detection

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -287,6 +287,9 @@ def cbf_clf_qp_generator(
                 p_mat, q_vec, g_mat, h_vec, init_params=solver_params
             )
 
+            # Sentinel: Explicitly catch NaN solutions even if solver claims success
+            status = jnp.where(jnp.any(jnp.isnan(sol)), 0, status)
+
             # Bolt: Rescale solution back to physical units
             if auto_p_mat:
                 if n_bfs > 0:

--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -556,13 +556,12 @@ def execute(
             planner_data_keys.append(key_str)
             planner_data_values.append(val)
 
-        if verbose:
-            _check_simulation_status(
-                controller_data_keys,
-                controller_data_values,
-                planner_data_keys,
-                planner_data_values,
-            )
+        _check_simulation_status(
+            controller_data_keys,
+            controller_data_values,
+            planner_data_keys,
+            planner_data_values,
+        )
 
         return (
             xs,
@@ -604,23 +603,23 @@ def execute(
 
     formatted_data = format_return_data(simulation_data)
 
-    if verbose:
-        (
-            _,
-            _,
-            _,
-            _,
-            controller_data_keys,
-            controller_data_values,
-            planner_data_keys,
-            planner_data_values,
-        ) = formatted_data
-        _check_simulation_status(
-            controller_data_keys,
-            controller_data_values,
-            planner_data_keys,
-            planner_data_values,
-        )
+    (
+        _,
+        _,
+        _,
+        _,
+        controller_data_keys,
+        controller_data_values,
+        planner_data_keys,
+        planner_data_values,
+    ) = formatted_data
+
+    _check_simulation_status(
+        controller_data_keys,
+        controller_data_values,
+        planner_data_keys,
+        planner_data_values,
+    )
 
     return formatted_data
 


### PR DESCRIPTION
Implemented changes to improve failure visibility in `cbfkit`. 
1.  **Explicit Error Reporting:** The `execute` function in `simulator.py` now reports controller errors (like infeasibility) even when `verbose=False`, preventing silent failures where the simulation returns truncated or frozen trajectories without explanation.
2.  **NaN Sentinel:** The `cbf_clf_qp_generator` now acts as a Sentinel by checking the QP solution for NaNs. If found, it overrides the solver status to `0` (UNSOLVED), ensuring that numerical instabilities are treated as hard failures rather than propagated as "successful" garbage.
Tested with a reproduction script involving an infeasible QP and existing unit tests.

---
*PR created automatically by Jules for task [711733278313919529](https://jules.google.com/task/711733278313919529) started by @bardhh*