### PR TITLE
🔧 Forge: Remove setuptools from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "cvxopt>=1.3.2,<2.0",
     "kvxopt>=1.3.2.0,<2.0",
     "pyyaml>=6.0.1,<7.0",
-    "setuptools>=69.0.3,<70.0",
     "black>=23.12.1,<24.0",
     "jaxopt>=0.8.3,<0.9",
     "control>=0.9.4,<1.0",


### PR DESCRIPTION
Remove `setuptools` from `project.dependencies` in `pyproject.toml`.

**Why:**
`setuptools` is a build backend (listed correctly in `[build-system]`), but the package code does not use it at runtime (e.g., via `pkg_resources` or direct imports). Listing it as a runtime dependency with a restrictive pin (`>=69.0.3,<70.0`) is unnecessary and can block installation in environments requiring other versions.

**Verification:**
- Verified `setuptools` is not used in `src/cbfkit`.
- Reinstalled package via `pip install -e .` and confirmed `setuptools` is absent from `Requires`.
- Confirmed package imports successfully: `python -c "import cbfkit"`.
- Confirmed package builds successfully: `python -m build`.

---
*PR created automatically by Jules for task [6609297369769067327](https://jules.google.com/task/6609297369769067327) started by @bardhh*