### PR TITLE
Simplify rectify_relative_degree API for better composability

### DIFF
--- a/src/cbfkit/certificates/rectifiers.py
+++ b/src/cbfkit/certificates/rectifiers.py
@@ -21,6 +21,7 @@ one with respect to the system dynamics, then the constraint function is not mod
 Example
 -------
 >>> from cbfkit.certificates import rectify_relative_degree
+>>> from cbfkit.certificates.conditions.barrier_conditions import zeroing_barriers
 >>>
 >>> def f(x):
 >>>     return jnp.array([x[2], x[3], x[4], x[5], 0, 0])
@@ -29,7 +30,7 @@ Example
 >>>     return jnp.array([[0, 0], [0, 0], [0, 0], [0, 0], [1, 0], [0, 1]])
 >>>
 >>> def dynamics(x):
->>>     return f(x), g(x), 1
+>>>     return f(x), g(x)
 >>>
 >>> def constraint(r1, r2):
 >>>     def h(x):
@@ -38,18 +39,27 @@ Example
 >>>
 >>> r1, r2 = 0.1, 0.05
 >>>
->>> cbf = rectify_relative_degree(constraint(r1, r2), dynamics, 6)
->>> print(cbf(jnp.array([0.5, 0.5, -0.1, 0, 0.2, 0])))
+>>> # New simpler usage
+>>> cbf = rectify_relative_degree(
+>>>     constraint(r1, r2),
+>>>     dynamics,
+>>>     6,
+>>>     certificate_conditions=zeroing_barriers.linear_class_k(1.0)
+>>> )
 """
 
-from typing import Callable, List, Union
+from typing import Callable, List, Optional, Union
 
 import jax.numpy as jnp
 import numpy as np
 from jax import Array, jacfwd, jacrev, jit, random
 
 from cbfkit.certificates import certificate_package
-from cbfkit.utils.user_types import CertificateCollection, DynamicsCallable
+from cbfkit.utils.user_types import (
+    CertificateCollection,
+    CertificateConditionsCallable,
+    DynamicsCallable,
+)
 
 # For random sample generation
 KEY = random.PRNGKey(0)
@@ -69,7 +79,8 @@ def rectify_relative_degree(
     state_dim: int,
     roots: Union[Array, None] = None,
     form: str = "exponential",
-) -> Callable[..., CertificateCollection]:
+    certificate_conditions: Optional[CertificateConditionsCallable] = None,
+) -> Union[Callable[..., CertificateCollection], CertificateCollection]:
     """Rectifies the relative degree of the provided constraint function with respect to the system
     dynamics deriving a new exponential- or high-order-CBF.
 
@@ -78,10 +89,13 @@ def rectify_relative_degree(
         system_dynamics (DynamicsCallable): dynamics function
         state_dim (int): dimension of the state
         form (str, optional): type of cascading procedure. Defaults to "exponential".
+        certificate_conditions (Optional[CertificateConditionsCallable]): certificate conditions.
+            If provided, returns a CertificateCollection directly. Defaults to None.
 
     Returns
     -------
-        Callable[[Dict[str, Any]], CertificateTuple]: Function to create the CertificateCollection
+        Union[Callable[..., CertificateCollection], CertificateCollection]: Function to create the CertificateCollection,
+            or the CertificateCollection itself if certificate_conditions is provided.
     """
     function_list = compute_function_list(function, system_dynamics, state_dim + 1, form)
 
@@ -143,7 +157,12 @@ def rectify_relative_degree(
 
             return func
 
-    return certificate_package(cbf, cbf_grad, cbf_hess, state_dim)
+    factory = certificate_package(cbf, cbf_grad, cbf_hess, state_dim)
+
+    if certificate_conditions is not None:
+        return factory(certificate_conditions)
+
+    return factory
 
 
 def compute_function_list(

--- a/tests/test_rectify_relative_degree_api.py
+++ b/tests/test_rectify_relative_degree_api.py
@@ -1,0 +1,66 @@
+
+import jax.numpy as jnp
+from cbfkit.certificates import rectify_relative_degree
+from cbfkit.certificates.conditions.barrier_conditions import zeroing_barriers
+
+def test_rectify_relative_degree_api():
+    """Test both legacy and new API for rectify_relative_degree."""
+
+    # 1. Setup simple system (2D single integrator)
+    # x_dot = u
+    def dynamics(x):
+        return jnp.zeros(2), jnp.eye(2) # f=0, g=I
+
+    # Barrier: h(x) = x[0] > 0
+    # Relative degree is 1, so h_dot = grad(h)*f + grad(h)*g*u = [1, 0] * u = u_0
+    def h(x):
+        return x[0]
+
+    state_dim = 2
+
+    # 2. Legacy Usage: Double Call
+    factory = rectify_relative_degree(
+        function=h,
+        system_dynamics=dynamics,
+        state_dim=state_dim,
+        form="exponential"
+    )
+
+    cert_legacy = factory(
+        certificate_conditions=zeroing_barriers.linear_class_k(1.0)
+    )
+
+    # 3. New Usage: Single Call
+    cert_new = rectify_relative_degree(
+        function=h,
+        system_dynamics=dynamics,
+        state_dim=state_dim,
+        form="exponential",
+        certificate_conditions=zeroing_barriers.linear_class_k(1.0)
+    )
+
+    # 4. Verify Equivalence
+    # We check if evaluating the certificate functions on a sample state gives same result
+
+    x_sample = jnp.array([0.5, 0.2])
+    t_sample = 0.0
+
+    # Check V(x)
+    # cert.functions is a list of callables.
+    # Note: certificate functions might be compiled, so we just run them.
+
+    v_legacy = cert_legacy.functions[0](t_sample, x_sample)
+    v_new = cert_new.functions[0](t_sample, x_sample)
+
+    assert jnp.allclose(v_legacy, v_new), f"V mismatch: {v_legacy} != {v_new}"
+
+    # Check grad V(x)
+    grad_legacy = cert_legacy.jacobians[0](t_sample, x_sample)
+    grad_new = cert_new.jacobians[0](t_sample, x_sample)
+
+    assert jnp.allclose(grad_legacy, grad_new), f"Grad mismatch: {grad_legacy} != {grad_new}"
+
+    print("API verification passed: Legacy and New usages produce identical results.")
+
+if __name__ == "__main__":
+    test_rectify_relative_degree_api()


### PR DESCRIPTION
Simplified the `rectify_relative_degree` API to allow direct creation of `CertificateCollection` objects when `certificate_conditions` are provided, eliminating the confusing "factory pattern" double-call. This change is fully backward compatible. Also fixed an incorrect example in the docstring.

---
*PR created automatically by Jules for task [2594296827758917395](https://jules.google.com/task/2594296827758917395) started by @bardhh*