### PR TITLE
🚨 Sentinel: Explicitly catch NaN/failure in MPPI controller

### DIFF
--- a/src/cbfkit/controllers/mppi/mppi_generator.py
+++ b/src/cbfkit/controllers/mppi/mppi_generator.py
@@ -162,12 +162,16 @@ def mppi_generator() -> MppiGenerator:
                 (n_con,)
             )
 
+            # Sentinel: Explicitly catch NaN solutions
+            is_nan = jnp.isnan(u).any()
+
             # logging data
             data = data._replace(
                 sampled_x_traj=robot_sampled_states,
                 x_traj=robot_selected_states,
                 u_traj=action_trajectory,
                 prev_robustness=prev_robustness,
+                error=is_nan,
             )
 
             return u, data


### PR DESCRIPTION
Sentinel: Explicitly catch NaN/failure in MPPI controller

Refactored the MPPI controller to detect if the computed control input `u` contains NaNs.
If NaNs are detected, the `error` flag in the returned `PlannerData` is set to `True`.
This ensures that the simulator stops execution immediately upon controller failure, preventing the silent propagation of invalid values.

- Modified `src/cbfkit/controllers/mppi/mppi_generator.py` to add NaN check and update `PlannerData`.
- Verified with reproduction script and existing tests.

---
*PR created automatically by Jules for task [15574915559905756943](https://jules.google.com/task/15574915559905756943) started by @bardhh*