### PR TITLE
🧾 Piper: Fix incorrect kwargs typing in CBF-CLF generators

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -74,7 +74,7 @@ def cbf_clf_qp_generator(
         barriers: Optional[CertificateCollection] = EMPTY_CERTIFICATE_COLLECTION,
         lyapunovs: Optional[CertificateCollection] = EMPTY_CERTIFICATE_COLLECTION,
         p_mat: Optional[Union[Array, None]] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> ControllerCallable:
         """Produces the function to deploy a CBF-CLF-QP control law.
 

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/activated_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/activated_cbfs.py
@@ -25,7 +25,7 @@ def generate_compute_activated_cbf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     Generates compute function for Activated CBF constraints.

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/consolidated_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/consolidated_cbfs.py
@@ -107,7 +107,7 @@ def generate_compute_consolidated_cbf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_cbfs.py
@@ -31,7 +31,7 @@ def generate_compute_ra_cbf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """Placeholder.
 
@@ -98,7 +98,7 @@ def generate_compute_estimate_feedback_ra_cbf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_clfs.py
@@ -30,7 +30,7 @@ def generate_compute_ra_clf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring
@@ -94,7 +94,7 @@ def generate_compute_estimate_feedback_ra_clf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_cbfs.py
@@ -29,7 +29,7 @@ def generate_compute_ra_pi_cbf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_clfs.py
@@ -29,7 +29,7 @@ def generate_compute_ra_pi_clf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/robust_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/robust_cbfs.py
@@ -29,7 +29,7 @@ def generate_compute_robust_cbf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/robust_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/robust_clfs.py
@@ -29,7 +29,7 @@ def generate_compute_robust_clf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_cbfs.py
@@ -28,7 +28,7 @@ def generate_compute_stochastic_cbf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_clfs.py
@@ -29,7 +29,7 @@ def generate_compute_stochastic_clf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """Placeholder.
 

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/unpack.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/unpack.py
@@ -12,7 +12,7 @@ def unpack_for_cbf(
     control_limits: Array,
     barriers: CertificateCollection,
     lyapunovs: CertificateCollection,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ):
     """Unpacks information required to generate CLF constraints of arbitrary type.
 
@@ -58,7 +58,7 @@ def unpack_for_clf(
     control_limits: Array,
     lyapunovs: CertificateCollection,
     barriers: CertificateCollection,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ):
     """Unpacks information required to generate CLF constraints of arbitrary type.
 

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/vanilla_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/vanilla_clfs.py
@@ -24,7 +24,7 @@ def generate_compute_vanilla_clf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/zeroing_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/zeroing_cbfs.py
@@ -28,7 +28,7 @@ def generate_compute_zeroing_cbf_constraints(
     dyn_func: DynamicsCallable,
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-    **kwargs: Dict[str, Any],
+    **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
     """
     #! To Do: docstring


### PR DESCRIPTION
Corrected `**kwargs` type annotations in `cbf_clf_qp_generator.py` and `generate_constraints` modules from `Dict[str, Any]` to `Any`. This fixes mypy errors where `float` values (like `scale_cbf`) were being passed/used where a `Dict` was expected by the annotation. The fix prevents misuse warnings and aligns the type hints with the actual implementation. Verified with mypy and existing tests.

---
*PR created automatically by Jules for task [17599636545033884169](https://jules.google.com/task/17599636545033884169) started by @bardhh*