### PR TITLE
🔍 Scout: Add solver iteration counter to controller data

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -291,6 +291,11 @@ def cbf_clf_qp_generator(
                 p_mat, q_vec, g_mat, h_vec, init_params=solver_params
             )
 
+            # Scout: Extract solver iterations for diagnostics
+            # new_params is (KKTSolution, OSQPState)
+            _, state = new_params
+            iter_num = state.iter_num
+
             # Sentinel: Explicitly catch NaN solutions even if solver claims success
             status = jnp.where(jnp.any(jnp.isnan(sol)), 0, status)
 
@@ -322,6 +327,7 @@ def cbf_clf_qp_generator(
             # logging data
             final_sub_data = sub_data or {}
             final_sub_data["solver_params"] = new_params
+            final_sub_data["solver_iter"] = iter_num
 
             data = ControllerData(
                 error=error,

--- a/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
@@ -48,15 +48,20 @@ def solve_inequality_constrained_qp(
     Returns:
         Tuple[Array, int, Any]: The solution to the QP, a status code, and the solver parameters.
     """
+    # Handle unpacked init_params if it comes from a previous run of this function
+    real_init_params = init_params
+    if isinstance(init_params, tuple) and len(init_params) == 2:
+        real_init_params = init_params[0]
+
     sol, state = QP.run(
-        init_params=init_params,
+        init_params=real_init_params,
         params_obj=params_obj,
         params_eq=params_eq,
         params_ineq=params_ineq,
     )
     status = state.status
     # We return the raw status code to allow callers to inspect failure reason.
-    return sol.primal, status, sol
+    return sol.primal, status, (sol, state)
 
 
 @jit

--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -538,12 +538,21 @@ def execute(
         for key in c_datas._fields:
             key_str = str(key)
             val = getattr(c_datas, key_str)
-            if val is None or isinstance(val, (dict, list, tuple)):
+            if val is None:
                 continue
+            if isinstance(val, dict):
+                # Flatten dictionary fields (e.g., sub_data)
+                for sub_k, sub_v in val.items():
+                    if isinstance(sub_v, (dict, list, tuple)):
+                        continue
+                    controller_data_keys.append(f"{key_str}_{sub_k}")
+                    controller_data_values.append(sub_v)
+                continue
+            if isinstance(val, (list, tuple)):
+                continue
+
             # We assume JIT results are arrays.
             # If a field was None in input and stayed None, it's None.
-            # If it was a list/dict (like sub_data), it's likely a container of arrays or ignored.
-            # format_return_data ignores dicts/lists/tuples.
             controller_data_keys.append(key_str)
             controller_data_values.append(val)
 

--- a/tests/benchmarks/scout_solver_stats.py
+++ b/tests/benchmarks/scout_solver_stats.py
@@ -1,0 +1,152 @@
+"""
+Scout Benchmark: Solver Statistics
+==================================
+
+This benchmark runs a standard CBF-CLF-QP simulation (unicycle reaching a goal)
+and reports solver statistics (iterations, status) to identify bottlenecks.
+"""
+
+import sys
+import os
+import jax.numpy as jnp
+import numpy as np
+import time
+
+# Ensure src is in path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../src")))
+
+import cbfkit.simulation.simulator as sim
+import cbfkit.systems.unicycle.models.accel_unicycle as unicycle
+from cbfkit.certificates import concatenate_certificates, rectify_relative_degree
+from cbfkit.certificates.conditions.barrier_conditions import zeroing_barriers
+from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller as cbf_controller
+from cbfkit.estimators import naive as estimator
+from cbfkit.integration import runge_kutta_4 as integrator
+from cbfkit.sensors import perfect as sensor
+from cbfkit.utils.user_types import PlannerData
+
+# Mocking the ellipsoid_cbf to avoid dependency on examples folder
+def ellipsoid_cbf(obstacle, ellipsoid):
+    """
+    Creates a CBF for an ellipsoidal obstacle.
+    h(x) = ((x - obs)^T P (x - obs)) - 1 >= 0
+    where P = diag(1/a^2, 1/b^2)
+    """
+    center = obstacle[:2]
+    radii = ellipsoid
+    P = jnp.diag(1.0 / (radii**2))
+
+    def h(x_and_t):
+        pos = x_and_t[:2]
+        diff = pos - center
+        return jnp.dot(diff, jnp.dot(P, diff)) - 1.0
+
+    return h
+
+def run_benchmark():
+    print("🔎 Scout: Starting Solver Statistics Benchmark...")
+
+    # Simulation parameters
+    tf = 5.0
+    dt = 0.01
+    num_steps = int(tf / dt)
+
+    init_state = jnp.array([0.0, 0.0, 0.0, jnp.pi / 4])
+    desired_state = jnp.array([2.0, 4.0, 0.0, 0.0])
+    actuation_constraints = jnp.array([100.0, 100.0])
+
+    unicycle_dynamics = unicycle.plant(lam=1.0)
+
+    # Simple nominal controller
+    uniycle_nom_controller = unicycle.controllers.proportional_controller(
+        dynamics=unicycle_dynamics,
+        Kp_pos=1.0,
+        Kp_theta=1.0,
+    )
+
+    # Obstacles
+    obstacles = [
+        (1.0, 2.0, 0.0),
+        (3.0, 2.0, 0.0),
+    ]
+    ellipsoids = [
+        (0.5, 1.5),
+        (0.75, 2.0),
+    ]
+
+    barriers = [
+        rectify_relative_degree(
+            function=ellipsoid_cbf(jnp.array(obs), jnp.array(ell)),
+            system_dynamics=unicycle_dynamics,
+            state_dim=len(init_state),
+            form="exponential",
+        )(
+            certificate_conditions=zeroing_barriers.linear_class_k(5.0),
+            obstacle=jnp.array(obs),
+            ellipsoid=jnp.array(ell),
+        )
+        for obs, ell in zip(obstacles, ellipsoids)
+    ]
+
+    barrier_packages = concatenate_certificates(*barriers)
+
+    controller = cbf_controller(
+        control_limits=actuation_constraints,
+        dynamics_func=unicycle_dynamics,
+        barriers=barrier_packages,
+    )
+
+    print(f"Running simulation for {num_steps} steps...")
+    start_time = time.time()
+
+    # Run with JIT to test JIT extraction path
+    results = sim.execute(
+        x0=init_state,
+        dt=dt,
+        num_steps=num_steps,
+        dynamics=unicycle_dynamics,
+        integrator=integrator,
+        nominal_controller=uniycle_nom_controller,
+        controller=controller,
+        sensor=sensor,
+        estimator=estimator,
+        filepath=None, # No file logging
+        verbose=True,
+        planner_data=PlannerData(
+            x_traj=jnp.tile(desired_state.reshape(-1, 1), (1, num_steps + 1)),
+        ),
+        use_jit=True,
+    )
+
+    end_time = time.time()
+    print(f"Simulation complete in {end_time - start_time:.4f} seconds.")
+
+    # Extract solver stats
+    controller_data = results.controller_data
+
+    # Debug info
+    # print("Keys:", list(controller_data.keys()))
+
+    target_key = "sub_data_solver_iter"
+
+    if target_key in controller_data:
+        iters = controller_data[target_key]
+        # Convert to numpy for stats
+        iters_np = np.array(iters)
+
+        print("\n📊 Solver Statistics:")
+        print(f"  Mean Iterations: {np.mean(iters_np):.2f}")
+        print(f"  Max Iterations:  {np.max(iters_np)}")
+        print(f"  Min Iterations:  {np.min(iters_np)}")
+        print(f"  Total Solves:    {len(iters_np)}")
+
+        # Check for high iterations
+        high_iters = np.sum(iters_np > 100)
+        print(f"  Steps > 100 iters: {high_iters} ({high_iters/len(iters_np)*100:.1f}%)")
+
+    else:
+        print(f"\n❌ Error: '{target_key}' not found in controller data.")
+        print("Available keys:", list(controller_data.keys()))
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
@@ -24,12 +24,17 @@ class TestQPSolverSafety(unittest.TestCase):
         # It imports solve_qp from cbf_clf_qp_generator module.
 
         # 2. Define the mock solver
+        from collections import namedtuple
+        MockState = namedtuple("MockState", ["iter_num"])
+
         def mock_solve(p_mat, q_vec, g_mat, h_vec, init_params=None):
             # Return dummy solution (zeros), status 2 (MAX_ITER), and None params
             # Solution size must match q_vec (which is n_controls + slacks)
             n_vars = q_vec.shape[0]
             # status=2 means MAX_ITER_REACHED
-            return jnp.zeros((n_vars,)), jnp.array(2, dtype=jnp.int32), None
+            # Scout: Controller expects (sol, state) in params to extract iter_num
+            mock_state = MockState(iter_num=jnp.array(100))
+            return jnp.zeros((n_vars,)), jnp.array(2, dtype=jnp.int32), (None, mock_state)
 
         # 3. Patch solve_qp in the module where it is used
         with patch('cbfkit.controllers.cbf_clf.cbf_clf_qp_generator.solve_qp', side_effect=mock_solve):


### PR DESCRIPTION
Scout: Add solver iteration counter to controller data

Changes:
- Modified `src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py` to return the full `(sol, state)` tuple from `solve_inequality_constrained_qp`, exposing solver diagnostics while supporting tuple unpacking for warm-starts.
- Updated `src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py` to extract `iter_num` from the solver state and log it in `sub_data["solver_iter"]`.
- Enhanced `src/cbfkit/simulation/simulator.py` to automatically flatten and log dictionary fields from `sub_data` (like `solver_iter`) into the simulation results.
- Added `tests/benchmarks/scout_solver_stats.py` as a diagnostic tool to run a standard simulation and report solver statistics.
- Updated regression tests in `tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py` to match the new solver signature.

---
*PR created automatically by Jules for task [2935199350701244206](https://jules.google.com/task/2935199350701244206) started by @bardhh*