### PR TITLE
🛡️ Aegis: Fix NaN gradients in CBF-QP controller during autodiff

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -266,7 +266,9 @@ def cbf_clf_qp_generator(
             # Janus: Avoid normalizing noise vectors. If norm < tol, do NOT scale up.
             # Input constraints (box limits) are already normalized (row norm = 1).
             if auto_p_mat:
-                row_norms_c = jnp.linalg.norm(g_mat_c, axis=1)
+                # Aegis: Use safe norm (sqrt(sum(sq) + eps)) to prevent NaN gradients at 0.
+                row_sq_sums = jnp.sum(g_mat_c**2, axis=1)
+                row_norms_c = jnp.sqrt(row_sq_sums + 1e-20)
                 # Janus: Smooth transition for noise scaling
                 high, low = 1e-8, 1e-9
                 slope = (high - 1.0) / (high - low)

--- a/tests/test_controllers/test_cbf_clf_controllers/test_autodiff_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_autodiff_safety.py
@@ -1,0 +1,86 @@
+
+import unittest
+import jax
+import jax.numpy as jnp
+from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+from cbfkit.certificates import certificate_package, concatenate_certificates
+from cbfkit.certificates.conditions.barrier_conditions.zeroing_barriers import linear_class_k
+from cbfkit.utils.user_types import ControllerData, EMPTY_CERTIFICATE_COLLECTION
+
+class TestAutodiffSafety(unittest.TestCase):
+    def test_gradient_at_zero_actuation(self):
+        """
+        Test that differentiating the controller through a state where
+        actuation vanishes (Lg Lf^k h = 0) does not produce NaNs.
+
+        System: x_dot = x * u
+        Barrier: h(x) = x  (keep x >= 0)
+
+        Constraint: dot_h + alpha*h >= 0
+                   x*u + x >= 0
+                   -x*u <= x
+
+        At x=0, the constraint becomes 0*u <= 0.
+        The row in A matrix is [0].
+        Normalization of this row involves norm(0).
+        """
+
+        # 1. Define Dynamics: x_dot = x * u
+        def dynamics(x):
+            # f(x) = 0
+            f = jnp.zeros((1,))
+            # g(x) = x (reshaped to 1x1)
+            g = x.reshape(1, 1)
+            return f, g
+
+        # 2. Define Barrier: h(x) = x
+        def cbf_factory(**kwargs):
+            def func(xt):
+                return xt[0]
+            return func
+
+        # Use certificate_package with auto-diff
+        package = certificate_package(cbf_factory, n=1)
+        # alpha(h) = h
+        barriers = concatenate_certificates(
+            package(certificate_conditions=linear_class_k(1.0))
+        )
+
+        # 3. Setup Controller
+        control_limits = jnp.array([10.0]) # u in [-10, 10]
+
+        controller = vanilla_cbf_clf_qp_controller(
+            control_limits=control_limits,
+            dynamics_func=dynamics,
+            barriers=barriers,
+            lyapunovs=EMPTY_CERTIFICATE_COLLECTION,
+            relaxable_cbf=False
+        )
+
+        # 4. Define Loss Function on Controller Output
+        def loss_fn(x_state):
+            t = 0.0
+            u_nom = jnp.array([1.0])
+            key = jnp.array([0, 0], dtype=jnp.uint32)
+            data = ControllerData()
+
+            # Run controller
+            u, _ = controller(t, x_state, u_nom, key, data)
+
+            # Loss is just sum of control input
+            return jnp.sum(u)
+
+        # 5. Compute Gradient at x=0
+        # At x=0, g(x)=0, so g_mat_c is 0.
+        x_target = jnp.array([0.0])
+
+        grad_fn = jax.grad(loss_fn)
+        grad = grad_fn(x_target)
+
+        print(f"Computed Gradient: {grad}")
+
+        # 6. Assert Validity
+        self.assertFalse(jnp.any(jnp.isnan(grad)), "Gradient contains NaNs!")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The use of `jnp.linalg.norm` on constraint rows caused NaN gradients during automatic differentiation when a constraint row was zero (e.g., `Lg h = 0`). This breaks the differentiability of the controller, which is critical for learning or sensitivity analysis.

This change introduces a "safe norm" calculation using a tiny epsilon (`1e-20`) to ensure the gradient at zero is defined (and zero), preserving the behavior of the normalization logic while fixing the autodiff issue.

**Changes:**
- Modified `src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py` to use safe norm.
- Added `tests/test_controllers/test_cbf_clf_controllers/test_autodiff_safety.py` to verify the fix.

---
*PR created automatically by Jules for task [5673891236819767313](https://jules.google.com/task/5673891236819767313) started by @bardhh*