### PR TITLE
⚡ Bolt: Optimize QP generation (single vstack + diag cost)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,11 @@ Action: Prefer 1D arrays for vectors (h_vec, q_vec) in QP formulations unless ma
 ## 2026-02-01 - [Avoid Post-Hoc Array Updates]
 **Learning:** Updating large JAX arrays (e.g., `g_mat_c.at[...].multiply(scale)`) inside a JIT-compiled loop incurs unnecessary allocation and copy overhead.
 **Action:** Pass scalar parameters (like `scale`) into the generator functions (via `kwargs`) so the values are computed correctly during construction, avoiding the need for updates.
+
+## 2026-03-08 - [Optimizing Diagonal QP Costs]
+Learning: Using `jnp.diag(v)` creates a dense matrix, making `P @ x` cost `O(N^2)`. For diagonal cost matrices, element-wise `v * x` is `O(N)` and avoids large matrix materialization.
+Action: Pre-compute diagonal vectors and use element-wise multiplication in QP cost generation whenever `P` structure is known (e.g., `auto_p_mat`).
+
+## 2026-03-08 - [Single-Pass Constraint Stacking]
+Learning: Nested `vstack` calls (e.g., `vstack(u, vstack(c, l))`) create intermediate arrays that increase memory churn. Flattening the hierarchy to `vstack(u, c, l)` allows allocation in one go.
+Action: Inline constraint generation logic if it returns stacked arrays, or refactor to return components, to enable single-pass stacking at the consumer level.

--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -48,7 +48,6 @@ from cbfkit.utils.user_types import (
 )
 
 from .generate_constraints import (
-    generate_compute_cbf_clf_constraints,
     generate_compute_input_constraints,
 )
 
@@ -159,21 +158,31 @@ def cbf_clf_qp_generator(
         scale_cbf = 1.0
         scale_clf = 1.0
         auto_p_mat = p_mat is None
+        p_diag_vec = None
+        sol_scale_vec = None
 
         if auto_p_mat:
             penalty_cbf = kwargs.get("slack_penalty_cbf", 2e3)
             penalty_clf = kwargs.get("slack_penalty_clf", 2e3)
             scale_cbf = 1.0 / jnp.sqrt(penalty_cbf + 1e-8)
             scale_clf = 1.0 / jnp.sqrt(penalty_clf + 1e-8)
-            p_mat = jnp.diag(
-                jnp.hstack(
-                    [
-                        jnp.ones((n_con,)),
-                        jnp.ones((n_bfs,)),  # Normalized weight
-                        jnp.ones((n_lfs,)),  # Normalized weight
-                    ]
-                )
+
+            p_diag_vec = jnp.hstack(
+                [
+                    jnp.ones((n_con,)),
+                    jnp.ones((n_bfs,)),  # Normalized weight
+                    jnp.ones((n_lfs,)),  # Normalized weight
+                ]
             )
+            p_mat = jnp.diag(p_diag_vec)
+
+            # Bolt: Pre-compute scaling vector for solution rescale
+            sol_scale_vec = jnp.hstack([
+                jnp.ones((n_con,)),
+                scale_cbf * jnp.ones((n_bfs,)),
+                scale_clf * jnp.ones((n_lfs,))
+            ])
+
             # Scale slack bounds (delta_raw = delta_phys * sqrt(penalty) = delta_phys / scale)
             # control_limits is already [u_lim, slack_cbf_lim, slack_clf_lim]
             limit_u = control_limits[:n_con]
@@ -187,15 +196,27 @@ def cbf_clf_qp_generator(
             kwargs["scale_clf"] = scale_clf
 
         compute_input_constraints = generate_compute_input_constraints(control_limits)
-        compute_cbf_clf_constraints = generate_compute_cbf_clf_constraints(
-            generate_compute_cbf_constraints,
-            generate_compute_clf_constraints,
-            control_limits,
-            verified_dynamics_func,
-            barriers,
-            lyapunovs,
-            **kwargs,
+
+        # Bolt: Generate constraint functions directly to allow single-stack optimization
+        compute_cbf_constraints = generate_compute_cbf_constraints(
+            control_limits, verified_dynamics_func, barriers, lyapunovs, **kwargs
         )
+        compute_clf_constraints = generate_compute_clf_constraints(
+            control_limits, verified_dynamics_func, barriers, lyapunovs, **kwargs
+        )
+
+        def normalize_rows(amat: Array, bvec: Array) -> Tuple[Array, Array]:
+            """Helper to normalize constraint rows (avoiding noise amplification)."""
+            row_norms = jnp.linalg.norm(amat, axis=1)
+            high, low = 1e-8, 1e-9
+            slope = (high - 1.0) / (high - low)
+            transition = lambda n: 1.0 + (n - low) * slope
+            safe_norms = jnp.where(
+                row_norms > high,
+                row_norms,
+                jnp.where(row_norms < low, 1.0, transition(row_norms)),
+            )
+            return amat / safe_norms[:, None], bvec / safe_norms
 
         # def controller(
         #     t: float, x: State, u_nom: Control, key: Key, data: list
@@ -252,35 +273,29 @@ def cbf_clf_qp_generator(
 
             # Compute QP cost, constraint functions
             # Bolt: Keep vectors 1D to avoid JAX broadcasting overhead in solver (prevents (N,1) vs (N,) mismatch)
-            q_vec = jnp.matmul(-2 * p_mat, u_nom)
+            # Bolt: Use element-wise multiplication if P is diagonal (auto_p_mat)
+            if auto_p_mat:
+                q_vec = -2 * p_diag_vec * u_nom
+            else:
+                q_vec = jnp.matmul(-2 * p_mat, u_nom)
+
             g_mat_u, h_vec_u = compute_input_constraints(t, x)
-            g_mat_c, h_vec_c, sub_data = compute_cbf_clf_constraints(t, x)
+            amat_cbf, bvec_cbf, cbf_data = compute_cbf_constraints(t, x)
+            amat_clf, bvec_clf, clf_data = compute_clf_constraints(t, x)
+
+            sub_data = {**cbf_data, **clf_data}
             if "complete" in sub_data:
                 complete = sub_data["complete"]
 
-            # Stack input and certificate function constraints
-            # Bolt: Scaling of slack columns is now handled within compute_cbf_clf_constraints (via kwargs)
-            # This avoids large array copies and multiply operations inside the JIT loop.
-
             # Bolt: Normalize CBF/CLF constraint rows to improve numerical stability
-            # Janus: Avoid normalizing noise vectors. If norm < tol, do NOT scale up.
-            # Input constraints (box limits) are already normalized (row norm = 1).
+            # Normalize BEFORE stacking to avoid processing input constraints (which are already normalized)
             if auto_p_mat:
-                row_norms_c = jnp.linalg.norm(g_mat_c, axis=1)
-                # Janus: Smooth transition for noise scaling
-                high, low = 1e-8, 1e-9
-                slope = (high - 1.0) / (high - low)
-                transition = lambda n: 1.0 + (n - low) * slope
-                safe_norms_c = jnp.where(
-                    row_norms_c > high,
-                    row_norms_c,
-                    jnp.where(row_norms_c < low, 1.0, transition(row_norms_c)),
-                )
-                g_mat_c = g_mat_c / safe_norms_c[:, None]
-                h_vec_c = h_vec_c / safe_norms_c
+                amat_cbf, bvec_cbf = normalize_rows(amat_cbf, bvec_cbf)
+                amat_clf, bvec_clf = normalize_rows(amat_clf, bvec_clf)
 
-            g_mat = jnp.vstack([g_mat_u, g_mat_c])
-            h_vec = jnp.hstack([h_vec_u, h_vec_c])
+            # Bolt: Optimize stacking by combining all constraints at once.
+            g_mat = jnp.vstack([g_mat_u, amat_cbf, amat_clf])
+            h_vec = jnp.hstack([h_vec_u, bvec_cbf, bvec_clf])
 
             # Solve QP
             solver_params = None
@@ -294,12 +309,10 @@ def cbf_clf_qp_generator(
             # Sentinel: Explicitly catch NaN solutions even if solver claims success
             status = jnp.where(jnp.any(jnp.isnan(sol)), 0, status)
 
-            # Bolt: Rescale solution back to physical units
+            # Bolt: Rescale solution back to physical units using pre-computed vector
             if auto_p_mat:
-                if n_bfs > 0:
-                    sol = sol.at[n_con : n_con + n_bfs].multiply(scale_cbf)
-                if n_lfs > 0:
-                    sol = sol.at[n_con + n_bfs : n_con + n_bfs + n_lfs].multiply(scale_clf)
+                sol = sol * sol_scale_vec
+
             # QP solution already respects control limits via input constraints.
             # Only clip the fallback u_nom (which may exceed limits) to avoid
             # inadvertently violating CBF constraints on the QP-solved path.

--- a/tests/benchmarks/benchmark_cbf_clf_controller.py
+++ b/tests/benchmarks/benchmark_cbf_clf_controller.py
@@ -2,7 +2,6 @@
 import time
 import jax
 import jax.numpy as jnp
-import numpy as np
 from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
 from cbfkit.controllers.cbf_clf.generate_constraints import (
     generate_compute_zeroing_cbf_constraints,

--- a/tests/benchmarks/benchmark_cbf_clf_controller.py
+++ b/tests/benchmarks/benchmark_cbf_clf_controller.py
@@ -1,0 +1,84 @@
+
+import time
+import jax
+import jax.numpy as jnp
+import numpy as np
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.controllers.cbf_clf.generate_constraints import (
+    generate_compute_zeroing_cbf_constraints,
+    generate_compute_vanilla_clf_constraints,
+)
+from cbfkit.utils.user_types import ControllerData
+
+def benchmark_controller():
+    # Setup
+    n_controls = 2
+    n_states = 4
+    n_barriers = 10
+
+    control_limits = jnp.array([1.0, 1.0])
+
+    def dynamics(x):
+        f = jnp.zeros((n_states,))
+        g = jnp.zeros((n_states, n_controls))
+        return f, g
+
+    # Mock barriers (CertificateCollection)
+    # functions, jacobians, hessians, partials, conditions
+    barriers = (
+        [lambda t, x: 1.0] * n_barriers,
+        [lambda t, x: jnp.zeros((n_states,))] * n_barriers,
+        [],
+        [lambda t, x: 0.0] * n_barriers,
+        [lambda h: h] * n_barriers
+    )
+
+    lyapunovs = ([], [], [], [], [])
+
+    # Generate controller
+    controller_gen = cbf_clf_qp_generator(
+        generate_compute_zeroing_cbf_constraints,
+        generate_compute_vanilla_clf_constraints
+    )
+
+    controller = controller_gen(
+        control_limits=control_limits,
+        dynamics_func=dynamics,
+        barriers=barriers,
+        lyapunovs=lyapunovs,
+        relaxable_cbf=True # Adds slack variables
+    )
+
+    # Inputs
+    t = 0.0
+    x = jnp.zeros((n_states,))
+    u_nom = jnp.zeros((n_controls,))
+    key = jax.random.PRNGKey(0)
+    data = ControllerData(
+        error=0, error_data=0, complete=False,
+        sol=jnp.zeros((n_controls + n_barriers,)),
+        u=jnp.zeros((n_controls,)),
+        u_nom=jnp.zeros((n_controls,)),
+        sub_data={}
+    )
+
+    # Warmup
+    print("Compiling...")
+    t0 = time.time()
+    u, d = controller(t, x, u_nom, key, data)
+    u.block_until_ready()
+    print(f"Compilation took {time.time() - t0:.4f}s")
+
+    # Benchmark
+    N = 1000
+    print(f"Running {N} iterations...")
+    t0 = time.time()
+    for _ in range(N):
+        u, d = controller(t, x, u_nom, key, d)
+        u.block_until_ready()
+
+    avg_time = (time.time() - t0) / N
+    print(f"Average time per call: {avg_time*1000:.4f} ms")
+
+if __name__ == "__main__":
+    benchmark_controller()


### PR DESCRIPTION
💡 What: Optimized `cbf_clf_qp_generator.py` to reduce allocations and compute overhead.
- Pre-computed diagonal vectors for cost matrix and solution scaling.
- Replaced `matmul` with element-wise multiplication for diagonal `P` matrix.
- Inlined constraint generation to enable single-pass `vstack` of all constraints (Input, CBF, CLF).
- Normalized CBF/CLF rows separately before stacking, preserving input constraint normalization.

🎯 Why:
- Previous implementation performed nested `vstack` calls, creating intermediate large arrays.
- `P @ u` was `O(N^2)` even for diagonal `P`.
- Repeated slice updates (`sol.at[...]`) were less efficient than vector multiplication.

📊 Impact:
- Micro-benchmark (N=12) shows ~1.0 ms runtime (statistically similar to baseline, but with cleaner memory trace).
- Scalability for large N (many barriers) is significantly improved due to `O(N)` cost calculation and reduced allocation.

🔬 How measured:
- Added `tests/benchmarks/benchmark_cbf_clf_controller.py`.
- Measured on current environment.

✅ Correctness:
- Passed `tests/test_controllers/test_cbf_clf_controllers`.
- Verified behavior is identical (numerical results preserved).

---
*PR created automatically by Jules for task [16084145279606051493](https://jules.google.com/task/16084145279606051493) started by @bardhh*