### PR TITLE
Fix sign error in stochastic barrier condition causing unstable growth

### DIFF
--- a/src/cbfkit/certificates/conditions/barrier_conditions/stochastic_barrier.py
+++ b/src/cbfkit/certificates/conditions/barrier_conditions/stochastic_barrier.py
@@ -3,7 +3,7 @@ stochastic_barrier.py
 ================
 
 This module contains the function specifying the right-hand side of stochastic CBF inequalities,
-e.g., -alpha*h + beta for hdot <= -alpha*h + beta.
+e.g., -alpha*h + beta for hdot >= -alpha*h + beta.
 
 Functions
 ---------
@@ -54,7 +54,7 @@ from jax import Array
 def right_hand_side(alpha: float, beta: float) -> Callable[[Array], Array]:
     """Generates function for computing RHS of barrier conditions for stochastic CBF:
 
-    hdot <= -alpha*h + beta
+    hdot >= -alpha*h + beta
 
     Args:
         None
@@ -65,4 +65,4 @@ def right_hand_side(alpha: float, beta: float) -> Callable[[Array], Array]:
     """
     assert alpha >= 0
     assert beta >= 0
-    return lambda h: -alpha * h + beta
+    return lambda h: alpha * h - beta

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_cbfs.py
@@ -22,7 +22,7 @@ from .unpack import unpack_for_cbf
 
 
 ###################################################################################################
-### STOCHASTIC CBF: LfB + LgB*u + 0.5*Tr[sigma.T * d2B/dx2 * sigma] <= -alpha*B + beta ############
+### STOCHASTIC CBF: LfB + LgB*u + 0.5*Tr[sigma.T * d2B/dx2 * sigma] >= -alpha*B + beta ############
 def generate_compute_stochastic_cbf_constraints(
     control_limits: Array,
     dyn_func: DynamicsCallable,


### PR DESCRIPTION
The `stochastic_barrier` module was returning a condition that, when combined with `stochastic_cbfs` constraint generation logic, resulted in enforcing `hdot >= alpha * h - beta`. For a safety barrier ($h \ge 0$), this forced the value of $h$ to grow exponentially when $h > \beta/\alpha$, rather than allowing it to decay boundedly ($\dot{h} \ge -\alpha h + \beta$).

This change inverts the sign of the returned condition to ensure the correct inequality is enforced by the QP solver. Verified with a reproduction script that checks the constraint direction at a safe state.

---
*PR created automatically by Jules for task [1861613795982856113](https://jules.google.com/task/1861613795982856113) started by @bardhh*