### PR TITLE
📦 Archivist: Enable deterministic Monte Carlo simulations via explicit seeding

### DIFF
--- a/src/cbfkit/simulation/monte_carlo.py
+++ b/src/cbfkit/simulation/monte_carlo.py
@@ -8,30 +8,66 @@ conduct_monte_carlo(execute, n_trials, n_processes, **kwargs)
     Conducts a Monte Carlo simulation."""
 
 import multiprocessing as mp
-from typing import Callable
+from typing import Callable, Optional
+import numpy as np
+from jax import random
 
 
 def _map_function(args):
-    """_summary_.
+    """Helper function to execute a single trial.
 
     Args:
-        args (_type_): _description_
+        args (tuple): Tuple containing (func, trial_no, worker_seed, kwargs).
 
     Returns
     -------
-        _type_: _description_
+        Any: Result of the trial execution.
     """
-    func, trial_no, kwargs = args
+    func, trial_no, worker_seed, kwargs = args
+
+    # Inject JAX key if a seed was provided
+    if worker_seed is not None:
+        kwargs = kwargs.copy()
+        kwargs["key"] = random.PRNGKey(worker_seed)
+
     return func(trial_no, **kwargs)
 
 
-def conduct_monte_carlo(execute: Callable, n_trials: int, n_processes: int = 1, **kwargs):
-    """_summary_.
+def conduct_monte_carlo(
+    execute: Callable, n_trials: int, n_processes: int = 1, seed: Optional[int] = None, **kwargs
+):
+    """Conducts a Monte Carlo simulation.
 
     Args:
-        execute (_type_): _description_
+        execute (Callable): The function to execute for each trial.
+                            Must accept `trial_no` (int) as the first argument and `**kwargs`.
+        n_trials (int): Number of trials to run.
+        n_processes (int, optional): Number of parallel processes. Defaults to 1.
+        seed (Optional[int], optional): Base seed for random number generation.
+                                        If provided, each trial receives a unique JAX PRNGKey
+                                        passed as 'key' in kwargs.
+                                        Requires `execute` to accept `**kwargs` or `key`.
+        **kwargs: Additional keyword arguments passed to `execute`.
+
+    Returns
+    -------
+        list: A list of results from each trial.
     """
-    args_list = [(execute, trial_no, kwargs) for trial_no in range(n_trials)]
+    args_list = []
+
+    # Generate integer seeds for each trial if a base seed is provided
+    worker_seeds = [None] * n_trials
+    if seed is not None:
+        rng = np.random.default_rng(seed)
+        # Generate random integers safely within range for PRNGKey
+        worker_seeds = rng.integers(low=0, high=2**32 - 1, size=n_trials)
+
+    for trial_no in range(n_trials):
+        # We pass the worker_seed (int or None)
+        worker_seed = worker_seeds[trial_no] if seed is not None else None
+
+        # Note: We do NOT convert to JAX key here to avoid pickling issues with multiprocessing
+        args_list.append((execute, trial_no, worker_seed, kwargs))
 
     if n_processes > 1:
         # Create a multiprocessing Pool

--- a/tests/test_simulation/test_monte_carlo_unit.py
+++ b/tests/test_simulation/test_monte_carlo_unit.py
@@ -1,0 +1,40 @@
+import unittest
+from cbfkit.simulation import monte_carlo
+import jax.numpy as jnp
+
+def simple_func(trial_no, **kwargs):
+    return trial_no, kwargs.get('key')
+
+def simple_func_no_kwargs(trial_no):
+    return trial_no
+
+class TestMonteCarloUnit(unittest.TestCase):
+    def test_legacy_behavior(self):
+        # Should work without seed and without kwargs support in func if no kwargs passed
+        results = monte_carlo.conduct_monte_carlo(simple_func_no_kwargs, n_trials=2)
+        self.assertEqual(results, [0, 1])
+
+    def test_seeded_behavior(self):
+        # Should inject key if seed provided
+        results = monte_carlo.conduct_monte_carlo(simple_func, n_trials=2, seed=10)
+        # results is list of (trial_no, key)
+        self.assertEqual(results[0][0], 0)
+        self.assertEqual(results[1][0], 1)
+
+        # Keys should be present
+        self.assertIsNotNone(results[0][1])
+        self.assertIsNotNone(results[1][1])
+
+        # Keys should be different
+        # (JAX keys are arrays, verify inequality)
+        self.assertFalse(jnp.array_equal(results[0][1], results[1][1]))
+
+    def test_seeded_behavior_repeatability(self):
+         results1 = monte_carlo.conduct_monte_carlo(simple_func, n_trials=1, seed=10)
+         results2 = monte_carlo.conduct_monte_carlo(simple_func, n_trials=1, seed=10)
+
+         # Same seed -> Same key
+         self.assertTrue(jnp.array_equal(results1[0][1], results2[0][1]))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR updates the Monte Carlo simulation utility to support fully deterministic execution.

**Changes:**
- `src/cbfkit/simulation/monte_carlo.py`:
  - Added `seed` argument to `conduct_monte_carlo`.
  - Implemented logic to generate `n_trials` integer seeds using `numpy.random.Generator` (avoiding JAX array pickling issues).
  - Updated `_map_function` to accept a worker seed and generate a local JAX `PRNGKey`, injecting it into `kwargs` as `key`.
- `tests/test_simulation/test_monte_carlo_unit.py`:
  - Added new test suite to verify:
    - Legacy behavior (no seed) remains unchanged.
    - Seeded behavior correctly injects keys.
    - Different trials get different keys.
    - Repeated runs with same seed produce identical keys.

**Impact:**
Users can now run reproducible Monte Carlo experiments by passing a `seed` integer. This fixes the issue where implicit randomness (or default `PRNGKey(0)`) led to either non-reproducible or identical trials.

---
*PR created automatically by Jules for task [48159486263901289](https://jules.google.com/task/48159486263901289) started by @bardhh*