### PR TITLE
📝 Scribe: Fix tutorial filenames in README and repair broken notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker compose -f .devcontainer/docker-compose.yml --profile gpu run --rm cbfkit
 macOS builds always target the CPU image because GPU passthrough is not supported.
 
 ## Start with Tutorials
-Explore the `tutorials` directory to help you get started with CBFKit. Open the Python notebook in the `tutorials` directory to get started. The script `simulate_new_control_system.ipynb` automatically generates the controller, plant, and certificate function for a Van der Pol oscillator. It also generates ROS2 nodes for the plant, controller, sensor, and estimator. These serve as a starting point for developing your own CBF-based controller.
+Explore the `tutorials` directory to help you get started with CBFKit. Open the Python notebook in the `tutorials` directory to get started. The script `code_generation_tutorial.ipynb` automatically generates the controller, plant, and certificate function for a Van der Pol oscillator. It also generates ROS2 nodes for the plant, controller, sensor, and estimator. These serve as a starting point for developing your own CBF-based controller.
 
 Generated files/folders:
 ```
@@ -106,8 +106,8 @@ van_der_pol_oscillator
 ```
 
 We recommend going through the tutorials in the following order to get familiar with the architecture of our library.
-- `simulate_new_control_system.ipynb`
-- `multi_robot_example.ipynb`
+- `code_generation_tutorial.ipynb`
+- `multi_robot_coordination.ipynb`
 - `simulate_mppi_cbf.py`
 - `simulate_mppi_cbf_ellipsoidal_stochastic_cbf.py`
 - `simulate_mppi_stl.py`

--- a/tutorials/code_generation_tutorial.ipynb
+++ b/tutorials/code_generation_tutorial.ipynb
@@ -457,16 +457,16 @@
     "\n",
     "# To add stochastic perturbation to system dynamics\n",
     "from cbfkit.modeling.additive_disturbances import generate_stochastic_perturbation\n",
-    "def sigma(x):
-    """
-    Computes the state-dependent diffusion term for the stochastic differential equation (SDE).
-
-    Args:
-        x (Array): The current state vector.
-
-    Returns:
-        Array: The diffusion matrix.
-    """\n",
+    "def sigma(x):\n",
+    "    \"\"\"\n",
+    "    Computes the state-dependent diffusion term for the stochastic differential equation (SDE).\n",
+    "\n",
+    "    Args:\n",
+    "        x (Array): The current state vector.\n",
+    "\n",
+    "    Returns:\n",
+    "        Array: The diffusion matrix.\n",
+    "    \"\"\"\n",
     "    return jnp.array([[0, 0], [0, 0.05 * x[0]]])  # State-dependent diffusion term in SDE"
    ]
   },
@@ -516,9 +516,9 @@
    "source": [
     "# Dynamics function with epsilon parameter: returns f(x), g(x), d(x)\n",
     "eps = 0.5\n",
-    "dynamics = van_der_pol_oscillator.plant(
-    epsilon=eps, perturbation=generate_stochastic_perturbation(sigma, DT)
-)\n",
+    "dynamics = van_der_pol_oscillator.plant(\n",
+    "    epsilon=eps, perturbation=generate_stochastic_perturbation(sigma, DT)\n",
+    ")\n",
     "\n",
     "#! To do: separate box explaining\n",
     "# Create barrier functions with linear class K function derivative conditions\n",


### PR DESCRIPTION
This PR addresses documentation inaccuracies in `README.md` by updating references to tutorial notebooks that were either renamed or incorrectly documented. Specifically, it points users to `code_generation_tutorial.ipynb` and `multi_robot_coordination.ipynb`.

Additionally, it repairs `tutorials/code_generation_tutorial.ipynb`, which contained malformed JSON strings (raw newlines in code cells) that rendered the notebook unusable. The fix ensures the notebook is valid JSON and the code within it executes successfully.


---
*PR created automatically by Jules for task [298567801666078120](https://jules.google.com/task/298567801666078120) started by @bardhh*