### PR TITLE
🔮 Oracle: Fix sign mismatch in stochastic barrier docstring

### DIFF
--- a/src/cbfkit/certificates/conditions/barrier_conditions/stochastic_barrier.py
+++ b/src/cbfkit/certificates/conditions/barrier_conditions/stochastic_barrier.py
@@ -7,7 +7,7 @@ e.g., -alpha*h + beta for hdot >= -alpha*h + beta.
 
 Functions
 ---------
--right_hand_side(alpha, beta):  -alpha*h + beta
+-right_hand_side(alpha, beta):  alpha*h - beta
 
 Notes
 -----
@@ -55,6 +55,9 @@ def right_hand_side(alpha: float, beta: float) -> Callable[[Array], Array]:
     """Generates function for computing RHS of barrier conditions for stochastic CBF:
 
     hdot >= -alpha*h + beta
+
+    Returns the term `alpha*h - beta` to be added to the inequality:
+    hdot + (alpha*h - beta) >= 0
 
     Args:
         None

--- a/tests/test_stochastic_barrier_semantics.py
+++ b/tests/test_stochastic_barrier_semantics.py
@@ -1,0 +1,31 @@
+
+import pytest
+import jax.numpy as jnp
+from cbfkit.certificates.conditions.barrier_conditions.stochastic_barrier import right_hand_side
+
+def test_stochastic_barrier_rhs_semantics():
+    """
+    Verifies that right_hand_side(alpha, beta) returns a function that computes `alpha * h - beta`.
+
+    The function returns the term that needs to be ADDED to the LHS of the inequality:
+    hdot + (alpha * h - beta) >= 0
+    which is equivalent to:
+    hdot >= -alpha * h + beta.
+
+    This test ensures the implementation remains consistent with this semantic interpretation.
+    """
+    alpha = 2.0
+    beta = 0.5
+    h_val = 10.0
+
+    # Instantiate the function
+    func = right_hand_side(alpha, beta)
+
+    # Evaluate
+    result = func(h_val)
+
+    # The implementation returns alpha * h - beta
+    expected = alpha * h_val - beta
+
+    assert jnp.isclose(result, expected), \
+        f"Expected {expected} (alpha*h - beta), but got {result}"


### PR DESCRIPTION
Fixed a semantic mismatch in `src/cbfkit/certificates/conditions/barrier_conditions/stochastic_barrier.py` where the docstring claimed the function returned `-alpha*h + beta` (the RHS of the inequality), while the code actually returns `alpha*h - beta` (the term added to the LHS).

Added `tests/test_stochastic_barrier_semantics.py` to permanently verify this behavior.

---
*PR created automatically by Jules for task [3936930065041428029](https://jules.google.com/task/3936930065041428029) started by @bardhh*