### PR TITLE
🛡️ Aegis: Fix discontinuous constraint normalization in CBF-CLF-QP

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -270,14 +270,9 @@ def cbf_clf_qp_generator(
                 row_sq_sums = jnp.sum(g_mat_c**2, axis=1)
                 row_norms_c = jnp.sqrt(row_sq_sums + 1e-20)
                 # Janus: Smooth transition for noise scaling
-                high, low = 1e-8, 1e-9
-                slope = (high - 1.0) / (high - low)
-                transition = lambda n: 1.0 + (n - low) * slope
-                safe_norms_c = jnp.where(
-                    row_norms_c > high,
-                    row_norms_c,
-                    jnp.where(row_norms_c < low, 1.0, transition(row_norms_c)),
-                )
+                # Aegis: Robust normalization using simple clamping to avoid discontinuities.
+                # Saturates normalization for norms < 1e-8.
+                safe_norms_c = jnp.maximum(row_norms_c, 1e-8)
                 g_mat_c = g_mat_c / safe_norms_c[:, None]
                 h_vec_c = h_vec_c / safe_norms_c
 

--- a/tests/test_controllers/test_normalization_continuity.py
+++ b/tests/test_controllers/test_normalization_continuity.py
@@ -1,0 +1,73 @@
+
+import jax
+import jax.numpy as jnp
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.utils.user_types import ControllerData
+
+# Mock generators
+def mock_cbf_gen(control_limits, dyn_func, barriers, lyapunovs, **kwargs):
+    def compute(t, x):
+        # x[0]: gradient magnitude 'g'
+        # x[1]: constraint RHS ratio 'ratio' (h = ratio * g)
+        g_val = x[0]
+        ratio = x[1]
+        h_val = ratio * g_val
+
+        # Constraint: g * u <= h  => u <= ratio
+
+        # We assume 1 control input, 1 CBF
+        amat = jnp.array([[g_val]]) # (1, 1)
+        bvec = jnp.array([h_val])   # (1,)
+
+        return amat, bvec, {}
+    return compute
+
+def mock_clf_gen(control_limits, dyn_func, barriers, lyapunovs, **kwargs):
+    def compute(t, x):
+        return jnp.zeros((0, 1)), jnp.zeros((0,)), {}
+    return compute
+
+def test_normalization_continuity():
+    """
+    Verifies that the controller output is continuous across the normalization threshold.
+    Specifically checks that small gradients (1e-9) and slightly larger gradients (1e-8)
+    result in consistent control inputs, indicating no massive normalization jump.
+    """
+    # Setup
+    controller_gen = cbf_clf_qp_generator(mock_cbf_gen, mock_clf_gen)
+
+    control_limits = jnp.array([10.0])
+    dynamics_func = lambda x: (jnp.zeros((1,)), jnp.eye(1))
+    dummy_barriers = ([lambda t,x: 0.0], [lambda t,x: jnp.zeros(1)], [], [], [])
+
+    # Create controller
+    controller = controller_gen(
+        control_limits=control_limits,
+        dynamics_func=dynamics_func,
+        barriers=dummy_barriers,
+        relaxable_cbf=False
+    )
+
+    u_nom = jnp.array([1.0])
+    t = 0.0
+    key = jax.random.PRNGKey(0)
+
+    data = ControllerData(
+        error=0, error_data=0, complete=False,
+        sol=jnp.zeros(1), u=jnp.zeros(1), u_nom=jnp.zeros(1), sub_data={}
+    )
+
+    # Case 1: g = 1e-9 (Below old threshold)
+    # Ratio = 0.1, so constraint implies u <= 0.1
+    x_noise = jnp.array([1e-9, 0.1])
+    u_noise, _ = controller(t, x_noise, u_nom, key, data)
+
+    # Case 2: g = 1.01e-8 (Above old threshold)
+    x_signal = jnp.array([1.01e-8, 0.1])
+    u_signal, _ = controller(t, x_signal, u_nom, key, data)
+
+    # Assert that the difference is small
+    # Before fix: u_noise ~ 1.0, u_signal ~ 0.1. Diff ~ 0.9.
+    # After fix: u_noise ~ 0.1, u_signal ~ 0.1. Diff ~ 0.0.
+    assert jnp.allclose(u_noise, u_signal, atol=0.05), \
+        f"Control input jump detected! u_noise={u_noise}, u_signal={u_signal}"

--- a/tests/test_controllers/test_normalization_robustness.py
+++ b/tests/test_controllers/test_normalization_robustness.py
@@ -4,7 +4,7 @@ import pytest
 
 def normalization_logic_fixed(norms):
     # This matches the new implementation in cbf_clf_qp_generator.py
-    return jnp.maximum(norms, 1e-6)
+    return jnp.maximum(norms, 1e-8)
 
 def test_normalization_stability():
     """
@@ -24,22 +24,22 @@ def test_normalization_stability():
     assert jnp.all(jnp.isfinite(scale_factors))
     assert jnp.all(jnp.isfinite(result_norms))
 
-    # 2. Divisor never zero (min divisor is 1e-6)
-    assert jnp.all(safe_norms >= 1e-6)
+    # 2. Divisor never zero (min divisor is 1e-8)
+    assert jnp.all(safe_norms >= 1e-8)
 
     # 3. Continuity check (simple diff)
     diffs = jnp.diff(result_norms)
     # The result norm should be monotonic?
-    # For n < 1e-6: result = n / 1e-6. Linear increase. Monotonic.
-    # For n > 1e-6: result = n / n = 1. Constant. Monotonic.
+    # For n < 1e-8: result = n / 1e-8. Linear increase. Monotonic.
+    # For n > 1e-8: result = n / n = 1. Constant. Monotonic.
     # So yes, non-decreasing.
     assert jnp.all(diffs >= -1e-7) # Tolerate float32 noise
 
     # 4. Check specific values
-    # Noise (1e-9) -> 1e-3
+    # Noise (1e-9) -> 0.1
     n_noise = jnp.array([1e-9])
     res_noise = n_noise / normalization_logic_fixed(n_noise)
-    assert jnp.allclose(res_noise, 1e-3)
+    assert jnp.allclose(res_noise, 0.1)
 
     # Signal (1e-1) -> 1.0
     n_signal = jnp.array([1e-1])


### PR DESCRIPTION
Replaced the discontinuous "noise transition" logic in `cbf_clf_qp_generator` with a robust `maximum(norm, 1e-8)` clamp. This eliminates a massive jump in constraint scaling (from 1e-9 to 1.0) that occurred over the interval [1e-9, 1e-8], causing control input instability.

---
*PR created automatically by Jules for task [14992517436068502960](https://jules.google.com/task/14992517436068502960) started by @bardhh*