### PR TITLE
⏱️ Chronos: Fix QP solver failure on high slack penalties

### DIFF
--- a/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
@@ -7,7 +7,7 @@ from jax import Array, jit
 from jaxopt import OSQP, EqualityConstrainedQP
 
 # Instantiate QP solver objects
-QP = OSQP()
+QP = OSQP(maxiter=1000000, tol=1e-3)
 EC_QP = EqualityConstrainedQP()
 
 

--- a/tests/test_controllers/test_cbf_clf_controllers/test_high_penalty_robustness.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_high_penalty_robustness.py
@@ -1,0 +1,63 @@
+
+import unittest
+import jax.numpy as jnp
+from jax import random
+from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+from cbfkit.utils.user_types import ControllerData
+
+class TestHighPenaltyRobustness(unittest.TestCase):
+    """
+    Regression test for handling high slack variable penalties in CBF-QP.
+    Previous versions failed with UNSOLVED/NaN for penalties >= 100.0 due to
+    solver iteration limits or ill-conditioning.
+    """
+
+    def test_high_penalty_feasibility(self):
+        # Scenario: Unsafe state requiring slack usage
+        # State: x = -2.0. Barrier h(x) = x >= 0.
+        # Condition: u + delta >= 2.0.
+        # Limit: u <= 0.5.
+        # Must use slack delta >= 1.5.
+
+        def dynamics(x):
+            return jnp.array([0.0]), jnp.array([[1.0]])
+
+        def h(t, x): return x[0]
+        def grad(t, x): return jnp.array([1.0])
+        def hess(t, x): return jnp.array([[0.0]])
+        def partial_t(t, x): return 0.0
+        def condition(val): return 1.0 * val
+
+        barriers = ([h], [grad], [hess], [partial_t], [condition])
+        x = jnp.array([-2.0])
+        u_nom = jnp.array([0.0])
+        key = random.PRNGKey(0)
+
+        # Penalty 1e5 was definitely failing in benchmarks
+        penalty = 1e5
+
+        ctl = vanilla_cbf_clf_qp_controller(
+            control_limits=jnp.array([0.5]),
+            dynamics_func=dynamics,
+            barriers=barriers,
+            nominal_input=None,
+            relaxable_cbf=True,
+            slack_penalty_cbf=penalty,
+        )
+
+        data = ControllerData()
+        u, data = ctl(0.0, x, u_nom, key, data)
+
+        # Assertions
+        self.assertFalse(data.error, f"Controller reported error for penalty {penalty}. Status: {data.error_data}")
+        self.assertFalse(jnp.any(jnp.isnan(u)), f"Controller returned NaN for penalty {penalty}: {u}")
+
+        # Check that slack was used (u should be near limit 0.5)
+        # u should be close to 0.5 (clamped)
+        # and slack should satisfy constraint.
+        self.assertTrue(u[0] <= 0.5 + 1e-3, f"Control input violated limit: {u[0]}")
+        # Ideally u is exactly 0.5 because minimizing slack squared means maximizing u to reduce delta.
+        self.assertTrue(u[0] >= 0.4, f"Control input suspiciously low: {u[0]}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Regression Test**: `tests/test_controllers/test_cbf_clf_controllers/test_high_penalty_robustness.py`
**Fix**: Modified `src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py` to initialize `OSQP` with `maxiter=1000000` and `tol=1e-3`.

**Why**: High slack penalties (e.g., used to strictly enforce safety or tune relaxation) create ill-conditioned QP constraints where slack variables have very small coefficients compared to control inputs. The default OSQP settings (maxiter=4000) were insufficient for these stiff problems, leading to premature termination (`MAX_ITER_REACHED` or `UNSOLVED`) and resulting in `NaN` control outputs. Increasing the iteration limit allows the solver to converge. JAX compiled loops ensure this does not significantly impact runtime for well-conditioned problems.

---
*PR created automatically by Jules for task [16618914428055266778](https://jules.google.com/task/16618914428055266778) started by @bardhh*