### PR TITLE
✉️ Hermes: Improve shape mismatch error messages for certificates

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/generating_functions.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/generating_functions.py
@@ -2,7 +2,7 @@
 #! docstring
 """
 
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import jax.numpy as jnp
 from jax import Array, jit, lax, vmap
@@ -96,12 +96,21 @@ def generate_compute_cbf_clf_constraints(
     return compute_cbf_clf_constraints
 
 
-def _stack_and_validate(values: list, name: str):
+def _stack_and_validate(values: list, name: str, expected_ndim: Optional[int] = None):
     """Stacks a list of arrays and validates that they all have the same shape."""
     if not values:
         return jnp.stack(values)
 
     first_shape = jnp.shape(values[0])
+    if expected_ndim is not None:
+        if len(first_shape) != expected_ndim:
+            type_map = {0: "scalar", 1: "vector", 2: "matrix"}
+            exp_type = type_map.get(expected_ndim, f"rank-{expected_ndim}")
+            raise ValueError(
+                f"Shape mismatch in {name}: Expected {exp_type} output (shape rank {expected_ndim}), "
+                f"but got shape {first_shape}. Ensure that your {name} return {exp_type}s."
+            )
+
     for i, val in enumerate(values):
         val_shape = jnp.shape(val)
         if val_shape != first_shape:
@@ -122,22 +131,22 @@ def generate_compute_certificate_values_list_comprehension(
     @jit
     def compute_certificate_values_list_comprehension(t, x):
         bf_values = [lf(t, x) for lf in functions]
-        bf_x = _stack_and_validate(bf_values, "certificate functions")
+        bf_x = _stack_and_validate(bf_values, "certificate functions", expected_ndim=0)
 
         bj_values = [lj(t, x) for lj in jacobians]
-        bj_x = _stack_and_validate(bj_values, "certificate jacobians")
+        bj_x = _stack_and_validate(bj_values, "certificate jacobians", expected_ndim=1)
 
         if compute_hessians:
             bh_values = [lh(t, x) for lh in hessians]
-            bh_x = _stack_and_validate(bh_values, "certificate hessians")
+            bh_x = _stack_and_validate(bh_values, "certificate hessians", expected_ndim=2)
         else:
             bh_x = None
 
         dbf_t_values = [lt(t, x) for lt in partials]
-        dbf_t = _stack_and_validate(dbf_t_values, "certificate partials")
+        dbf_t = _stack_and_validate(dbf_t_values, "certificate partials", expected_ndim=0)
 
         bc_values = [lc(lf) for lc, lf in zip(conditions, bf_x)]
-        bc_x = _stack_and_validate(bc_values, "certificate conditions")
+        bc_x = _stack_and_validate(bc_values, "certificate conditions", expected_ndim=0)
 
         return bf_x, bj_x, bh_x, dbf_t, bc_x
 


### PR DESCRIPTION
✉️ Hermes: Improve shape mismatch error messages for certificates

Before: `ValueError: Cannot broadcast to shape with fewer dimensions: arr_shape=(1, 1, 1) shape=(1, 1)` (or similar cryptic JAX error)
After: `ValueError: Shape mismatch in certificate functions: Expected scalar output (shape rank 0), but got shape (1,). Ensure that your certificate functions return scalars.`

User Fix: Change certificate functions to return `x[0]` instead of `x[0:1]` or `jnp.array([val])`.

Tests Run:
- Verified with reproduction script `reproduce_shape_mismatch.py`.
- Ran existing tests in `tests/test_controllers/test_cbf_clf_controllers/`.

---
*PR created automatically by Jules for task [10688980513529559860](https://jules.google.com/task/10688980513529559860) started by @bardhh*