### PR TITLE
⚡ Bolt: Optimize MPPI loop state memory

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -441,6 +441,8 @@ def execute(
 
         if planner is not None:
             _, p_data = planner(0.0, x0, None, prime_key1, p_data)  # type: ignore
+            # Bolt: Strip sampled_x_traj from p_data to avoid carrying it in JIT loop
+            p_data = p_data._replace(sampled_x_traj=None)
 
         if controller is not None:
             f_dummy, g_dummy = dynamics(x0)

--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -205,7 +205,9 @@ def simulator_jit(
         t_next = t + dt
 
         # Pack carry
-        new_carry = (key, t_next, x_next, u, z, c, controller_data, planner_data)
+        # Bolt: Strip sampled_x_traj from carry to save bandwidth/memory
+        planner_data_carry = planner_data._replace(sampled_x_traj=None)
+        new_carry = (key, t_next, x_next, u, z, c, controller_data, planner_data_carry)
 
         # Bolt: Filter solver_params from output to save memory/bandwidth
         controller_data_log = controller_data


### PR DESCRIPTION
⚡ Bolt: Strip unused heavy arrays from JIT loop carry

💡 **What**:
Modified `simulator.py` and `simulator_jit.py` to ensure that the `sampled_x_traj` field in `PlannerData` (which contains large arrays of sampled trajectories, e.g., 500 samples * 50 steps * 4 states) is **not** carried in the `jax.lax.scan` loop state. It is still preserved in the scan output for logging/visualization.

🎯 **Why**:
In MPPI simulations, `sampled_x_traj` is a large intermediate result used only for visualization. It is not required for the next iteration of the planner. However, `jax.lax.scan` forces the carry structure to match across iterations. By default, this meant carrying a large buffer (~100k-1M floats) through the loop state every step, increasing memory bandwidth and allocation overhead.

📊 **Impact**:
- **Runtime**: ~15% reduction in wall time for a 2s unicycle MPPI simulation on CPU (median 0.308s -> 0.262s).
- **Memory**: Avoids unnecessary movement of large arrays in the recurrent loop state.

🔬 **How measured**:
Ran a reproduction script (`reproduce_bottleneck.py`) simulating a unicycle with MPPI planner (500 samples, 50 horizon) for 40 steps. Measured execution time of `sim.execute(..., use_jit=True)`.

✅ **Correctness**:
- Ran `reproduce_bottleneck.py` to confirm `sampled_x_traj` is still present in the final `SimulationResults` (it is).
- Ran `tests/test_simulation/test_simulator_jit_rk4.py` and `tests/test_simulation/test_control_loop.py` to ensure no regression in simulation logic.
- Ran `tests/test_planners/test_waypoint_planner.py` to ensure planner interface remains compatible.

---
*PR created automatically by Jules for task [9977269803448556562](https://jules.google.com/task/9977269803448556562) started by @bardhh*