### PR TITLE
🏗️ Atlas: Remove unused `**kwargs` from `rectify_relative_degree`

### DIFF
--- a/examples/differential_drive/augmented_dynamic_obstacle_cbf.py
+++ b/examples/differential_drive/augmented_dynamic_obstacle_cbf.py
@@ -190,8 +190,6 @@ def run_simulation():
         form="exponential",
     )(
         certificate_conditions=zeroing_barriers.linear_class_k(1.0),
-        obstacle=jnp.array([]),  # Unused
-        ellipsoid=(1.0, 1.0),  # Unused
     )
     barriers.append(b1)
 
@@ -203,8 +201,6 @@ def run_simulation():
         function=h2, system_dynamics=aug_dynamics, state_dim=8, form="exponential"
     )(
         certificate_conditions=zeroing_barriers.linear_class_k(1.0),
-        obstacle=jnp.array([]),
-        ellipsoid=(1.0, 1.0),
     )
     barriers.append(b2)
 

--- a/examples/differential_drive/barrier_activated_cbf.py
+++ b/examples/differential_drive/barrier_activated_cbf.py
@@ -99,8 +99,6 @@ def create_scenario():
             form="exponential",
         )(
             certificate_conditions=zeroing_barriers.linear_class_k(5.0),
-            obstacle=jnp.array(obs),
-            ellipsoid=(d_min, d_min),
         )
         barriers.append(barrier)
 

--- a/examples/differential_drive/dynamic_obstacle_cbf.py
+++ b/examples/differential_drive/dynamic_obstacle_cbf.py
@@ -130,8 +130,6 @@ def run_simulation():
             form="exponential",
         )(
             certificate_conditions=zeroing_barriers.linear_class_k(2.0),
-            obstacle=jnp.array([0.0]),  # Dummy arg, function handles position
-            ellipsoid=(1.0, 1.0),  # Dummy arg
         )
 
         barriers.append(barrier_rectified)

--- a/examples/differential_drive/human_aware_mppi_cbf.py
+++ b/examples/differential_drive/human_aware_mppi_cbf.py
@@ -221,8 +221,6 @@ def run_simulation():
             function=h, system_dynamics=aug_dynamics, state_dim=len(z0), form="exponential"
         )(
             certificate_conditions=zeroing_barriers.linear_class_k(1.0),
-            obstacle=jnp.array([]),
-            ellipsoid=(1.0, 1.0),
         )
         barriers.append(b)
 

--- a/examples/differential_drive/multi_scenario_human_aware.py
+++ b/examples/differential_drive/multi_scenario_human_aware.py
@@ -172,8 +172,6 @@ def run_scenario(config):
             function=h, system_dynamics=aug_dynamics, state_dim=len(z0), form="exponential"
         )(
             certificate_conditions=zeroing_barriers.linear_class_k(1.0),
-            obstacle=jnp.array([]),
-            ellipsoid=(1.0, 1.0),
         )
         barriers.append(b)
 

--- a/examples/differential_drive/single_robot_cbf.py
+++ b/examples/differential_drive/single_robot_cbf.py
@@ -144,8 +144,6 @@ def create_robot_with_obstacles():
             form="exponential",
         )(
             certificate_conditions=zeroing_barriers.linear_class_k(10.0),
-            obstacle=jnp.array(obs),
-            ellipsoid=(d_min_obstacle, d_min_obstacle),
         )
         barriers.append(barrier)
 

--- a/examples/unicycle/reach_goal/mppi_cbf_control.py
+++ b/examples/unicycle/reach_goal/mppi_cbf_control.py
@@ -141,8 +141,6 @@ barriers = [
         form="exponential",
     )(
         certificate_conditions=zeroing_barriers.linear_class_k(5.0),
-        obstacle=obs,
-        ellipsoid=ell,
     )
     for obs, ell in zip(obstacles, ellipsoids)
 ]

--- a/examples/unicycle/reach_goal/stochastic_cbf_control.py
+++ b/examples/unicycle/reach_goal/stochastic_cbf_control.py
@@ -67,8 +67,6 @@ barriers = [
         form="exponential",
     )(
         certificate_conditions=stochastic_barrier.right_hand_side(alpha=1.0, beta=1.0),
-        obstacle=jnp.array(obs),
-        ellipsoid=jnp.array(ell),
     )
     for obs, ell in zip(obstacles, ellipsoids)
 ]

--- a/examples/unicycle/reach_goal/vanilla_cbf_control.py
+++ b/examples/unicycle/reach_goal/vanilla_cbf_control.py
@@ -67,8 +67,6 @@ barriers = [
         form="exponential",
     )(
         certificate_conditions=zeroing_barriers.linear_class_k(5.0),
-        obstacle=jnp.array(obs),
-        ellipsoid=jnp.array(ell),
     )
     for obs, ell in zip(obstacles, ellipsoids)
 ]

--- a/examples/unicycle/reach_goal/vanilla_cbf_start_to_goal_main.py
+++ b/examples/unicycle/reach_goal/vanilla_cbf_start_to_goal_main.py
@@ -61,8 +61,6 @@ barriers = [
         form="exponential",
     )(
         certificate_conditions=zeroing_barriers.linear_class_k(10.0),
-        obstacle=obs,
-        ellipsoid=ell,
     )
     for obs, ell in zip(obstacles, ellipsoids)
 ]

--- a/src/cbfkit/certificates/rectifiers.py
+++ b/src/cbfkit/certificates/rectifiers.py
@@ -117,7 +117,7 @@ def rectify_relative_degree(
         # Calculate the polynomial coefficients using JAX and SciPy
         polynomial_coefficients = polynomial_coefficients_from_roots(roots)
 
-        def cbf(**kwargs):
+        def cbf():
             @jit
             def func(x: Array) -> Array:
                 return jnp.sum(
@@ -131,8 +131,8 @@ def rectify_relative_degree(
 
             return func
 
-        def cbf_grad(**kwargs) -> Callable[[Array], Array]:
-            jacobian = jacfwd(cbf(**kwargs))
+        def cbf_grad() -> Callable[[Array], Array]:
+            jacobian = jacfwd(cbf())
 
             @jit
             def func(x: Array) -> Array:
@@ -140,8 +140,8 @@ def rectify_relative_degree(
 
             return func
 
-        def cbf_hess(**kwargs) -> Callable[[Array], Array]:
-            hessian = jacfwd(jacrev(cbf(**kwargs)))
+        def cbf_hess() -> Callable[[Array], Array]:
+            hessian = jacfwd(jacrev(cbf()))
 
             @jit
             def func(x: Array) -> Array:
@@ -151,7 +151,7 @@ def rectify_relative_degree(
 
     elif form == "high-order":
 
-        def cbf(**kwargs):
+        def cbf():
             def func(x: Array) -> Array:
                 return function_list[0](x)
 

--- a/tutorials/mppi_stochastic_cbf_reach_avoid.py
+++ b/tutorials/mppi_stochastic_cbf_reach_avoid.py
@@ -92,8 +92,6 @@ barriers = [
         form="exponential",
     )(
         certificate_conditions=stochastic_barrier.right_hand_side(alpha=1.0, beta=1.0),
-        obstacle=obs,
-        ellipsoid=ell,
     )
     for obs, ell in zip(obstacles, ellipsoids)
 ]

--- a/tutorials/simulate_mppi_cbf_ellipsoidal_stochastic_cbf.py
+++ b/tutorials/simulate_mppi_cbf_ellipsoidal_stochastic_cbf.py
@@ -91,8 +91,6 @@ barriers = [
         certificate_conditions=stochastic_barrier.right_hand_side(
             alpha=1.0, beta=1.0
         ),  # 1.0, 1.0),
-        obstacle=obs,
-        ellipsoid=ell,
     )
     for obs, ell in zip(obstacles, ellipsoids)
 ]


### PR DESCRIPTION
🏗️ Atlas: Remove unused `**kwargs` from `rectify_relative_degree` to prevent confusion.

This change modifies `src/cbfkit/certificates/rectifiers.py` so that the certificate factory returned by `rectify_relative_degree` no longer accepts arbitrary `**kwargs`. Previously, users could pass arguments like `obstacle` or `ellipsoid` to the factory, which were silently ignored because the underlying certificate function was already closed over its parameters. This led to confusing code where users thought they were dynamically updating parameters.

The fix involves removing `**kwargs` from the inner `cbf`, `cbf_grad`, and `cbf_hess` definitions. Any extra arguments now raise a `TypeError`, clarifying usage.

I have updated all affected examples and tutorials to remove the redundant arguments:
- `examples/unicycle/reach_goal/vanilla_cbf_control.py`
- `examples/unicycle/reach_goal/mppi_cbf_control.py`
- `examples/differential_drive/augmented_dynamic_obstacle_cbf.py`
- `examples/differential_drive/single_robot_cbf.py`
- `examples/differential_drive/barrier_activated_cbf.py`
- `examples/differential_drive/dynamic_obstacle_cbf.py`
- `examples/differential_drive/human_aware_mppi_cbf.py`
- `examples/differential_drive/multi_scenario_human_aware.py`
- `examples/unicycle/reach_goal/vanilla_cbf_start_to_goal_main.py`
- `examples/unicycle/reach_goal/stochastic_cbf_control.py`
- `tutorials/mppi_stochastic_cbf_reach_avoid.py`
- `tutorials/simulate_mppi_cbf_ellipsoidal_stochastic_cbf.py`

Tests were run and passed (with one known unrelated failure in `test_solver_failure.py` due to a mock mismatch). A reproduction script confirmed the fix works (catching `TypeError`).


---
*PR created automatically by Jules for task [15383927674162957390](https://jules.google.com/task/15383927674162957390) started by @bardhh*