### PR TITLE
🔮 Oracle: Fix misleading docstrings in zeroing barrier conditions

### DIFF
--- a/src/cbfkit/certificates/conditions/barrier_conditions/zeroing_barriers.py
+++ b/src/cbfkit/certificates/conditions/barrier_conditions/zeroing_barriers.py
@@ -54,40 +54,53 @@ from jax import Array
 
 
 def linear_class_k(alpha: float) -> Callable[[Array], Array]:
-    """Generates function for computing RHS of barrier conditions for zeroing CBF:
+    """Generates the class K function alpha(h) for the zeroing CBF condition:
 
-    hdot >= -alpha*h
+    hdot + alpha(h) >= 0
+
+    which is equivalent to:
+    hdot >= -alpha(h)
+
+    where alpha(h) = alpha * h.
 
     Args:
         None
 
     Returns
     -------
-        Callable[[Array], Array]: Zeroing CBF barrier conditions
+        Callable[[Array], Array]: The class K function alpha(h).
     """
     assert alpha >= 0
     return lambda h: alpha * h
 
 
 def cubic_class_k(alpha: float) -> Callable[[Array], Array]:
-    """Generates function for computing RHS of barrier conditions for zeroing CBF:
+    """Generates the class K function alpha(h) for the zeroing CBF condition:
 
-    hdot >= -alpha*h**3
+    hdot + alpha(h) >= 0
+
+    which is equivalent to:
+    hdot >= -alpha(h)
+
+    where alpha(h) = alpha * h^3.
 
     Args:
         None
 
     Returns
     -------
-        Callable[[Array], Array]: Zeroing CBF barrier conditions
+        Callable[[Array], Array]: The class K function alpha(h).
     """
     assert alpha >= 0
     return lambda h: alpha * h**3
 
 
 def generic_class_k(alpha: Callable[[Array], Array]) -> Callable[[Array], Array]:
-    """Generates function for computing RHS of barrier conditions for zeroing CBF:
+    """Generates the class K function alpha(h) for the zeroing CBF condition:
 
+    hdot + alpha(h) >= 0
+
+    which is equivalent to:
     hdot >= -alpha(h)
 
     Args:
@@ -95,7 +108,7 @@ def generic_class_k(alpha: Callable[[Array], Array]) -> Callable[[Array], Array]
 
     Returns
     -------
-        Callable[[Array], Array]: Zeroing CBF barrier conditions
+        Callable[[Array], Array]: The class K function alpha(h).
     """
 
     def func(h: Array) -> Array:

--- a/tests/test_zeroing_barrier_semantics.py
+++ b/tests/test_zeroing_barrier_semantics.py
@@ -1,0 +1,58 @@
+
+import pytest
+import jax.numpy as jnp
+from cbfkit.certificates.conditions.barrier_conditions.zeroing_barriers import linear_class_k, cubic_class_k, generic_class_k
+
+def test_linear_class_k_semantics():
+    """
+    Verifies that linear_class_k(alpha) returns a function that computes `alpha * h`.
+
+    The function returns the term alpha(h) that needs to be ADDED to the LHS of the inequality:
+    hdot + alpha(h) >= 0
+    which is equivalent to:
+    hdot >= -alpha(h)
+
+    where alpha(h) = alpha * h.
+    """
+    alpha = 2.0
+    h_val = 3.0
+
+    func = linear_class_k(alpha)
+    result = func(h_val)
+
+    # Expected result is alpha * h (positive for positive alpha/h)
+    expected = alpha * h_val
+
+    assert jnp.isclose(result, expected), f"Expected {expected}, but got {result}"
+
+    # Explicitly check it's NOT returning the RHS (-alpha * h)
+    assert not jnp.isclose(result, -expected), "Function appears to return RHS (-alpha*h) which contradicts code/new spec"
+
+def test_cubic_class_k_semantics():
+    """
+    Verifies that cubic_class_k(alpha) returns a function that computes `alpha * h^3`.
+    """
+    alpha = 2.0
+    h_val = 2.0
+
+    func = cubic_class_k(alpha)
+    result = func(h_val)
+
+    expected = alpha * (h_val ** 3) # 2 * 8 = 16
+
+    assert jnp.isclose(result, expected), f"Expected {expected}, but got {result}"
+
+def test_generic_class_k_semantics():
+    """
+    Verifies that generic_class_k(alpha_func) wraps the function correctly.
+    """
+    def my_alpha(h):
+        return h + 1.0
+
+    func = generic_class_k(my_alpha)
+    h_val = 5.0
+
+    result = func(h_val)
+    expected = 6.0
+
+    assert jnp.isclose(result, expected), f"Expected {expected}, but got {result}"


### PR DESCRIPTION
Resolved semantic mismatch between docstrings and code in zeroing barrier conditions. Updated docstrings to accurately reflect that the functions return the class K function (LHS term) rather than the RHS of the inequality. Added semantic verification tests.

---
*PR created automatically by Jules for task [12721712922370902186](https://jules.google.com/task/12721712922370902186) started by @bardhh*