### PR TITLE
🔧 Forge: Fix missing Jinja2 templates in package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ dev = [
 requires = ["setuptools>=69.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.package-data]
+"cbfkit" = ["codegen/templates/*.j2"]
+
 [tool.black]
 line-length = 100
 


### PR DESCRIPTION
Fixes a packaging issue where Jinja2 templates required for code generation were not included in the distribution.

Added `[tool.setuptools.package-data]` to `pyproject.toml` to include `codegen/templates/*.j2` files in the `cbfkit` package.

Verified by:
1. Running `python -m build` and confirming `*.j2` files are present in the generated wheel.
2. Running `pip install -e .` and confirming `import cbfkit` works.


---
*PR created automatically by Jules for task [590591084529691519](https://jules.google.com/task/590591084529691519) started by @bardhh*