### PR TITLE
🏗️ Atlas: Simplify certificate_package with use_factory arg

### DIFF
--- a/src/cbfkit/certificates/packager.py
+++ b/src/cbfkit/certificates/packager.py
@@ -65,20 +65,23 @@ def certificate_package(
     input_style: Union[
         CertificateInputStyleName, CertificateInputStyle
     ] = CertificateInputStyle.CONCATENATED,
+    use_factory: bool = True,
 ) -> Callable[..., CertificateCollection]:
     """Function for packaging and later creating CBF executables.
 
     Args:
-        func (Callable): certificate function factory
-        func_grad (Callable, optional): certificate gradient vector function factory.
+        func (Callable): certificate function factory (or function if use_factory=False)
+        func_grad (Callable, optional): certificate gradient vector function factory (or function).
             If None, computed automatically using jax.grad.
-        func_hess (Callable, optional): certificate hessian matrix function factory.
+        func_hess (Callable, optional): certificate hessian matrix function factory (or function).
             If None, computed automatically using jax.hessian.
         n (int): state dimension
         input_style (str | CertificateInputStyle): expected signature of the certificate function.
             - "concatenated" (default): func returns f(xt) where xt is [x, t].
             - "separated": func returns f(t, x).
             - "state": func returns f(x).
+        use_factory (bool): whether func, func_grad, and func_hess are factories (returning the function)
+            or the functions themselves. Defaults to True (factories).
 
     Returns
     -------
@@ -109,7 +112,10 @@ def certificate_package(
         -------
             BarrierTuple: _description_
         """
-        v_func = func(**kwargs)
+        if use_factory:
+            v_func = func(**kwargs)
+        else:
+            v_func = func  # type: ignore[assignment]
 
         if input_style == CertificateInputStyle.SEPARATED:
             _orig_v_sep = v_func
@@ -128,14 +134,21 @@ def certificate_package(
             j_func = grad(v_func)
             t_func = j_func
         else:
-            j_func = func_grad(**kwargs)
-            t_func = func_grad(**kwargs)
+            if use_factory:
+                j_func = func_grad(**kwargs)
+                t_func = func_grad(**kwargs)
+            else:
+                j_func = func_grad  # type: ignore[assignment]
+                t_func = func_grad  # type: ignore[assignment]
 
         if func_hess is None:
             # Auto-differentiate
             h_func = hessian(v_func)
         else:
-            h_func = func_hess(**kwargs)
+            if use_factory:
+                h_func = func_hess(**kwargs)
+            else:
+                h_func = func_hess  # type: ignore[assignment]
 
         c_func = certificate_conditions
 

--- a/tests/test_certificates/test_packager.py
+++ b/tests/test_certificates/test_packager.py
@@ -77,5 +77,25 @@ class TestCertificatePackager(unittest.TestCase):
         partial_t_val = collection.partials[0](0.0, jnp.array([2.0]))
         self.assertAlmostEqual(float(partial_t_val), 0.0)
 
+    def test_direct_function(self):
+        # Test use_factory=False with input_style="state"
+        def h(x):
+            return x[0] - 1.0
+
+        dummy_conditions = lambda x: x
+
+        # No factory needed!
+        pkg = certificate_package(h, n=1, input_style="state", use_factory=False)
+        collection = pkg(certificate_conditions=dummy_conditions)
+
+        # h(x) = x[0] - 1.
+        # x = [2.] -> h = 1.
+        h_val = collection.functions[0](0.0, jnp.array([2.0]))
+        self.assertAlmostEqual(float(h_val), 1.0)
+
+        # Gradient should be [1.]
+        grad_val = collection.jacobians[0](0.0, jnp.array([2.0]))
+        self.assertTrue(jnp.allclose(grad_val, jnp.array([1.0])))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Title: 🏗️ Atlas: Simplify certificate_package with use_factory arg

Before:
```python
def h_factory():
    def h(x): return x[0] - 1.0
    return h

pkg = certificate_package(h_factory)(conditions)
```

After:
```python
def h(x): return x[0] - 1.0

pkg = certificate_package(h, use_factory=False)(conditions)
```

This removes unnecessary boilerplate for simple, static certificate functions (CBFs/CLFs) while preserving backward compatibility for parameterized factories.

Tests run:
- `pytest tests/test_certificates/test_packager.py` (passed)
- `pytest tests/test_rectify_relative_degree_api.py` (passed)


---
*PR created automatically by Jules for task [14608564280118655627](https://jules.google.com/task/14608564280118655627) started by @bardhh*