### PR TITLE
⚙️ Flux: Speed up model generation tests and mark jit benchmark as slow

### DIFF
--- a/tests/test_models/test_model_generation.py
+++ b/tests/test_models/test_model_generation.py
@@ -25,6 +25,7 @@ To run all tests in this module (from the root of the repository):
 """
 
 import unittest
+import unittest.mock
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from cbfkit.codegen.create_new_system.generate_model import generate_model
@@ -127,16 +128,19 @@ class TestModelGeneration(unittest.TestCase):
         if params is None:
             params = {}
 
-        generated_states, generated_controls = generate_model(
-            target_directory,
-            model_name,
-            drift_dynamics,
-            control_matrix,
-            barrier_funcs=barrier_funcs,
-            lyapunov_funcs=lyapunov_funcs,
-            nominal_controller=nominal_controller,
-            params=params,
-        )
+        with unittest.mock.patch(
+            "cbfkit.codegen.create_new_system.generate_model.run_black"
+        ):
+            generated_states, generated_controls = generate_model(
+                target_directory,
+                model_name,
+                drift_dynamics,
+                control_matrix,
+                barrier_funcs=barrier_funcs,
+                lyapunov_funcs=lyapunov_funcs,
+                nominal_controller=nominal_controller,
+                params=params,
+            )
 
         self.assertTrue(
             (dims[0] == generated_states) and (dims[1] == generated_controls)

--- a/tests/test_simulation/test_control_loop.py
+++ b/tests/test_simulation/test_control_loop.py
@@ -137,6 +137,7 @@ def initial_state():
 
 
 @pytest.mark.benchmark
+@pytest.mark.slow
 def test_execution_performance_jit(initial_state):
     """Tests that JIT-compiled execution is fast (average step < 1ms)."""
     planner_data = PlannerData(


### PR DESCRIPTION
Improved CI performance by mocking `black` formatter in model generation tests (speeding up `test_model_generation.py` significantly) and marking the JIT execution performance benchmark as a slow test to avoid running it on every Python version in the CI matrix. This aligns with the goal of reducing flakiness and wasted runtime.

---
*PR created automatically by Jules for task [790272262319826422](https://jules.google.com/task/790272262319826422) started by @bardhh*