### PR TITLE
🚨 Sentinel: Explicitly report NaN failures in CBF-CLF-QP controller

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -313,6 +313,9 @@ def cbf_clf_qp_generator(
             g_mat = jnp.vstack([g_mat_u, g_mat_c])
             h_vec = jnp.hstack([h_vec_u, h_vec_c])
 
+            # Sentinel: Detect NaNs in QP inputs
+            nan_in_inputs = jnp.any(jnp.isnan(q_vec)) | jnp.any(jnp.isnan(g_mat)) | jnp.any(jnp.isnan(h_vec))
+
             # Solve QP
             solver_params = None
             if data.sub_data is not None and "solver_params" in data.sub_data:
@@ -328,7 +331,8 @@ def cbf_clf_qp_generator(
             iter_num = state.iter_num
 
             # Sentinel: Explicitly catch NaN solutions even if solver claims success
-            status = jnp.where(jnp.any(jnp.isnan(sol)), 0, status)
+            # Also catch if inputs were NaN (solver might return 0 and UNSOLVED status 0)
+            status = jnp.where(jnp.any(jnp.isnan(sol)) | nan_in_inputs, -1, status)
 
             # Bolt: Rescale solution back to physical units
             if auto_p_mat:

--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -49,6 +49,7 @@ from .utils import SimulationStepData
 
 
 SOLVER_STATUS_MAP = {
+    -1: "NAN_DETECTED",
     0: "UNSOLVED (Likely Infeasible)",
     1: "SOLVED",
     2: "MAX_ITER_REACHED",


### PR DESCRIPTION
This PR improves failure handling in the `cbf_clf_qp_generator` controller. Previously, if the nominal control input `u_nom` or constraint matrices contained `NaN`s, the QP solver (`jaxopt.OSQP`) would return a status of `0` ("UNSOLVED") and a solution of zeros (or NaNs), leading to confusing error messages like "UNSOLVED (Likely Infeasible)".

Changes:
1.  **Explicit NaN Detection:** The controller now checks for `NaN`s in the QP inputs (`q_vec`, `g_mat`, `h_vec`) and the solution `sol`.
2.  **New Error Status:** If `NaN`s are detected, the status is explicitly set to `-1`.
3.  **Clearer Logging:** `SOLVER_STATUS_MAP` in `simulator.py` now maps status `-1` to "NAN_DETECTED".

This ensures that numerical instabilities or invalid inputs are reported accurately, distinguishing them from solver convergence issues or infeasibility.

---
*PR created automatically by Jules for task [10741279769228032299](https://jules.google.com/task/10741279769228032299) started by @bardhh*