### PR TITLE
📦 Archivist: Fix recursion randomness and add seeding to rectifiers

### DIFF
--- a/src/cbfkit/certificates/rectifiers.py
+++ b/src/cbfkit/certificates/rectifiers.py
@@ -80,6 +80,7 @@ def rectify_relative_degree(
     roots: Union[Array, None] = None,
     form: str = "exponential",
     certificate_conditions: Optional[CertificateConditionsCallable] = None,
+    rng: Optional[Union[int, Array]] = None,
 ) -> Union[Callable[..., CertificateCollection], CertificateCollection]:
     """Rectifies the relative degree of the provided constraint function with respect to the system
     dynamics deriving a new exponential- or high-order-CBF.
@@ -91,13 +92,25 @@ def rectify_relative_degree(
         form (str, optional): type of cascading procedure. Defaults to "exponential".
         certificate_conditions (Optional[CertificateConditionsCallable]): certificate conditions.
             If provided, returns a CertificateCollection directly. Defaults to None.
+        rng (Optional[Union[int, Array]]): random seed or key for relative degree sampling.
+            Defaults to None (using global default).
 
     Returns
     -------
         Union[Callable[..., CertificateCollection], CertificateCollection]: Function to create the CertificateCollection,
             or the CertificateCollection itself if certificate_conditions is provided.
     """
-    function_list = compute_function_list(function, system_dynamics, state_dim + 1, form)
+    subkey: Array
+    if rng is None:
+        subkey = SUBKEY  # type: ignore[assignment]
+    elif isinstance(rng, int):
+        subkey = random.PRNGKey(rng)  # type: ignore[assignment]
+    else:
+        subkey = rng  # type: ignore[assignment]
+
+    function_list = compute_function_list(
+        function, system_dynamics, state_dim + 1, form, subkey=subkey
+    )
 
     if form == "exponential":
         n_fl = len(function_list)
@@ -197,11 +210,12 @@ def compute_function_list(
 
     if subkey is None:
         subkey = SUBKEY  # type: ignore[assignment]
-    else:
-        _, subkey = random.split(KEY)  # type: ignore[assignment]
+
+    # Split the key to ensure different samples are used at each recursion level
+    sample_key, next_subkey = random.split(subkey)  # type: ignore[arg-type]
 
     # Do this at every level
-    samples = random.normal(subkey, (n_samples, state_dim))  # type: ignore[arg-type]
+    samples = random.normal(sample_key, (n_samples, state_dim))  # type: ignore[arg-type]
     jacobian = jacfwd(function)
 
     total = jnp.array(0.0)
@@ -237,7 +251,7 @@ def compute_function_list(
             state_dim,
             form,
             func_list,
-            subkey,
+            next_subkey,
         )
 
     return func_list

--- a/tests/test_certificates/test_rectifiers_reproducibility.py
+++ b/tests/test_certificates/test_rectifiers_reproducibility.py
@@ -1,0 +1,107 @@
+
+import jax.numpy as jnp
+import jax.random as random
+from unittest.mock import patch
+import pytest
+from cbfkit.certificates import rectifiers
+
+class TestRectifiersReproducibility:
+    """Test suite for reproducibility and determinism in rectifiers module."""
+
+    @pytest.fixture
+    def dynamics_and_constraint(self):
+        """Define a simple chain of integrators: x1 -> x2 -> x3 -> u
+        Relative degree of x1 w.r.t u is 3.
+        """
+        def dynamics(x):
+            # x is size 3: [x1, x2, x3]
+            return jnp.array([x[1], x[2], 0.0]), jnp.array([[0.0], [0.0], [1.0]])
+
+        def constraint(x):
+            # x is size 4 (including time/extra)
+            return x[0]
+
+        return dynamics, constraint
+
+    def test_unique_keys_recursion(self, dynamics_and_constraint):
+        """Test that random keys used in recursion are unique."""
+        dynamics, constraint = dynamics_and_constraint
+
+        keys_seen = []
+        original_normal = rectifiers.random.normal
+
+        def mock_normal(key, shape):
+            keys_seen.append(key)
+            return original_normal(key, shape)
+
+        with patch('cbfkit.certificates.rectifiers.random.normal', side_effect=mock_normal):
+            # Pass a fixed seed to ensure deterministic starting point
+            rectifiers.rectify_relative_degree(
+                constraint,
+                dynamics,
+                state_dim=3,
+                rng=42
+            )
+
+        # We expect at least 3 levels for relative degree 3 system
+        assert len(keys_seen) >= 3
+
+        # Check for duplicates
+        for i in range(len(keys_seen)):
+            for j in range(i + 1, len(keys_seen)):
+                assert not jnp.array_equal(keys_seen[i], keys_seen[j]), \
+                    f"Keys at step {i} and {j} are identical: {keys_seen[i]}"
+
+    def test_determinism_with_seed(self, dynamics_and_constraint):
+        """Test that same seed produces identical sequence of keys."""
+        dynamics, constraint = dynamics_and_constraint
+
+        def get_keys_for_seed(seed):
+            keys_seen = []
+            original_normal = rectifiers.random.normal
+
+            def mock_normal(key, shape):
+                keys_seen.append(key)
+                return original_normal(key, shape)
+
+            with patch('cbfkit.certificates.rectifiers.random.normal', side_effect=mock_normal):
+                rectifiers.rectify_relative_degree(
+                    constraint,
+                    dynamics,
+                    state_dim=3,
+                    rng=seed
+                )
+            return keys_seen
+
+        keys1 = get_keys_for_seed(123)
+        keys2 = get_keys_for_seed(123)
+
+        assert len(keys1) == len(keys2)
+        for k1, k2 in zip(keys1, keys2):
+            assert jnp.array_equal(k1, k2), "Keys differ for same seed"
+
+    def test_different_seeds(self, dynamics_and_constraint):
+        """Test that different seeds produce different keys."""
+        dynamics, constraint = dynamics_and_constraint
+
+        def get_first_key(seed):
+            keys_seen = []
+            original_normal = rectifiers.random.normal
+
+            def mock_normal(key, shape):
+                keys_seen.append(key)
+                return original_normal(key, shape)
+
+            with patch('cbfkit.certificates.rectifiers.random.normal', side_effect=mock_normal):
+                rectifiers.rectify_relative_degree(
+                    constraint,
+                    dynamics,
+                    state_dim=3,
+                    rng=seed
+                )
+            return keys_seen[0]
+
+        key1 = get_first_key(123)
+        key2 = get_first_key(456)
+
+        assert not jnp.array_equal(key1, key2), "Different seeds produced same first key"


### PR DESCRIPTION
Archivist: Fix recursion randomness and add seeding to rectifiers

Detected a bug in `cbfkit.certificates.rectifiers.compute_function_list` where the random key `subkey` was being reset to a global constant (or split from a global constant) at every recursion level, causing identical random samples to be used for relative degree verification at all levels.

Changes:
1.  Updated `compute_function_list` to correctly split and propagate the random key (`subkey`) to recursive calls.
2.  Updated `rectify_relative_degree` to accept an optional `rng` argument (int or JAX Array), enabling deterministic execution.
3.  Added `tests/test_certificates/test_rectifiers_reproducibility.py` to verify:
    -   Unique keys are used across recursion levels.
    -   Passing the same seed produces identical results.
    -   Passing different seeds produces different results.


---
*PR created automatically by Jules for task [16055086658101256795](https://jules.google.com/task/16055086658101256795) started by @bardhh*