### PR TITLE
🧮 Janus: Robust constraint normalization with scaling clamp

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -297,16 +297,11 @@ def cbf_clf_qp_generator(
                 # Aegis: Use safe norm (sqrt(sum(sq) + eps)) to prevent NaN gradients at 0.
                 row_sq_sums = jnp.sum(g_mat_c**2, axis=1)
                 row_norms_c = jnp.sqrt(row_sq_sums + 1e-20)
-                # Janus: Smooth transition for noise scaling
-                high, low = 1e-8, 1e-9
-                scale_high = 1.0 / high
-                slope = (scale_high - 1.0) / (high - low)
-                scale_factor = lambda n: 1.0 + (n - low) * slope
-                safe_scales_c = jnp.where(
-                    row_norms_c > high,
-                    1.0 / row_norms_c,
-                    jnp.where(row_norms_c < low, 1.0, scale_factor(row_norms_c)),
-                )
+                # Janus: Normalize constraints robustly.
+                # Use a clamped scaling factor (max 1e8) to:
+                # 1. Enforce constraints with small gradients (e.g. 1e-10) to catch gross infeasibility (Safety).
+                # 2. Allow normalization of small signals (e.g. 2e-8) for solver convergence.
+                safe_scales_c = jnp.minimum(1.0 / row_norms_c, 1e8)
                 g_mat_c = g_mat_c * safe_scales_c[:, None]
                 h_vec_c = h_vec_c * safe_scales_c
 

--- a/tests/test_controllers/test_cbf_clf_controllers/test_vanishing_gradient_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_vanishing_gradient_safety.py
@@ -1,0 +1,120 @@
+
+import jax
+import jax.numpy as jnp
+import pytest
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.utils.user_types import ControllerData
+
+# Enable 64-bit precision to match some configs, but code should work in 32-bit too.
+# The issue is more prominent in 32-bit.
+jax.config.update("jax_enable_x64", False)
+
+def test_vanishing_gradient_infeasibility():
+    """
+    Verifies that a hard constraint with vanishing gradient (1e-10)
+    that contradicts another constraint is detected as infeasible.
+    """
+    def mock_cbf(control_limits, dynamics, barriers, lyapunovs, **kwargs):
+        def compute(t, x):
+            # Constraint 1: -1.0 * u <= -10.0  => u >= 10.0
+            # Constraint 2: 1e-10 * u <= -10.0 => u <= -1e11 (practically -inf)
+            # Infeasible (10 vs -inf).
+            # This represents a case where the system is unsafe (h < 0, b < 0)
+            # and gradient is vanishing. We MUST detect this.
+            g_mat = jnp.array([[-1.0], [1e-10]])
+            h_vec = jnp.array([-10.0, -10.0])
+            return g_mat, h_vec, {"complete": True}
+        return compute
+
+    def mock_clf(*args, **kwargs):
+        return lambda t, x: (jnp.zeros((0, 1)), jnp.zeros((0,)), {})
+
+    generator = cbf_clf_qp_generator(mock_cbf, mock_clf)
+    control_limits = jnp.array([100.0])
+
+    controller = generator(
+        control_limits=control_limits,
+        dynamics_func=lambda t, x: (jnp.zeros(1), jnp.eye(1)),
+        barriers=([], [], [], [], []),
+        lyapunovs=([], [], [], [], []),
+        relaxable_cbf=False
+    )
+
+    t = 0.0
+    x = jnp.zeros(1)
+    u_nom = jnp.zeros(1) # nominal doesn't matter much if constraints conflict
+    key = jax.random.PRNGKey(0)
+    data = ControllerData(
+        error=False, error_data=0, complete=False,
+        sol=jnp.zeros(1), u=jnp.zeros(1), u_nom=u_nom,
+        sub_data={"solver_params": None}
+    )
+
+    u, res_data = controller(t, x, u_nom, key, data)
+
+    # Currently (before fix), solver returns Success (1) with u=10.
+    # Because 1e-10 * 10 = 1e-9 < 1e-3.
+    # We expect it to FAIL (status != 1) or NaN.
+
+    assert res_data.error_data != 1, f"Solver claimed success! u={u}, status={res_data.error_data}"
+
+def test_vanishing_gradient_spurious():
+    """
+    Verifies that a constraint with vanishing gradient (1e-10) and compatible RHS (1e-10)
+    does NOT clamp the control input unnecessarily (spurious constraint).
+    """
+    def mock_cbf(*args, **kwargs):
+        def compute(t, x):
+            # 1e-10 * u <= 1e-10
+            # Physically: u <= 1.
+            # But if it's noise, we want to ignore it and allow u=10.
+            g_mat = jnp.array([[1e-10]])
+            h_vec = jnp.array([1e-10])
+            return g_mat, h_vec, {"complete": True}
+        return compute
+
+    def mock_clf(*args, **kwargs):
+        return lambda t, x: (jnp.zeros((0, 1)), jnp.zeros((0,)), {})
+
+    generator = cbf_clf_qp_generator(mock_cbf, mock_clf)
+    control_limits = jnp.array([100.0])
+
+    controller = generator(
+        control_limits=control_limits,
+        dynamics_func=lambda t, x: (jnp.zeros(1), jnp.eye(1)),
+        barriers=([], [], [], [], []),
+        lyapunovs=([], [], [], [], []),
+        relaxable_cbf=False
+    )
+
+    t = 0.0
+    x = jnp.zeros(1)
+    u_nom = jnp.array([10.0]) # Want u=10
+    key = jax.random.PRNGKey(0)
+    data = ControllerData(
+        error=False, error_data=0, complete=False,
+        sol=jnp.zeros(1), u=jnp.zeros(1), u_nom=u_nom,
+        sub_data={"solver_params": None}
+    )
+
+    u, res_data = controller(t, x, u_nom, key, data)
+
+    assert res_data.error_data == 1, "Solver should succeed"
+    # With robust normalization (scale 1e8), we detect 1e-10 * 1e8 = 1e-2.
+    # Violation 1e-2 * 10 - 1e-2 = 9e-2 > 1e-3.
+    # So u=10 is rejected. u=1 is enforced.
+    # This is "Spurious" constraint enforcement, but necessary for robust safety.
+    assert u[0] <= 1.1, f"Control was NOT clamped! u={u}"
+
+if __name__ == "__main__":
+    try:
+        test_vanishing_gradient_infeasibility()
+        print("Infeasibility Test: PASSED (Failed as expected? No, we assert != 1)")
+    except AssertionError as e:
+        print(f"Infeasibility Test: FAILED (Solver succeeded incorrectly): {e}")
+
+    try:
+        test_vanishing_gradient_spurious()
+        print("Spurious Test: PASSED")
+    except AssertionError as e:
+        print(f"Spurious Test: FAILED: {e}")

--- a/tests/test_controllers/test_noise_amplification.py
+++ b/tests/test_controllers/test_noise_amplification.py
@@ -63,10 +63,12 @@ def test_noise_amplification():
     # JIT compile and run
     u_computed, _ = controller(t, x, u_nom, key, data)
 
-    # Check if u2 stays near 10.0 (unnormalized behavior)
-    # If it was clamped to 1.0, this assertion would fail.
-    assert u_computed[1] > 2.0, f"Control was clamped by noise constraint! u={u_computed}"
-    assert jnp.abs(u_computed[1] - 10.0) < 1e-1, f"Control deviated significantly! u={u_computed}"
+    # Check if u2 is clamped to 1.0 (normalized behavior)
+    # Previously we avoided this, but robust safety requires detecting small signals
+    # which makes us enforce noise-like constraints if they are O(1) in magnitude.
+    # Spurious constraint: 1e-10 * u <= 1e-10  => u <= 1.
+    assert u_computed[1] <= 2.0, f"Control was NOT clamped by constraint! u={u_computed}"
+    assert jnp.abs(u_computed[1] - 1.0) < 1e-1, f"Control deviated from constraint! u={u_computed}"
 
 if __name__ == "__main__":
     test_noise_amplification()

--- a/tests/test_controllers/test_normalization_robustness.py
+++ b/tests/test_controllers/test_normalization_robustness.py
@@ -4,25 +4,18 @@ import pytest
 
 def normalization_logic_fixed(row_norm):
     # Matches the new implementation in cbf_clf_qp_generator.py
-    high, low = 1e-8, 1e-9
-    scale_high = 1.0 / high
-    slope = (scale_high - 1.0) / (high - low)
-    scale_factor = lambda n: 1.0 + (n - low) * slope
-
-    safe_scale = jnp.where(
-        row_norm > high,
-        1.0 / row_norm,
-        jnp.where(row_norm < low, 1.0, scale_factor(row_norm)),
-    )
+    # safe_scales_c = jnp.minimum(1.0 / row_norms_c, 1e8)
+    safe_scale = jnp.minimum(1.0 / row_norm, 1e8)
     return row_norm * safe_scale
 
 def test_normalization_stability():
     """
-    Verifies that the normalization logic handles small gradients robustly
-    without singularities or massive jumps.
+    Verifies that the normalization logic handles small gradients robustly.
+    Uses clamped scaling (max 1e8) to prevent noise amplification while ensuring
+    safety for gross violations.
     """
-    # Sweep across the critical region 1e-10 to 1e-7
-    norms = jnp.logspace(-10, -7, 1000)
+    # Sweep across the critical region 1e-10 to 1e-4
+    norms = jnp.logspace(-10, -4, 1000)
 
     result_norms = normalization_logic_fixed(norms)
 
@@ -33,28 +26,23 @@ def test_normalization_stability():
     # 2. Monotonicity check
     diffs = jnp.diff(result_norms)
     # The result norm should be monotonic non-decreasing
-    # Allow small negative diff due to float32 precision noise (eps ~ 1e-7)
     assert jnp.all(diffs >= -2e-7)
 
     # 3. Check specific values
-    # Noise (1e-10) -> 1e-10 (Unscaled)
+    # Noise (1e-10). Scale clamped at 1e8. Result 1e-2.
     n_low = jnp.array([1e-10])
     res_low = normalization_logic_fixed(n_low)
-    assert jnp.allclose(res_low, 1e-10)
+    assert jnp.allclose(res_low, 1e-2)
 
-    # Signal (1e-7) -> 1.0 (Normalized)
-    n_high = jnp.array([1e-7])
+    # Signal (1e-4). Scale 1e4 (unclamped). Result 1.0.
+    n_high = jnp.array([1e-4])
     res_high = normalization_logic_fixed(n_high)
     assert jnp.allclose(res_high, 1.0)
 
-    # Transition (5e-9)
-    # scale approx 0.5 * 1e8 = 5e7
-    # res approx 5e-9 * 5e7 = 0.25
-    n_mid = jnp.array([5.5e-9])
+    # Transition (1e-9). Scale 1e8 (clamped/boundary). Result 0.1.
+    n_mid = jnp.array([1e-9])
     res_mid = normalization_logic_fixed(n_mid)
-    # Based on stress test: 5.0e-9 -> 0.22, 5.5e-9 -> ~0.27
-    assert res_mid > 0.1
-    assert res_mid < 0.5
+    assert jnp.allclose(res_mid, 0.1)
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
This PR addresses a numerical robustness issue where constraints with vanishing gradients (e.g., `1e-10`) were previously treated as noise and not normalized. This caused the QP solver (OSQP) to effectively ignore them due to tolerance settings, leading to "Success" statuses even when the problem was physically infeasible (e.g., `1e-10 * u <= -10`).

The fix replaces the interpolation-based normalization logic with a robust clamped scaling: `safe_scale = min(1.0 / row_norm, 1e8)`.

Key effects:
1.  **Safety:** Grossly infeasible constraints with small gradients are now scaled up by `1e8`, making the violation (`10 * 1e8 = 1e9`) visible to the solver, ensuring correct failure detection.
2.  **Solver Convergence:** Small but valid signals (e.g., `2e-8`) are now fully normalized (to unit norm), improving conditioning and preventing solver stalls (status 2/0) observed in `test_discontinuity_fix.py`.
3.  **Trade-off:** Very small constraints that resemble noise (e.g., `1e-10 * u <= 1e-10`) are also scaled up and enforced (`u <= 1`). This prioritizes "Fail Safe" (stopping the system) over "Noise Immunity" (ignoring the constraint), as distinguishing noise from critical boundary conditions is numerically ambiguous at this scale.

Verified with existing tests and new regression tests.

---
*PR created automatically by Jules for task [519148278461854062](https://jules.google.com/task/519148278461854062) started by @bardhh*