### PR TITLE
✉️ Hermes: Clear error message for invalid CertificateCollection inputs

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -54,6 +54,30 @@ from .generate_constraints import (
 )
 
 
+def _validate_certificate_collection(cert_collection: Any, name: str) -> None:
+    """Validates that the certificate collection has the expected structure."""
+    if cert_collection is None:
+        return
+
+    # Check if it's iterable
+    try:
+        iter(cert_collection)
+    except TypeError:
+        raise TypeError(
+            f"'{name}' must be a CertificateCollection (tuple/list of length 5), but got {type(cert_collection)}."
+        )
+
+    # Check length
+    if len(cert_collection) != 5:
+        raise ValueError(
+            f"Invalid structure for '{name}'. Expected a CertificateCollection with 5 elements "
+            "(functions, jacobians, hessians, partials, conditions), "
+            f"but got a collection of length {len(cert_collection)}. "
+            "Did you pass a list of barrier functions directly? You must provide the derivatives and conditions as well, "
+            "or use a helper like 'cbfkit.certificates.CertificateCollection'."
+        )
+
+
 def cbf_clf_qp_generator(
     generate_compute_cbf_constraints: GenerateComputeCertificateConstraintCallable,
     generate_compute_clf_constraints: GenerateComputeCertificateConstraintCallable,
@@ -154,6 +178,9 @@ def cbf_clf_qp_generator(
             barriers = EMPTY_CERTIFICATE_COLLECTION
         if lyapunovs is None:
             lyapunovs = EMPTY_CERTIFICATE_COLLECTION
+
+        _validate_certificate_collection(barriers, "barriers")
+        _validate_certificate_collection(lyapunovs, "lyapunovs")
 
         assert barriers is not None
         assert lyapunovs is not None

--- a/tests/test_controllers/test_cbf_clf_controllers/test_certificate_validation.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_certificate_validation.py
@@ -1,0 +1,42 @@
+
+import pytest
+import jax.numpy as jnp
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.controllers.cbf_clf.generate_constraints.zeroing_cbfs import generate_compute_zeroing_cbf_constraints
+from cbfkit.controllers.cbf_clf.generate_constraints.vanilla_clfs import generate_compute_vanilla_clf_constraints
+
+def test_certificate_validation_invalid_type():
+    """Test that passing a list instead of CertificateCollection raises ValueError."""
+    generator = cbf_clf_qp_generator(
+        generate_compute_zeroing_cbf_constraints,
+        generate_compute_vanilla_clf_constraints
+    )
+
+    def dynamics(x):
+        return jnp.zeros((2,)), jnp.zeros((2, 1))
+
+    # Should raise ValueError/TypeError because it's a list, not length 5 tuple-like
+    # Note: If it's a list of length 1, it hits the length check.
+    with pytest.raises(ValueError, match="Expected a CertificateCollection with 5 elements"):
+        generator(
+            control_limits=jnp.array([1.0]),
+            dynamics_func=dynamics,
+            barriers=[lambda t, x: 0.0]
+        )
+
+def test_certificate_validation_invalid_length():
+    """Test that passing a tuple of wrong length raises ValueError."""
+    generator = cbf_clf_qp_generator(
+        generate_compute_zeroing_cbf_constraints,
+        generate_compute_vanilla_clf_constraints
+    )
+
+    def dynamics(x):
+        return jnp.zeros((2,)), jnp.zeros((2, 1))
+
+    with pytest.raises(ValueError, match="but got a collection of length 1"):
+        generator(
+            control_limits=jnp.array([1.0]),
+            dynamics_func=dynamics,
+            barriers=([lambda t, x: 0.0],)
+        )


### PR DESCRIPTION
Implemented a developer experience improvement that validates the structure of `barriers` and `lyapunovs` arguments in `cbf_clf_qp_generator`. Previously, passing a list of functions (instead of a 5-element tuple/NamedTuple) would cause a confusing `ValueError: not enough values to unpack` deep in the call stack. The new validation raises a clear error message explaining that a `CertificateCollection` is expected and hinting at the likely mistake. Includes a new test file verifying the improved error handling.

---
*PR created automatically by Jules for task [7319508640415071284](https://jules.google.com/task/7319508640415071284) started by @bardhh*