### PR TITLE
⚙️ Flux: Cache uv dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       JAX_PLATFORM_NAME: cpu
+      UV_CACHE_DIR: /tmp/.uv-cache
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -21,6 +22,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache uv
+      uses: actions/cache@v4
+      with:
+        path: /tmp/.uv-cache
+        key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-uv-
     - name: Install dependencies
       env:
         UV_SYSTEM_PYTHON: 1


### PR DESCRIPTION
Implemented caching for `uv` in GitHub Actions to reduce installation time.
- Configured `UV_CACHE_DIR` to `/tmp/.uv-cache`.
- Added `actions/cache` step using `uv.lock` hash as key.
- Reduces network I/O and wheel building for dependencies like JAX and SciPy.

---
*PR created automatically by Jules for task [10241632483303012171](https://jules.google.com/task/10241632483303012171) started by @bardhh*