### PR TITLE
🧾 Piper: Enforce mandatory Control in ControllerCallable to prevent JIT errors

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -39,6 +39,7 @@ from cbfkit.utils.user_types import (
     CbfClfQpConfig,
     CbfClfQpGenerator,
     CertificateCollection,
+    Control,
     ControllerCallable,
     ControllerCallableReturns,
     ControllerData,
@@ -272,7 +273,7 @@ def cbf_clf_qp_generator(
         # ) -> ControllerCallableReturns:
         @jit
         def controller(
-            t: float, x: State, u_nom: Array, key: Key, data: ControllerData
+            t: float, x: State, u_nom: Control, key: Key, data: ControllerData
         ) -> ControllerCallableReturns:
             """JIT-compatible portion of the CBF-CLF-QP control law.
 

--- a/src/cbfkit/ros/controller_wrappers.py
+++ b/src/cbfkit/ros/controller_wrappers.py
@@ -37,7 +37,7 @@ def controller_wrapper(
     def wrapped_controller(
         t: Time,
         x: State,
-        u_nom: Optional[Control],
+        u_nom: Control,
         key: Key,
         data: ControllerData,
     ) -> ControllerCallableReturns:

--- a/src/cbfkit/ros2/controller_wrappers.py
+++ b/src/cbfkit/ros2/controller_wrappers.py
@@ -40,7 +40,7 @@ def controller_wrapper(
     def wrapped_controller(
         t: Time,
         x: State,
-        u_nom: Optional[Control],
+        u_nom: Control,
         key: Key,
         data: ControllerData,
     ) -> ControllerCallableReturns:

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -181,7 +181,7 @@ PerturbationCallable = Callable[[State, Control, Array, Array], PerturbationCall
 ControllerCallableReturns = Tuple[Array, ControllerData]
 
 ControllerCallable = Callable[
-    [Time, State, Optional[Control], Key, ControllerData], ControllerCallableReturns
+    [Time, State, Control, Key, ControllerData], ControllerCallableReturns
 ]
 
 NominalControllerCallable = Callable[[Time, State, Key, Optional[State]], ControllerCallableReturns]


### PR DESCRIPTION
Updated `ControllerCallable` in `src/cbfkit/utils/user_types.py` to require `Control` (Array) instead of `Optional[Control]`. This fixes a discrepancy where `cbf_clf_qp_generator` (JIT-compiled) expects a concrete array but the interface allowed `None`. Also updated `cbf_clf_qp_generator.py` and ROS wrappers to match the new signature. Verified with `mypy` and existing tests.

---
*PR created automatically by Jules for task [14503280553265937572](https://jules.google.com/task/14503280553265937572) started by @bardhh*