### PR TITLE
🚨 Sentinel: Accept MAX_ITER_REACHED (status 2) as valid QP solution

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -365,8 +365,12 @@ def cbf_clf_qp_generator(
             # QP solution already respects control limits via input constraints.
             # Only clip the fallback u_nom (which may exceed limits) to avoid
             # inadvertently violating CBF constraints on the QP-solved path.
+            # Sentinel: Accept SOLVED (1) or MAX_ITER_REACHED (2) as success.
+            # Status 2 means we ran out of time but have a candidate solution.
+            success = (status == 1) | (status == 2)
+
             u = lax.cond(
-                status == 1,
+                success,
                 # Bolt: Avoid jnp.array copy and reshape (sol is already 1D)
                 lambda _fake: sol[:n_con],
                 # Aegis: Return NaN if QP fails to make failure mode explicit.
@@ -379,12 +383,14 @@ def cbf_clf_qp_generator(
                 #! To Do: integrate RA-PI states
                 pass
 
-            error = lax.cond(status == 1, lambda _fake: False, lambda _fake: True, 0)
+            error = lax.cond(success, lambda _fake: False, lambda _fake: True, 0)
 
             # logging data
             final_sub_data = sub_data or {}
             final_sub_data["solver_params"] = new_params
             final_sub_data["solver_iter"] = iter_num
+            # Sentinel: Explicitly log solver status for diagnostics/warnings
+            final_sub_data["solver_status"] = status
 
             data = ControllerData(
                 error=error,

--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -101,6 +101,26 @@ def _check_simulation_status(
                 f"Warning: Simulation stopped early due to controller error at step {first_error_idx}{status_msg}."
             )
 
+    # Sentinel: Warn if solver hit MAX_ITER_REACHED (status 2) but was accepted
+    # We check 'sub_data_solver_status' (explicit) or 'error_data' (legacy/implicit)
+    status_key = None
+    if "sub_data_solver_status" in controller_data_keys:
+        status_key = "sub_data_solver_status"
+    elif "error_data" in controller_data_keys:
+        status_key = "error_data"
+
+    if status_key:
+        idx_data = controller_data_keys.index(status_key)
+        status_codes = controller_data_values[idx_data]
+        # Check for status 2 (MAX_ITER_REACHED)
+        max_iter_mask = status_codes == 2
+        if jnp.any(max_iter_mask):
+            count = int(jnp.sum(max_iter_mask).item())
+            print(
+                f"Warning: Solver reached max iterations in {count} steps. "
+                "Solutions were accepted but may be suboptimal."
+            )
+
     # Check planner errors
     if "error" in planner_data_keys:
         idx = planner_data_keys.index("error")


### PR DESCRIPTION
The QP solver returning status 2 (MAX_ITER_REACHED) was previously treated as a hard failure, causing the controller to output NaNs and stopping the simulation. This change accepts status 2 as a valid (though potentially suboptimal) solution, allowing the simulation to proceed, while adding a post-simulation warning to inform the user.


---
*PR created automatically by Jules for task [8375673286245176271](https://jules.google.com/task/8375673286245176271) started by @bardhh*