### PR TITLE
🧹 Curator: Lazy-load pandas in logger to reduce import time

### DIFF
--- a/src/cbfkit/utils/logger.py
+++ b/src/cbfkit/utils/logger.py
@@ -24,8 +24,6 @@ Examples
 import os
 from typing import Any, Dict, List, Union
 
-import pandas as pd
-
 LogEntry = Dict[str, Any]
 
 
@@ -48,6 +46,8 @@ def write_log(filepath: str, data: Union[List[LogEntry], Dict[str, Any]]) -> Non
         if filepath[-4] == ".":
             raise ValueError("filepath must have no extension, or have extension `.csv`")
         filepath += ".csv"
+
+    import pandas as pd
 
     df = pd.DataFrame.from_dict(data)
     df.to_csv(filepath)


### PR DESCRIPTION
Lazy-load pandas in logger.py to reduce import overhead

Moved `import pandas as pd` inside `write_log` function in `src/cbfkit/utils/logger.py`.
This prevents `pandas` from being loaded during package initialization (via `cbfkit.utils`), drastically reducing import time and memory usage for users who do not utilize the logging functionality.

Verification:
- Created and ran `verify_lazy_pandas.py` to confirm `pandas` is not in `sys.modules` after importing `cbfkit.utils`.
- Created and ran `verify_logging.py` to confirm `write_log` still functions correctly.
- Ran `pytest` to ensure no regressions.

---
*PR created automatically by Jules for task [7497399548098003051](https://jules.google.com/task/7497399548098003051) started by @bardhh*