### PR TITLE
⚡ Bolt: Optimize QP generator graph and clean up simulator JIT

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -238,6 +238,16 @@ def cbf_clf_qp_generator(
             kwargs["scale_cbf"] = scale_cbf
             kwargs["scale_clf"] = scale_clf
 
+        # Bolt: Pre-compute solution scaling vector to avoid repetitive slice updates in JIT loop
+        sol_scaling_vector = jnp.ones((n_con + n_bfs + n_lfs,))
+        if auto_p_mat:
+            if n_bfs > 0:
+                sol_scaling_vector = sol_scaling_vector.at[n_con : n_con + n_bfs].set(scale_cbf)
+            if n_lfs > 0:
+                sol_scaling_vector = sol_scaling_vector.at[n_con + n_bfs : n_con + n_bfs + n_lfs].set(
+                    scale_clf
+                )
+
         # Ensure p_mat is defined for the controller closure
         assert p_mat is not None
 
@@ -358,10 +368,7 @@ def cbf_clf_qp_generator(
 
             # Bolt: Rescale solution back to physical units
             if auto_p_mat:
-                if n_bfs > 0:
-                    sol = sol.at[n_con : n_con + n_bfs].multiply(scale_cbf)
-                if n_lfs > 0:
-                    sol = sol.at[n_con + n_bfs : n_con + n_bfs + n_lfs].multiply(scale_clf)
+                sol = sol * sol_scaling_vector
             # QP solution already respects control limits via input constraints.
             # Only clip the fallback u_nom (which may exceed limits) to avoid
             # inadvertently violating CBF constraints on the QP-solved path.

--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -209,17 +209,6 @@ def simulator_jit(
         planner_data_carry = planner_data._replace(sampled_x_traj=None)
         new_carry = (key, t_next, x_next, u, z, c, controller_data, planner_data_carry)
 
-        # Bolt: Filter solver_params from output to save memory/bandwidth
-        controller_data_log = controller_data
-        if (
-            controller_data.sub_data is not None
-            and "solver_params" in controller_data.sub_data
-        ):
-            new_sub_data = {
-                k: v for k, v in controller_data.sub_data.items() if k != "solver_params"
-            }
-            controller_data_log = controller_data._replace(sub_data=new_sub_data)
-
         # Output (trajectory)
         # Bolt: Strip solver_params from logged data to save memory
         log_controller_data = controller_data


### PR DESCRIPTION
This PR implements a performance optimization in the JAX computation graph for the CBF-CLF-QP controller and cleans up dead code in the JIT simulator loop.

### 💡 What
1.  **`src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py`**: Refactored the post-QP solution scaling logic. Instead of iteratively updating slices of the solution vector using `.at[...].multiply(...)`, we now pre-compute a scaling vector (ones + slack scales) outside the JIT closure and perform a single element-wise multiplication inside the loop.
2.  **`src/cbfkit/simulation/simulator_jit.py`**: Removed a block of dead code that created `controller_data_log` by filtering `solver_params`, but the result was immediately discarded and never used.

### 🎯 Why
-   **Graph Optimization**: The iterative slice updates (`at[].multiply`) generated multiple `scatter` primitives in the XLA computation graph. For high-frequency control loops, simplifying the graph reduces overhead and compilation complexity.
-   **Code Hygiene**: The dead code in `simulator_jit.py` was confusing and potentially misleading for future maintenance.

### 📊 Impact
-   **Graph Size**: Reduced `scatter` primitives in the controller graph from 4 to 3 (in benchmark config), and total equations from 400 to 396.
-   **Runtime**: Marginal improvement in execution per step due to fewer primitives, but primary benefit is cleaner graph and code.

###  microscope How measured
-   Created a micro-benchmark `tests/benchmarks/bolt_qp_generator_graph.py` (deleted after verification) that counts JAX primitives in the traced controller.
-   Measured reduction in Scatter primitives and total equations.
-   Ran on local dev environment.

### ✅ Correctness
-   Ran `tests/test_controllers/test_cbf_clf_controllers/` (all passed).
-   Ran `tests/test_simulation/test_simulator_jit_rk4.py` and `tests/test_simulation/test_control_loop.py` (all passed).
-   Verified that `sol_scaling_vector` logic mathematically matches the original slicing logic.


---
*PR created automatically by Jules for task [5427049714501018431](https://jules.google.com/task/5427049714501018431) started by @bardhh*