### PR TITLE
🧮 Janus: Robustify QP slack scaling for high penalties

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -215,14 +215,26 @@ def cbf_clf_qp_generator(
         if auto_p_mat:
             penalty_cbf = slack_penalty_cbf
             penalty_clf = slack_penalty_clf
-            scale_cbf = 1.0 / jnp.sqrt(penalty_cbf + 1e-8)
-            scale_clf = 1.0 / jnp.sqrt(penalty_clf + 1e-8)
+
+            # Janus: Robust scaling. Clamp penalty to avoid tiny scale factors (leading to ill-conditioned A).
+            # If penalty > 1e6, scale factor saturates at 1e-3.
+            # Transfer excess penalty to P matrix diagonal: weight = penalty * scale^2
+            max_penalty = 1e6
+            eff_penalty_cbf = jnp.minimum(penalty_cbf, max_penalty)
+            eff_penalty_clf = jnp.minimum(penalty_clf, max_penalty)
+
+            scale_cbf = 1.0 / jnp.sqrt(eff_penalty_cbf + 1e-8)
+            scale_clf = 1.0 / jnp.sqrt(eff_penalty_clf + 1e-8)
+
+            weight_cbf = penalty_cbf * (scale_cbf**2)
+            weight_clf = penalty_clf * (scale_clf**2)
+
             p_mat = jnp.diag(
                 jnp.hstack(
                     [
                         jnp.ones((n_con,)),
-                        jnp.ones((n_bfs,)),  # Normalized weight
-                        jnp.ones((n_lfs,)),  # Normalized weight
+                        weight_cbf * jnp.ones((n_bfs,)),  # Normalized weight
+                        weight_clf * jnp.ones((n_lfs,)),  # Normalized weight
                     ]
                 )
             )


### PR DESCRIPTION
Proposed Changes
----------------
1.  **Modified `src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py`**:
    *   Implemented logic to clamp the `scale_cbf` and `scale_clf` factors based on a maximum effective penalty (`1e6`).
    *   Updated the construction of `p_mat` to include weights (`residual_penalty`) for slack variables, ensuring the total cost remains `0.5 * penalty * slack^2`.

Verification
------------
*   **Stress Test**: Created `stress_slack_conditioning.py` (not checked in) to simulate a high-penalty (1e8) scenario. Verified that the solver now converges (Status 1) and satisfies constraints, whereas it previously returned Status 0 (Unsolved).
*   **Regression Tests**: Ran `tests/test_controllers/` and confirmed all passed, including `test_high_penalty_robustness.py`.


---
*PR created automatically by Jules for task [17569112169297403565](https://jules.google.com/task/17569112169297403565) started by @bardhh*