### PR TITLE
📦 Archivist: Fix Monte Carlo seeding for random and deterministic runs

### DIFF
--- a/src/cbfkit/simulation/monte_carlo.py
+++ b/src/cbfkit/simulation/monte_carlo.py
@@ -7,6 +7,7 @@ _map_function(args)
 conduct_monte_carlo(execute, n_trials, n_processes, **kwargs)
     Conducts a Monte Carlo simulation."""
 
+import inspect
 import multiprocessing as mp
 from typing import Callable, Optional
 import numpy as np
@@ -25,8 +26,24 @@ def _map_function(args):
     """
     func, trial_no, worker_seed, kwargs = args
 
-    # Inject JAX key if a seed was provided
+    # Seed global numpy random for legacy support and ensure diversity
     if worker_seed is not None:
+        # np.random.seed requires uint32
+        np.random.seed(int(worker_seed % (2**32)))
+
+    # Determine if we can inject JAX key
+    inject_key = False
+    if worker_seed is not None:
+        try:
+            sig = inspect.signature(func)
+            params = sig.parameters
+            if "key" in params or any(p.kind == p.VAR_KEYWORD for p in params.values()):
+                inject_key = True
+        except (ValueError, TypeError):
+            # Fallback: if we can't inspect, assume compliant with docstring (accepts kwargs)
+            inject_key = True
+
+    if inject_key and worker_seed is not None:
         kwargs = kwargs.copy()
         kwargs["key"] = random.PRNGKey(worker_seed)
 
@@ -55,16 +72,14 @@ def conduct_monte_carlo(
     """
     args_list = []
 
-    # Generate integer seeds for each trial if a base seed is provided
-    worker_seeds = [None] * n_trials
-    if seed is not None:
-        rng = np.random.default_rng(seed)
-        # Generate random integers safely within range for PRNGKey
-        worker_seeds = rng.integers(low=0, high=2**32 - 1, size=n_trials)
+    # Generate integer seeds for each trial
+    # If seed is None, we use entropy to ensure trials are different
+    rng = np.random.default_rng(seed)
+    # Generate random integers safely within range for PRNGKey
+    worker_seeds = rng.integers(low=0, high=2**32 - 1, size=n_trials)
 
     for trial_no in range(n_trials):
-        # We pass the worker_seed (int or None)
-        worker_seed = worker_seeds[trial_no] if seed is not None else None
+        worker_seed = worker_seeds[trial_no]
 
         # Note: We do NOT convert to JAX key here to avoid pickling issues with multiprocessing
         args_list.append((execute, trial_no, worker_seed, kwargs))

--- a/tests/test_simulation/test_monte_carlo_unit.py
+++ b/tests/test_simulation/test_monte_carlo_unit.py
@@ -36,5 +36,30 @@ class TestMonteCarloUnit(unittest.TestCase):
          # Same seed -> Same key
          self.assertTrue(jnp.array_equal(results1[0][1], results2[0][1]))
 
+    def test_unseeded_behavior_randomness(self):
+        # When seed is None, we expect different keys/results across trials
+        results = monte_carlo.conduct_monte_carlo(simple_func, n_trials=5, seed=None)
+        # results: list of (trial_no, key)
+
+        # Check that keys are not None (if simple_func accepts key)
+        # simple_func returns kwargs.get('key')
+
+        keys = [res[1] for res in results]
+
+        # Keys should be present (not None) because simple_func accepts **kwargs
+        for k in keys:
+            self.assertIsNotNone(k)
+
+        # Keys should be different
+        # Compare first two
+        self.assertFalse(jnp.array_equal(keys[0], keys[1]))
+
+        # Check all unique
+        # Convert to bytes for set hashing
+        # Note: keys are JAX arrays
+        import numpy as np
+        key_bytes = [np.array(k).tobytes() for k in keys]
+        self.assertEqual(len(set(key_bytes)), 5)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug in `conduct_monte_carlo` where unseeded runs (passing `seed=None`) resulted in identical trials because the underlying `simulator.execute` function defaulted to a fixed `PRNGKey(0)`.

The fix involves:
1. Always generating integer seeds for workers (using `np.random.default_rng(seed)` which falls back to OS entropy if `seed` is None).
2. Explicitly seeding the global `np.random` state in each worker process (using the generated worker seed) to support legacy/NumPy-based randomness.
3. Using `inspect.signature` to intelligently inject a JAX `PRNGKey` into the worker function's kwargs *only* if the function accepts it (or `**kwargs`), preventing crashes for functions that do not support JAX keys while ensuring those that do (like `sim.execute`) receive a unique key.
4. Adding a regression test to verify that unseeded runs produce distinct random keys/results.

---
*PR created automatically by Jules for task [15440291466700991361](https://jules.google.com/task/15440291466700991361) started by @bardhh*