### PR TITLE
🧾 Piper: Type stl_trajectory_cost and lax data inputs in simulator

### DIFF
--- a/src/cbfkit/simulation/backend.py
+++ b/src/cbfkit/simulation/backend.py
@@ -22,6 +22,7 @@ from cbfkit.utils.user_types import (
     PlannerData,
     SensorCallable,
     State,
+    StlTrajectoryCostCallable,
     Time,
 )
 
@@ -38,7 +39,7 @@ def stepper(
     perturbation: PerturbationCallable,
     sigma: Array,
     key: Key,
-    stl_trajectory_cost,
+    stl_trajectory_cost: Optional[StlTrajectoryCostCallable],
 ) -> Callable[
     [
         Time,

--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -17,7 +17,7 @@ Examples
 >>> run code
 """
 
-from typing import Any, Callable, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -39,6 +39,7 @@ from cbfkit.utils.user_types import (
     SensorCallable,
     SimulationResults,
     State,
+    StlTrajectoryCostCallable,
     Time,
 )
 
@@ -168,7 +169,7 @@ def simulator(
     sigma: Optional[Array],
     key: Array,
     callbacks: List[SimulationCallback] = [],
-    stl_trajectory_cost=None,
+    stl_trajectory_cost: Optional[StlTrajectoryCostCallable] = None,
 ) -> Callable[
     [Array, Optional[ControllerData], Optional[PlannerData]],
     Iterator[SimulationStepData],
@@ -341,10 +342,10 @@ def execute(
     key: Optional[Union[Array, None]] = None,
     filepath: Optional[str] = None,
     verbose: Optional[bool] = True,
-    controller_data: Optional[ControllerData] = None,
-    planner_data: Optional[PlannerData] = None,
+    controller_data: Optional[Union[ControllerData, Dict[str, Any]]] = None,
+    planner_data: Optional[Union[PlannerData, Dict[str, Any]]] = None,
     initial_covariance: Optional[Covariance] = None,
-    stl_trajectory_cost=None,
+    stl_trajectory_cost: Optional[StlTrajectoryCostCallable] = None,
     use_jit: bool = False,
     jit_progress: bool = False,
     jit_progress_interval: int = 50,

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -322,6 +322,7 @@ class ComputeCertificateConstraintFunctionGenerator(Protocol):
 # Miscellaneous
 
 # Cost function Callables
+StlTrajectoryCostCallable = Callable[[float, Array], Union[float, Array]]
 TrajectoryCostCallableReturns = Tuple[Array]
 TrajectoryCostCallable = Callable[[State, Control], TrajectoryCostCallableReturns]
 StageCostCallableReturns = Tuple[Array]


### PR DESCRIPTION
Piper mission: Typing improvement.

This PR adds a specific type alias `StlTrajectoryCostCallable` to `user_types.py` and uses it to type the `stl_trajectory_cost` argument in `simulator.py` and `backend.py`, which was previously untyped (implicit Any).

It also updates the `execute` function signature in `simulator.py` to correctly reflect that `controller_data` and `planner_data` can be initialized with dictionaries, preventing potential type checker confusion where the implementation explicitly handles dicts but the signature only claimed to support the NamedTuple types.

This improves type safety and clarity for simulation interfaces.


---
*PR created automatically by Jules for task [1731273840555564649](https://jules.google.com/task/1731273840555564649) started by @bardhh*