### PR TITLE
🏗️ Atlas: Simplify certificate creation with generate_certificate

### DIFF
--- a/src/cbfkit/certificates/__init__.py
+++ b/src/cbfkit/certificates/__init__.py
@@ -4,11 +4,12 @@ This module provides utilities for packaging, rectifying, and defining condition
 used throughout cbfkit.
 """
 
-from .packager import certificate_package, concatenate_certificates
+from .packager import certificate_package, concatenate_certificates, generate_certificate
 from .rectifiers import rectify_relative_degree
 
 __all__ = [
     "certificate_package",
     "concatenate_certificates",
     "rectify_relative_degree",
+    "generate_certificate",
 ]

--- a/src/cbfkit/certificates/packager.py
+++ b/src/cbfkit/certificates/packager.py
@@ -8,6 +8,7 @@ Functions
 ---------
 -certificate_package: packages the certificate function and its gradients. Supports automated
  differentiation if gradients/Hessians are not provided.
+-generate_certificate: simpler interface to create a CertificateCollection from a function.
 -concatenate_certificates: combines multiple certificate packages into usable form
 
 Notes
@@ -180,6 +181,135 @@ def certificate_package(
         )
 
     return package
+
+
+def generate_certificate(
+    certificate: Callable[..., Array],
+    certificate_conditions: CertificateConditionsCallable,
+    input_style: Union[
+        Literal["state", "separated"], CertificateInputStyle
+    ] = CertificateInputStyle.STATE,
+    certificate_grad: Optional[Callable[..., Array]] = None,
+    certificate_hess: Optional[Callable[..., Array]] = None,
+) -> CertificateCollection:
+    """Creates a CertificateCollection from a single function, automatically computing derivatives.
+
+    Unlike `certificate_package`, this function does not use the factory pattern and does not
+    require specifying the state dimension.
+
+    Args:
+        certificate: The certificate function h(x) or h(t, x).
+        certificate_conditions: Function defining the conditions (e.g. Class K).
+        input_style: Signature of the certificate function.
+            - "state" (default): certificate(x)
+            - "separated": certificate(t, x)
+        certificate_grad: Optional manual gradient function. If provided, must match input_style.
+        certificate_hess: Optional manual hessian function. If provided, must match input_style.
+
+    Returns:
+        CertificateCollection: A collection containing the function and its derivatives.
+    """
+    # Normalize input_style to enum
+    if isinstance(input_style, str):
+        try:
+            input_style = CertificateInputStyle(input_style)
+        except ValueError:
+            valid_styles = ["state", "separated"]
+            raise ValueError(
+                f"Invalid input_style '{input_style}' for generate_certificate. Must be one of {valid_styles}"
+            ) from None
+
+    if input_style == CertificateInputStyle.CONCATENATED:
+        raise ValueError(
+            "generate_certificate does not support 'concatenated' input style. "
+            "Use 'state' or 'separated', or use `certificate_package` instead."
+        )
+
+    # Wrap the certificate function to always accept (t, x)
+    if input_style == CertificateInputStyle.STATE:
+        # User provided h(x)
+        def v_func_canonical(t: float, x: Array) -> Array:
+            return certificate(x)
+
+        # Gradient w.r.t x
+        if certificate_grad is None:
+            grad_x = grad(certificate)
+
+            def j_func_canonical(t: float, x: Array) -> Array:
+                return grad_x(x)
+        else:
+            # Manual grad h(x)
+            def j_func_canonical(t: float, x: Array) -> Array:
+                return certificate_grad(x)  # type: ignore
+
+        # Hessian w.r.t x
+        if certificate_hess is None:
+            hess_x = hessian(certificate)
+
+            def h_func_canonical(t: float, x: Array) -> Array:
+                return hess_x(x)
+        else:
+            # Manual hess h(x)
+            def h_func_canonical(t: float, x: Array) -> Array:
+                return certificate_hess(x)  # type: ignore
+
+        # Partial w.r.t t (always 0 for state-only function)
+        def t_func_canonical(t: float, x: Array) -> Array:
+            return jnp.array(0.0)
+
+    else:
+        # User provided h(t, x)
+        def v_func_canonical(t: float, x: Array) -> Array:
+            return certificate(t, x)
+
+        # Gradient w.r.t x (arg 1)
+        if certificate_grad is None:
+            grad_x = grad(certificate, argnums=1)
+
+            def j_func_canonical(t: float, x: Array) -> Array:
+                return grad_x(t, x)
+        else:
+            # Manual grad h(t, x) w.r.t x?
+            # Convention: if manual grad is provided for h(t, x), it should return grad_x h(t, x)
+            # Or should it return full gradient? Let's assume it matches the auto-diff output: dh/dx.
+            def j_func_canonical(t: float, x: Array) -> Array:
+                return certificate_grad(t, x)  # type: ignore
+
+        # Hessian w.r.t x (arg 1)
+        if certificate_hess is None:
+            hess_x = hessian(certificate, argnums=1)
+
+            def h_func_canonical(t: float, x: Array) -> Array:
+                return hess_x(t, x)
+        else:
+            def h_func_canonical(t: float, x: Array) -> Array:
+                return certificate_hess(t, x)  # type: ignore
+
+        # Partial w.r.t t (arg 0)
+        # Note: If user provides manual grad, we still need partial t.
+        # Currently, if manual grad is provided, we assume partial t is handled separately or user only cared about x?
+        # CertificateCollection needs partials.
+        # If manual grad is provided, we can't infer partial t unless user provides it?
+        # For now, let's auto-diff partial t unless we add a `certificate_partial` argument.
+        # Let's keep it simple: always auto-diff partial t for now, as it's rarely manually optimized.
+        grad_t = grad(certificate, argnums=0)
+
+        def t_func_canonical(t: float, x: Array) -> Array:
+            return grad_t(t, x)
+
+    # JIT compile the canonical functions
+    v_jit = jit(v_func_canonical)
+    j_jit = jit(j_func_canonical)
+    h_jit = jit(h_func_canonical)
+    t_jit = jit(t_func_canonical)
+
+    return CertificateCollection(
+        [v_jit],
+        [j_jit],
+        [h_jit],
+        [t_jit],
+        [certificate_conditions],
+    )
 
 
 def concatenate_certificates(*tuples: CertificateCollection) -> CertificateCollection:

--- a/tests/test_certificates/test_generate_certificate.py
+++ b/tests/test_certificates/test_generate_certificate.py
@@ -1,0 +1,64 @@
+
+import jax.numpy as jnp
+from cbfkit.certificates.packager import generate_certificate
+from cbfkit.certificates.conditions.barrier_conditions import zeroing_barriers
+from cbfkit.utils.user_types import CertificateCollection
+
+def test_generate_certificate_state():
+    # h(x) = x[0] - 1
+    def h(x):
+        return x[0] - 1.0
+
+    # Conditions
+    conditions = zeroing_barriers.linear_class_k(1.0)
+
+    # Create certificate
+    coll = generate_certificate(h, conditions, input_style="state")
+
+    assert isinstance(coll, CertificateCollection)
+
+    # Test values
+    t = 0.0
+    x = jnp.array([2.0, 0.0])
+
+    # h(x) = 2 - 1 = 1
+    assert jnp.isclose(coll.functions[0](t, x), 1.0)
+
+    # grad(h) = [1, 0]
+    assert jnp.allclose(coll.jacobians[0](t, x), jnp.array([1.0, 0.0]))
+
+    # partial_t = 0
+    assert jnp.isclose(coll.partials[0](t, x), 0.0)
+
+def test_generate_certificate_separated():
+    # h(t, x) = x[0] - t
+    def h(t, x):
+        return x[0] - t
+
+    conditions = zeroing_barriers.linear_class_k(1.0)
+
+    coll = generate_certificate(h, conditions, input_style="separated")
+
+    t = 1.0
+    x = jnp.array([2.0, 0.0])
+
+    # h = 2 - 1 = 1
+    assert jnp.isclose(coll.functions[0](t, x), 1.0)
+
+    # grad_x = [1, 0]
+    assert jnp.allclose(coll.jacobians[0](t, x), jnp.array([1.0, 0.0]))
+
+    # partial_t = -1
+    assert jnp.isclose(coll.partials[0](t, x), -1.0)
+
+if __name__ == "__main__":
+    try:
+        test_generate_certificate_state()
+        print("test_generate_certificate_state passed")
+        test_generate_certificate_separated()
+        print("test_generate_certificate_separated passed")
+    except ImportError:
+        print("generate_certificate not yet implemented")
+    except Exception as e:
+        print(f"Tests failed: {e}")
+        raise


### PR DESCRIPTION
This PR introduces a `generate_certificate` helper function in `cbfkit.certificates`. This function simplifies the process of creating a `CertificateCollection` (which includes gradients, Hessians, etc.) from a simple user-defined function `h(x)` or `h(t, x)`. It automatically handles automatic differentiation using JAX and correctly shapes the outputs for the controller, removing the need for users to manually construct lists of derivatives or use the complex `certificate_package` factory when not necessary.


---
*PR created automatically by Jules for task [7085676941324253799](https://jules.google.com/task/7085676941324253799) started by @bardhh*