### PR TITLE
🧮 Janus: Robust relative degree detection

### DIFF
--- a/src/cbfkit/certificates/rectifiers.py
+++ b/src/cbfkit/certificates/rectifiers.py
@@ -65,6 +65,11 @@ from cbfkit.utils.user_types import (
 KEY = random.PRNGKey(0)
 KEY, SUBKEY = random.split(KEY)
 
+# Tolerance for determining if relative degree is reached.
+# If total absolute control authority over random samples is below this threshold,
+# we treat it as zero (effective relative degree is higher).
+RELATIVE_DEGREE_TOLERANCE = 1e-6
+
 
 def kwargs_wrapper(func: Callable) -> Callable:
     def wrapper(**kwargs):
@@ -240,7 +245,7 @@ def compute_function_list(
             "Encountered NaN during relative degree verification. Check your dynamics function and constraint function for numerical stability."
         )
 
-    if total == 0:
+    if total < RELATIVE_DEGREE_TOLERANCE:
         if form == "exponential":
             new_func = exponential_new_func
 

--- a/uv.lock
+++ b/uv.lock
@@ -215,14 +215,12 @@ name = "cbfkit"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
-    { name = "black" },
     { name = "casadi" },
     { name = "control" },
     { name = "cvxopt", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxopt" },
-    { name = "jinja2" },
     { name = "kvxopt", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64'" },
     { name = "matplotlib" },
     { name = "pandas" },
@@ -230,6 +228,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+codegen = [
+    { name = "black" },
+    { name = "jinja2" },
+]
 dev = [
     { name = "black" },
     { name = "cmake" },
@@ -258,7 +260,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", specifier = ">=23.12.1,<24.0" },
+    { name = "black", marker = "extra == 'codegen'", specifier = ">=23.12.1,<24.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.12.1,<24.0" },
     { name = "casadi", specifier = ">=3.6.4,<4.0" },
     { name = "cmake", marker = "extra == 'dev'", specifier = ">=3.28.1,<4.0" },
@@ -268,7 +270,7 @@ requires-dist = [
     { name = "jax", specifier = ">=0.4.23" },
     { name = "jaxlib", specifier = ">=0.4.23" },
     { name = "jaxopt", specifier = ">=0.8.3,<0.9" },
-    { name = "jinja2", specifier = ">=3.0.0" },
+    { name = "jinja2", marker = "extra == 'codegen'", specifier = ">=3.0.0" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0.0,<2.0" },
     { name = "kvxopt", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64'", specifier = ">=1.3.2.0,<2.0" },
     { name = "matplotlib", specifier = ">=3.8.2,<4.0" },
@@ -283,7 +285,7 @@ requires-dist = [
     { name = "setuptools", marker = "extra == 'dev'", specifier = ">=69.0.3,<70.0" },
     { name = "tqdm", specifier = ">=4.66.2,<5.0" },
 ]
-provides-extras = ["test", "dev"]
+provides-extras = ["codegen", "test", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Janus: Robust relative degree detection

Stress case: System with `h(x) = x1`, `x1_dot = x2 + eps*u` where `eps=1e-10`. 
Before: Identified as relative degree 1. QP constraint involved `1e-10 * u`, leading to extremely stiff/ill-conditioned control requirements.
After: Identifies as relative degree 2 (ignoring `eps`). QP constraint involves `u` with order 1 coefficient, restoring proper conditioning.

Change:
- Modified `src/cbfkit/certificates/rectifiers.py` to use `total < RELATIVE_DEGREE_TOLERANCE` (1e-6) instead of exact zero check.
- Added named constant `RELATIVE_DEGREE_TOLERANCE`.


---
*PR created automatically by Jules for task [3032796809039573067](https://jules.google.com/task/3032796809039573067) started by @bardhh*