### PR TITLE
📦 Archivist: Fix RNG correlation in Python simulation backend

### DIFF
--- a/src/cbfkit/simulation/backend.py
+++ b/src/cbfkit/simulation/backend.py
@@ -71,7 +71,7 @@ def stepper(
             planner_data = PlannerData()
 
         nonlocal key
-        key, subkey = random.split(key)  # type: ignore
+        key, _ = random.split(key)  # type: ignore
 
         if z is None:
             z = x
@@ -98,7 +98,8 @@ def stepper(
             planner_data = planner_data._replace(prev_robustness=None)
 
         if planner is not None:
-            u_planner, planner_data = planner(t, z, None, subkey, planner_data)  # type: ignore
+            key, planner_key = random.split(key)  # type: ignore
+            u_planner, planner_data = planner(t, z, None, planner_key, planner_data)
             if planner_data.error:
                 return (
                     x,
@@ -116,15 +117,18 @@ def stepper(
         elif planner_data.x_traj is not None:
             timestep_idx = jnp.round(t / dt).astype(int)
             timestep_idx = jnp.clip(timestep_idx, 0, planner_data.x_traj.shape[1] - 1)
-            u, _ = nominal_controller(t, z, subkey, planner_data.x_traj[:, timestep_idx])  # type: ignore
+            key, nom_key = random.split(key)  # type: ignore
+            u, _ = nominal_controller(t, z, nom_key, planner_data.x_traj[:, timestep_idx])
         else:
             if nominal_controller is None:
                 u = jnp.zeros((g.shape[1],))
             else:
-                u, _ = nominal_controller(t, z, subkey, None)  # type: ignore
+                key, nom_key = random.split(key)  # type: ignore
+                u, _ = nominal_controller(t, z, nom_key, None)
 
+        key, ctrl_key = random.split(key)  # type: ignore
         if controller is not None:
-            u, controller_data = controller(t, z, u, subkey, controller_data)  # type: ignore
+            u, controller_data = controller(t, z, u, ctrl_key, controller_data)
             if controller_data.error:
                 return (
                     x,

--- a/tests/test_simulation/test_rng_consistency.py
+++ b/tests/test_simulation/test_rng_consistency.py
@@ -1,0 +1,73 @@
+
+import jax.numpy as jnp
+from jax import random
+from cbfkit.simulation.simulator import execute
+from cbfkit.utils.user_types import ControllerData, PlannerData
+import pytest
+
+def dynamics(x):
+    return jnp.zeros_like(x), jnp.eye(len(x))
+
+def integrator(x, f, dt):
+    return x
+
+def test_rng_consistency_between_backends():
+    """
+    Verifies that the Python backend and JIT backend produce identical
+    sequences of random keys for Planners and Controllers given the same seed.
+    This also ensures that Planner and Controller receive different keys (no correlation).
+    """
+    x0 = jnp.zeros(2)
+    dt = 0.1
+    num_steps = 1
+
+    # Define components that capture the key
+    # We use the data return path to extract the key value from the opaque simulation loop
+
+    def planner(t, x, u_prev, key, data):
+        # Store key[1] in prev_robustness (must be Array for JIT compatibility)
+        return jnp.zeros(2), data._replace(prev_robustness=jnp.array(key[1], dtype=float))
+
+    def controller(t, x, u_nom, key, data):
+        # Store key[1] in u (must be Array for JIT compatibility)
+        return jnp.zeros(2), data._replace(u=jnp.array([key[1], 0.0], dtype=float))
+
+    # Initialize data structures for JIT structure matching
+    init_c_data = ControllerData(u=jnp.zeros(2))
+    init_p_data = PlannerData(prev_robustness=jnp.array(0.0, dtype=float))
+
+    # 1. Run JIT Backend (The "Golden" Reference)
+    results_jit = execute(
+        x0=x0, dt=dt, num_steps=num_steps,
+        dynamics=dynamics, integrator=integrator,
+        planner=planner, controller=controller,
+        controller_data=init_c_data,
+        planner_data=init_p_data,
+        use_jit=True, verbose=False
+    )
+
+    p_key_jit = float(results_jit.planner_data['prev_robustness'][0])
+    c_key_jit = float(results_jit.controller_data['u'][0][0])
+
+    # Assert independence
+    assert p_key_jit != c_key_jit, "JIT: Planner and Controller received the same key!"
+
+    # 2. Run Python Backend
+    results_py = execute(
+        x0=x0, dt=dt, num_steps=num_steps,
+        dynamics=dynamics, integrator=integrator,
+        planner=planner, controller=controller,
+        controller_data=init_c_data, # Pass init data for consistency, though optional for Python
+        planner_data=init_p_data,
+        use_jit=False, verbose=False
+    )
+
+    p_key_py = float(results_py.planner_data['prev_robustness'][0])
+    c_key_py = float(results_py.controller_data['u'][0][0])
+
+    # Assert independence
+    assert p_key_py != c_key_py, "Python: Planner and Controller received the same key!"
+
+    # Assert Consistency
+    assert p_key_py == p_key_jit, f"Planner keys differ! Py: {p_key_py}, JIT: {p_key_jit}"
+    assert c_key_py == c_key_jit, f"Controller keys differ! Py: {c_key_py}, JIT: {c_key_jit}"

--- a/uv.lock
+++ b/uv.lock
@@ -215,14 +215,12 @@ name = "cbfkit"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
-    { name = "black" },
     { name = "casadi" },
     { name = "control" },
     { name = "cvxopt", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxopt" },
-    { name = "jinja2" },
     { name = "kvxopt", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64'" },
     { name = "matplotlib" },
     { name = "pandas" },
@@ -230,6 +228,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+codegen = [
+    { name = "black" },
+    { name = "jinja2" },
+]
 dev = [
     { name = "black" },
     { name = "cmake" },
@@ -258,7 +260,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", specifier = ">=23.12.1,<24.0" },
+    { name = "black", marker = "extra == 'codegen'", specifier = ">=23.12.1,<24.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.12.1,<24.0" },
     { name = "casadi", specifier = ">=3.6.4,<4.0" },
     { name = "cmake", marker = "extra == 'dev'", specifier = ">=3.28.1,<4.0" },
@@ -268,7 +270,7 @@ requires-dist = [
     { name = "jax", specifier = ">=0.4.23" },
     { name = "jaxlib", specifier = ">=0.4.23" },
     { name = "jaxopt", specifier = ">=0.8.3,<0.9" },
-    { name = "jinja2", specifier = ">=3.0.0" },
+    { name = "jinja2", marker = "extra == 'codegen'", specifier = ">=3.0.0" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0.0,<2.0" },
     { name = "kvxopt", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64'", specifier = ">=1.3.2.0,<2.0" },
     { name = "matplotlib", specifier = ">=3.8.2,<4.0" },
@@ -283,7 +285,7 @@ requires-dist = [
     { name = "setuptools", marker = "extra == 'dev'", specifier = ">=69.0.3,<70.0" },
     { name = "tqdm", specifier = ">=4.66.2,<5.0" },
 ]
-provides-extras = ["test", "dev"]
+provides-extras = ["codegen", "test", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
The Python simulation backend was reusing the same random key for planner, nominal controller, and safety controller within a single timestep, causing correlated random behavior. This change aligns the RNG splitting logic with the JIT backend, ensuring independent random streams for each component and improving cross-backend reproducibility. A new test `tests/test_simulation/test_rng_consistency.py` was added to verify the fix and ensure future consistency.

---
*PR created automatically by Jules for task [15059305681361155448](https://jules.google.com/task/15059305681361155448) started by @bardhh*