### PR TITLE
🛡️ Aegis: Enforce consistent lengths in CertificateCollection

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -70,37 +70,53 @@ def _normalize_certificate_collection(
     if cert_collection is None:
         return EMPTY_CERTIFICATE_COLLECTION
 
+    collection = None
+
     # Case 1: Already a CertificateCollection
     if isinstance(cert_collection, CertificateCollection):
-        return cert_collection
+        collection = cert_collection
 
     # Case 2: List/Tuple of CertificateCollections (user passed [c1, c2] or [])
-    if isinstance(cert_collection, (list, tuple)):
+    elif isinstance(cert_collection, (list, tuple)):
         if len(cert_collection) == 0:
             return EMPTY_CERTIFICATE_COLLECTION
         if isinstance(cert_collection[0], CertificateCollection):
-            return concatenate_certificates(*cert_collection)
+            collection = concatenate_certificates(*cert_collection)
 
-    # Case 3: Raw tuple of length 5 (legacy structure: (funcs, jacs, hess, parts, conds))
-    # Check if it's iterable
-    try:
-        iter(cert_collection)
-    except TypeError:
-        raise TypeError(
-            f"'{name}' must be a CertificateCollection (tuple/list of length 5) or a list of them, but got {type(cert_collection)}."
-        )
+    if collection is None:
+        # Case 3: Raw tuple of length 5 (legacy structure: (funcs, jacs, hess, parts, conds))
+        # Check if it's iterable
+        try:
+            iter(cert_collection)
+        except TypeError:
+            raise TypeError(
+                f"'{name}' must be a CertificateCollection (tuple/list of length 5) or a list of them, but got {type(cert_collection)}."
+            )
 
-    # Check length
-    if len(cert_collection) != 5:
+        # Check length
+        if len(cert_collection) != 5:
+            raise ValueError(
+                f"Invalid structure for '{name}'. Expected a CertificateCollection with 5 elements "
+                "(functions, jacobians, hessians, partials, conditions), "
+                f"but got a collection of length {len(cert_collection)}. "
+                "Did you pass a list of barrier functions directly? You must provide the derivatives and conditions as well, "
+                "or use a helper like 'cbfkit.certificates.CertificateCollection'."
+            )
+
+        collection = CertificateCollection(*cert_collection)
+
+    # Validate component consistency
+    # Aegis: Ensure all component lists have the same length to prevent obscure JAX errors downstream.
+    lengths = [len(x) for x in collection]
+    if len(set(lengths)) > 1:
         raise ValueError(
-            f"Invalid structure for '{name}'. Expected a CertificateCollection with 5 elements "
-            "(functions, jacobians, hessians, partials, conditions), "
-            f"but got a collection of length {len(cert_collection)}. "
-            "Did you pass a list of barrier functions directly? You must provide the derivatives and conditions as well, "
-            "or use a helper like 'cbfkit.certificates.CertificateCollection'."
+            f"Inconsistent component lengths in '{name}'. "
+            f"All components (functions, jacobians, hessians, partials, conditions) must have the same length. "
+            f"Got lengths: functions={lengths[0]}, jacobians={lengths[1]}, hessians={lengths[2]}, "
+            f"partials={lengths[3]}, conditions={lengths[4]}."
         )
 
-    return CertificateCollection(*cert_collection)
+    return collection
 
 
 def cbf_clf_qp_generator(

--- a/tests/test_controllers/test_cbf_clf_controllers/test_certificate_validation.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_certificate_validation.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
 from cbfkit.controllers.cbf_clf.generate_constraints.zeroing_cbfs import generate_compute_zeroing_cbf_constraints
 from cbfkit.controllers.cbf_clf.generate_constraints.vanilla_clfs import generate_compute_vanilla_clf_constraints
+from cbfkit.utils.user_types import CertificateCollection
 
 def test_certificate_validation_invalid_type():
     """Test that passing a list instead of CertificateCollection raises ValueError."""
@@ -39,4 +40,26 @@ def test_certificate_validation_invalid_length():
             control_limits=jnp.array([1.0]),
             dynamics_func=dynamics,
             barriers=([lambda t, x: 0.0],)
+        )
+
+def test_certificate_validation_inconsistent_components():
+    """Test that passing a CertificateCollection with inconsistent list lengths raises ValueError."""
+    generator = cbf_clf_qp_generator(
+        generate_compute_zeroing_cbf_constraints,
+        generate_compute_vanilla_clf_constraints
+    )
+
+    def dynamics(x):
+        return jnp.zeros((2,)), jnp.zeros((2, 1))
+
+    # functions has 1 element, others have 0
+    inconsistent_barriers = CertificateCollection(
+        [lambda t, x: 0.0], [], [], [], []
+    )
+
+    with pytest.raises(ValueError, match="Inconsistent component lengths"):
+        generator(
+            control_limits=jnp.array([1.0]),
+            dynamics_func=dynamics,
+            barriers=inconsistent_barriers
         )

--- a/uv.lock
+++ b/uv.lock
@@ -215,14 +215,12 @@ name = "cbfkit"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
-    { name = "black" },
     { name = "casadi" },
     { name = "control" },
     { name = "cvxopt", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64'" },
     { name = "jax" },
     { name = "jaxlib" },
     { name = "jaxopt" },
-    { name = "jinja2" },
     { name = "kvxopt", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64'" },
     { name = "matplotlib" },
     { name = "pandas" },
@@ -230,6 +228,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+codegen = [
+    { name = "black" },
+    { name = "jinja2" },
+]
 dev = [
     { name = "black" },
     { name = "cmake" },
@@ -258,7 +260,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", specifier = ">=23.12.1,<24.0" },
+    { name = "black", marker = "extra == 'codegen'", specifier = ">=23.12.1,<24.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.12.1,<24.0" },
     { name = "casadi", specifier = ">=3.6.4,<4.0" },
     { name = "cmake", marker = "extra == 'dev'", specifier = ">=3.28.1,<4.0" },
@@ -268,7 +270,7 @@ requires-dist = [
     { name = "jax", specifier = ">=0.4.23" },
     { name = "jaxlib", specifier = ">=0.4.23" },
     { name = "jaxopt", specifier = ">=0.8.3,<0.9" },
-    { name = "jinja2", specifier = ">=3.0.0" },
+    { name = "jinja2", marker = "extra == 'codegen'", specifier = ">=3.0.0" },
     { name = "jupyter", marker = "extra == 'dev'", specifier = ">=1.0.0,<2.0" },
     { name = "kvxopt", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64'", specifier = ">=1.3.2.0,<2.0" },
     { name = "matplotlib", specifier = ">=3.8.2,<4.0" },
@@ -283,7 +285,7 @@ requires-dist = [
     { name = "setuptools", marker = "extra == 'dev'", specifier = ">=69.0.3,<70.0" },
     { name = "tqdm", specifier = ">=4.66.2,<5.0" },
 ]
-provides-extras = ["test", "dev"]
+provides-extras = ["codegen", "test", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Identified a correctness risk where `CertificateCollection` objects with inconsistent component list lengths (e.g., providing functions but missing derivatives) would cause obscure runtime/JIT errors deep in the stack (e.g., `ValueError: Need at least one array to stack`). 

Implemented strict validation in the controller generator to catch this issue early and raise a descriptive `ValueError`.

Added a new test case `test_certificate_validation_inconsistent_components` to verify the fix.

---
*PR created automatically by Jules for task [794306767540025137](https://jules.google.com/task/794306767540025137) started by @bardhh*