### PR TITLE
🔮 Oracle: Fix risk bound in path_integral_barrier to use one-sided inverse CDF

### DIFF
--- a/src/cbfkit/certificates/conditions/barrier_conditions/path_integral_barrier.py
+++ b/src/cbfkit/certificates/conditions/barrier_conditions/path_integral_barrier.py
@@ -59,7 +59,7 @@ def right_hand_side(
 ) -> Callable[[Array], Array]:
     """Generates function for computing RHS of barrier conditions for risk-aware path integral CBF:
 
-    Lh <= 1 - gamma - sqrt(2 * T) * eta * erfinv(1 - rho) + integral
+    Lh <= 1 - gamma - sqrt(2 * T) * eta * erfinv(1 - 2*rho) + integral
 
     where integral is the Lebesgue integral of the generator of h from 0 to the current time.
 
@@ -78,4 +78,4 @@ def right_hand_side(
     assert eta > 0
     assert 0 < time_period < jnp.inf
 
-    return lambda integral: 1 - gamma - jnp.sqrt(2 * time_period) * eta * erfinv(1 - rho) + integral
+    return lambda integral: 1 - gamma - jnp.sqrt(2 * time_period) * eta * erfinv(1 - 2 * rho) + integral

--- a/tests/test_path_integral_barrier_semantics.py
+++ b/tests/test_path_integral_barrier_semantics.py
@@ -1,0 +1,44 @@
+
+import pytest
+import jax.numpy as jnp
+from jax.scipy.special import erfinv
+from cbfkit.certificates.conditions.barrier_conditions.path_integral_barrier import right_hand_side
+
+def test_path_integral_barrier_risk_bound():
+    """
+    Verifies that right_hand_side(rho, ...) uses the correct inverse error function term
+    corresponding to a one-sided risk bound.
+
+    The expected term involves erfinv(1 - 2*rho), which corresponds to the standard normal
+    quantile for probability 1-rho (one-sided).
+
+    The previous implementation incorrectly used erfinv(1 - rho).
+    """
+    rho = 0.05
+    gamma = 0.5
+    eta = 1.0
+    time_period = 1.0
+
+    # Instantiate the function
+    # right_hand_side returns a callable that takes 'integral' as input
+    func = right_hand_side(rho, gamma, eta, time_period)
+
+    # Evaluate at integral = 0
+    integral_val = 0.0
+    result = func(integral_val)
+
+    # Expected calculation:
+    # 1 - gamma - sqrt(2*T) * eta * erfinv(1 - 2*rho) + integral
+    # We use 1 - 2*rho because for a one-sided risk constraint P(h < 0) <= rho,
+    # the bound is determined by Phi^{-1}(1-rho) = sqrt(2) * erfinv(1 - 2*rho).
+
+    expected_term = erfinv(1 - 2 * rho)
+    expected = 1 - gamma - jnp.sqrt(2 * time_period) * eta * expected_term + integral_val
+
+    # Allow small tolerance for floating point
+    assert jnp.isclose(result, expected), \
+        f"Expected {expected} (using erfinv(1-2rho)), but got {result}. " \
+        f"Value using erfinv(1-rho) would be {1 - gamma - jnp.sqrt(2 * time_period) * eta * erfinv(1 - rho)}"
+
+if __name__ == "__main__":
+    test_path_integral_barrier_risk_bound()


### PR DESCRIPTION
The `path_integral_barrier` module was calculating the risk bound term using `erfinv(1 - rho)`, which corresponds to a two-sided confidence interval for a one-sided risk constraint. This change updates it to `erfinv(1 - 2 * rho)`, aligning with the standard Gaussian risk bound derivation ($\Phi^{-1}(1-\rho)$) and the implementation in `risk_aware_cbfs.py`. A regression test `tests/test_path_integral_barrier_semantics.py` has been added.

---
*PR created automatically by Jules for task [6972974695253797185](https://jules.google.com/task/6972974695253797185) started by @bardhh*