### PR TITLE
📝 Scribe: Fix import paths in cbf_clf_qp_generator docstring

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -15,8 +15,8 @@ CBF-CLF-QP control laws.
 
 Examples
 --------
->>> from cbfkit.controllers.model_based.cbf_clf_controllers.cbf_clf_qp_generator import cbf_clf_qp_generator
->>> from cbfkit.controllers.model_based.cbf_clf_controllers.generate_constraints import (
+>>> from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+>>> from cbfkit.controllers.cbf_clf.generate_constraints import (
 >>>     generate_compute_zeroing_cbf_constraints,
 >>>     generate_compute_vanilla_clf_constraints,
 >>> )


### PR DESCRIPTION
Fixed incorrect import paths in the `cbf_clf_qp_generator.py` docstring example. The example was referencing a non-existent `model_based` module, likely from a previous version of the codebase. Updated to point to `cbfkit.controllers.cbf_clf`. Verified runnability with a script.

---
*PR created automatically by Jules for task [1149023616887587593](https://jules.google.com/task/1149023616887587593) started by @bardhh*