### PR TITLE
🔮 Oracle: Fix `a_s` docstring claiming "Exponential stability"

### DIFF
--- a/src/cbfkit/certificates/conditions/lyapunov_conditions/asymptotic_stability.py
+++ b/src/cbfkit/certificates/conditions/lyapunov_conditions/asymptotic_stability.py
@@ -58,7 +58,7 @@ from jax import Array
 
 
 def a_s() -> Callable[[Array], Array]:
-    """Generates function for computing RHS of Lyapunov conditions for Exponential stability:
+    """Generates function for computing RHS of Lyapunov conditions for Asymptotic stability:
 
     Vdot <= 0
 


### PR DESCRIPTION
Oracle: Fix incorrect stability type claim in `a_s` docstring.

Spec text vs behavior:
- `asymptotic_stability.py` function `a_s` claimed to implement "Exponential stability" in its docstring, contradicting its name (Asymptotic Stability) and the module description.
- Behavior (implementation) returns `Vdot <= 0`, which is consistent with weak Lyapunov stability (often used as a proxy for AS in CLF contexts), but definitely not exponential stability.

What changed:
- Updated the docstring of `a_s` to say "Asymptotic stability" instead of "Exponential stability".

Tests run:
- Verified with reproduction script that the docstring now claims "Asymptotic stability".
- Ran `pytest -q tests/test_certificates` (passed).

---
*PR created automatically by Jules for task [9589763153766834315](https://jules.google.com/task/9589763153766834315) started by @bardhh*