### PR TITLE
🧾 Piper: Add CbfClfQpData TypedDict for controller sub_data

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -26,7 +26,7 @@ Examples
 >>> )
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import jax.numpy as jnp
 import jax.debug as jdebug
@@ -39,6 +39,7 @@ from cbfkit.optimization.quadratic_program.qp_solver_jaxopt import (
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
     CbfClfQpConfig,
+    CbfClfQpData,
     CbfClfQpGenerator,
     CertificateCollection,
     Control,
@@ -428,8 +429,12 @@ def cbf_clf_qp_generator(
 
             # Solve QP
             solver_params = None
-            if data.sub_data is not None and "solver_params" in data.sub_data:
-                solver_params = data.sub_data["solver_params"]
+
+            # Cast sub_data to typed version for safe access
+            controller_sub_data = cast(CbfClfQpData, data.sub_data if data.sub_data is not None else {})
+
+            if "solver_params" in controller_sub_data:
+                solver_params = controller_sub_data["solver_params"]
 
             sol, status, new_params = solve_qp(
                 p_mat, q_vec, g_mat, h_vec, init_params=solver_params
@@ -487,7 +492,7 @@ def cbf_clf_qp_generator(
             error = lax.cond(success, lambda _fake: False, lambda _fake: True, 0)
 
             # logging data
-            final_sub_data = sub_data or {}
+            final_sub_data = cast(CbfClfQpData, sub_data or {})
             final_sub_data["solver_params"] = new_params
             final_sub_data["solver_iter"] = iter_num
             # Sentinel: Explicitly log solver status for diagnostics/warnings
@@ -500,7 +505,7 @@ def cbf_clf_qp_generator(
                 sol=jnp.array(sol),
                 u=u,
                 u_nom=u_nom,
-                sub_data=final_sub_data,
+                sub_data=cast(Dict[str, Any], final_sub_data),
             )
 
             return u, data

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -287,6 +287,22 @@ class CbfClfQpConfig(TypedDict, total=False):
     clf_complete_tol: float
 
 
+class CbfClfQpData(TypedDict, total=False):
+    """Data returned by CBF-CLF-QP controllers in sub_data.
+
+    Attributes:
+        solver_params (Tuple[Any, Any]): Tuple of (KKTSolution, OSQPState) from jaxopt.
+        solver_iter (Union[int, Array]): Number of iterations taken by the solver.
+        solver_status (Union[int, Array]): Exit status of the solver.
+        complete (bool): Whether the CLF task is complete.
+    """
+
+    solver_params: Tuple[Any, Any]
+    solver_iter: Union[int, Array]
+    solver_status: Union[int, Array]
+    complete: bool
+
+
 class CbfClfQpGenerator(Protocol):
     """Protocol for CBF-CLF-QP generator."""
 


### PR DESCRIPTION
This PR introduces a `TypedDict` named `CbfClfQpData` to formalize the structure of the `sub_data` dictionary used within `cbf_clf_qp_generator.py` and returned in `ControllerData`.

**Changes:**
- Added `CbfClfQpData` to `src/cbfkit/utils/user_types.py`.
- Updated `src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py` to cast `sub_data` to `CbfClfQpData` for internal logic and back to `Dict[str, Any]` for the return value.

**Benefits:**
- Explicit documentation of expected keys (`solver_params`, `solver_iter`, `solver_status`, `complete`).
- Better IDE autocompletion and type checking for controller internals.
- No runtime overhead.

---
*PR created automatically by Jules for task [17515704120069950377](https://jules.google.com/task/17515704120069950377) started by @bardhh*