### PR TITLE
⚙️ Flux: Fix broken tests and enable codegen CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         UV_SYSTEM_PYTHON: 1
       run: |
         pip install uv
-        uv pip install -e ".[test]"
+        uv pip install -e ".[test,codegen]"
     - name: Lint with ruff
       if: matrix.python-version == '3.10'
       env:

--- a/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
@@ -10,8 +10,8 @@ class TestQPSolverSafety(unittest.TestCase):
     def test_max_iter_safety(self):
         """
         Regression test: Verify handling of MAX_ITER_REACHED (status 2).
-        The controller currently accepts status 2 as success to prevent crashes,
-        relying on warnings for sub-optimality.
+        The controller treats status 2 as failure (unsafe to use unconverged result),
+        returning NaNs.
         """
 
         # 1. Setup simple controller
@@ -72,14 +72,14 @@ class TestQPSolverSafety(unittest.TestCase):
             u, new_data = controller(t, x, u_nom, key, data)
 
             # 5. Assertions
-            # The controller currently accepts status 2 as success.
-            # u should be zeros (from mock solution)
-            self.assertFalse(jnp.isnan(u).any(), f"Controller returned NaNs {u} for MAX_ITER status (should be accepted)!")
+            # The controller treats status 2 as failure.
+            # u should be NaNs
+            self.assertTrue(jnp.isnan(u).any(), f"Controller returned valid output {u} for MAX_ITER status (should be NaNs)!")
 
-            # Error flag should be False (success)
-            self.assertFalse(new_data.error, "Controller reported error for status 2!")
+            # Error flag should be True (failure)
+            self.assertTrue(new_data.error, "Controller failed to report error for status 2!")
 
-            # Error data should capture the status code 2 (even if successful, it stores status)
+            # Error data should capture the status code 2
             self.assertEqual(new_data.error_data, 2, f"Controller reported wrong status: {new_data.error_data}")
 
 if __name__ == '__main__':

--- a/tests/test_models/test_model_generation.py
+++ b/tests/test_models/test_model_generation.py
@@ -28,6 +28,11 @@ import unittest
 import unittest.mock
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import pytest
+
+# Skip if jinja2 is not available (part of optional codegen dependencies)
+pytest.importorskip("jinja2")
+
 from cbfkit.codegen.create_new_system.generate_model import generate_model
 
 


### PR DESCRIPTION
This PR addresses CI reliability issues by fixing broken tests and ensuring necessary dependencies are installed in the CI environment.

### Changes
- **Tests**: `tests/test_models/test_model_generation.py` now uses `pytest.importorskip("jinja2")`. This prevents test collection failures on environments without `jinja2`, while still allowing the test to run when dependencies are present.
- **Tests**: `tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py` was updated to assert that `MAX_ITER_REACHED` status returns NaNs. The previous assertion (expecting success) was stale and contradicted the safety-critical design of the controller.
- **CI**: `.github/workflows/ci.yml` was updated to install `.[test,codegen]` dependencies. This ensures that the code generation tests (which depend on `jinja2`) are actually executed in CI, improving coverage.

### Impact
- CI signal is now green and reliable.
- Code generation features are now verified in CI.
- Incorrect test assumptions about solver safety are corrected.

---
*PR created automatically by Jules for task [17539265025561979578](https://jules.google.com/task/17539265025561979578) started by @bardhh*