### PR TITLE
🏗️ Atlas: Support scalar control limits in CBF-CLF-QP

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -154,7 +154,8 @@ def cbf_clf_qp_generator(
         """Produces the function to deploy a CBF-CLF-QP control law.
 
         Args:
-            control_limits (Array): symmetric actuation constraints [u1_bar, u2_bar, etc.]
+            control_limits (Array): symmetric actuation constraints [u1_bar, u2_bar, etc.].
+                Can be a scalar for 1D systems.
             dynamics_func (DynamicsCallable): function to compute dynamics based on current state
             barriers (CertificateCollection | List[CertificateCollection]): collection of barrier functions,
                 gradients, hessians, dh/dt, conditions. Can be a single collection or a list of them.
@@ -186,6 +187,9 @@ def cbf_clf_qp_generator(
                 "slack_penalty_clf": slack_penalty_clf,
             }
         )
+
+        # Atlas: Support scalar inputs for 1D systems
+        control_limits = jnp.atleast_1d(jnp.asarray(control_limits))
 
         # Validate configuration to prevent silent failures (e.g., NaNs from negative penalties)
         if slack_penalty_cbf < 0:


### PR DESCRIPTION
This PR improves the `cbf_clf_qp_generator` to robustly handle scalar inputs for `control_limits`.

Previously, passing a scalar (e.g., `1.0`) or a 0-d JAX array would cause a crash because `len()` was called on it. Users were forced to wrap scalar limits in a list or array (e.g., `[1.0]`).

Changes:
- Automatically converts `control_limits` to at least a 1D array using `jnp.atleast_1d`.
- Updates docstring to explicitly state that scalars are allowed for 1D systems.

Verified with a reproduction script (`tests/repro_scalar_limits.py`, now deleted) and existing regression tests.

---
*PR created automatically by Jules for task [18252291406279483784](https://jules.google.com/task/18252291406279483784) started by @bardhh*