### PR TITLE
✉️ Hermes: Improve CBF-CLF-QP failure reporting and fix safety test

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -454,20 +454,36 @@ def cbf_clf_qp_generator(
             # Status 2 (MAX_ITER) or 5 (MAX_ITER_UNSOLVED) means potentially unconverged/unsafe solution.
             success = status == 1
 
-            def _print_failure(status, iter_num):
-                jdebug.print(
-                    "⚠️ CBF-CLF-QP Failed! Status: {status} (Iter: {iter}). Output set to NaN.",
-                    status=status,
-                    iter=iter_num,
+            def _print_failure(status, iter_num, sub_data):
+                msg = "⚠️ CBF-CLF-QP Failed! Status: {status} (Iter: {iter}). Output set to NaN."
+
+                # Check for CBF values in sub_data (static check on pytree structure)
+                if "bfs" in sub_data:
+                    min_h = jnp.min(sub_data["bfs"])
+                    jdebug.print(
+                        msg + " Min CBF: {min_h}",
+                        status=status,
+                        iter=iter_num,
+                        min_h=min_h,
+                    )
+                else:
+                    jdebug.print(msg, status=status, iter=iter_num)
+
+                # Hint for Status 5
+                lax.cond(
+                    status == 5,
+                    lambda: jdebug.print("  ↳ Hint: Status 5 (MAX_ITER_UNSOLVED) often means the QP is infeasible."),
+                    lambda: None,
                 )
 
             # Debug hook: Print failure details if solver failed
             lax.cond(
                 success,
-                lambda *_: None,
+                lambda _s, _i, _d: None,
                 _print_failure,
                 status,
                 iter_num,
+                sub_data,
             )
 
             u = lax.cond(

--- a/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
@@ -10,8 +10,8 @@ class TestQPSolverSafety(unittest.TestCase):
     def test_max_iter_safety(self):
         """
         Regression test: Verify handling of MAX_ITER_REACHED (status 2).
-        The controller currently accepts status 2 as success to prevent crashes,
-        relying on warnings for sub-optimality.
+        The controller currently treats status 2 as failure to ensure safety,
+        returning NaNs.
         """
 
         # 1. Setup simple controller
@@ -72,14 +72,14 @@ class TestQPSolverSafety(unittest.TestCase):
             u, new_data = controller(t, x, u_nom, key, data)
 
             # 5. Assertions
-            # The controller currently accepts status 2 as success.
-            # u should be zeros (from mock solution)
-            self.assertFalse(jnp.isnan(u).any(), f"Controller returned NaNs {u} for MAX_ITER status (should be accepted)!")
+            # The controller currently treats status 2 (MAX_ITER) as failure (safe behavior).
+            # u should be NaNs
+            self.assertTrue(jnp.isnan(u).any(), f"Controller returned valid output {u} for MAX_ITER status (should be rejected)!")
 
-            # Error flag should be False (success)
-            self.assertFalse(new_data.error, "Controller reported error for status 2!")
+            # Error flag should be True (failure)
+            self.assertTrue(new_data.error, "Controller did not report error for status 2!")
 
-            # Error data should capture the status code 2 (even if successful, it stores status)
+            # Error data should capture the status code 2
             self.assertEqual(new_data.error_data, 2, f"Controller reported wrong status: {new_data.error_data}")
 
 if __name__ == '__main__':


### PR DESCRIPTION
Improved the error message for CBF-CLF-QP solver failures by including the minimum CBF value and a hint for status 5. Also corrected a regression test (`test_qp_solver_safety.py`) that was incorrectly asserting success for MAX_ITER status, whereas the code enforces failure for safety.

---
*PR created automatically by Jules for task [1004036997623017421](https://jules.google.com/task/1004036997623017421) started by @bardhh*