### PR TITLE
🔧 Forge: modernizes license metadata in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,8 @@ authors = [
     {name = "Georgios Fainekos"},
     {name = "Hideki Okamoto"}
 ]
-license = { file = "LICENSE" }
+license = "BSD-3-Clause"
 classifiers = [
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Updated `pyproject.toml` to fix `setuptools` deprecation warnings by using an SPDX license identifier and removing the redundant License classifier. Verified that the build is clean and artifacts remain correct.

---
*PR created automatically by Jules for task [4898290403386142287](https://jules.google.com/task/4898290403386142287) started by @bardhh*