### PR TITLE
🧾 Piper: Type `ControllerData.error_data` as `int | Array`

### DIFF
--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -62,7 +62,7 @@ class ControllerData(NamedTuple):
     """Data structure for controller output."""
 
     error: bool = False
-    error_data: Any = None
+    error_data: Optional[Union[int, Array]] = None
     complete: bool = False
     sol: Optional[Array] = None
     u: Optional[Array] = None


### PR DESCRIPTION
Piper 🧾 has updated `ControllerData` in `src/cbfkit/utils/user_types.py`.

**Improvement:**
- Typed `error_data` as `Optional[Union[int, Array]]` instead of `Any`.

**Why:**
- `error_data` is used to propagate solver status codes (integers) or arrays of status codes (in vmapped contexts).
- Explicit typing prevents assigning invalid data types to this field and improves code clarity/documentation.

**Verification:**
- Validated that existing code (e.g. `cbf_clf_qp_generator.py`) complies with the new type.
- Ran existing tests `tests/test_controllers/test_cbf_clf_controllers/test_cbf_clf_qp_controllers.py` to ensure no runtime regressions.


---
*PR created automatically by Jules for task [8579199596450858902](https://jules.google.com/task/8579199596450858902) started by @bardhh*