### PR TITLE
📦 Archivist: deterministic UKF example config

### DIFF
--- a/examples/van_der_pol/common/config.py
+++ b/examples/van_der_pol/common/config.py
@@ -49,9 +49,10 @@ class UKFEstimationConfig:
     x_max = 5.0
     y_max = 5.0
     # Note: These random values are generated once at import time
-    x_rand = np.random.uniform(low=-x_max, high=x_max)
-    y_rand = np.random.uniform(low=-y_max, high=y_max)
-    a_rand = np.random.uniform(low=-jnp.pi, high=jnp.pi)
+    rng = np.random.default_rng(0)
+    x_rand = rng.uniform(low=-x_max, high=x_max)
+    y_rand = rng.uniform(low=-y_max, high=y_max)
+    a_rand = rng.uniform(low=-jnp.pi, high=jnp.pi)
     initial_state = jnp.array([x_rand, y_rand, a_rand])
     desired_state = jnp.array([0.0, 0.0, 0])
     Q = 0.5 * jnp.eye(len(initial_state))

--- a/tests/test_config_reproducibility.py
+++ b/tests/test_config_reproducibility.py
@@ -1,0 +1,27 @@
+import sys
+import importlib
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+def test_ukf_config_reproducibility():
+    """Test that UKFEstimationConfig in examples.van_der_pol.common.config is deterministic."""
+
+    # First import
+    if "examples.van_der_pol.common.config" in sys.modules:
+        del sys.modules["examples.van_der_pol.common.config"]
+
+    import examples.van_der_pol.common.config as config1
+    val1 = config1.ukf_state_estimation.initial_state
+
+    # Second import (reload)
+    # We must delete the module from sys.modules to force re-execution of the module body
+    del sys.modules["examples.van_der_pol.common.config"]
+    del config1
+
+    import examples.van_der_pol.common.config as config2
+    val2 = config2.ukf_state_estimation.initial_state
+
+    # Use explicit assertion failure message
+    np.testing.assert_array_equal(val1, val2,
+                                  err_msg="Config initial_state should be deterministic across reloads")


### PR DESCRIPTION
Repro steps:
1. Run `import examples.van_der_pol.common.config`
2. Inspect `config.ukf_state_estimation.initial_state`
3. Reload module and inspect again.

Before behavior:
`initial_state` changes on every reload/import because `np.random.uniform` is called at module level using the global random state.

After behavior:
`initial_state` is consistent across reloads because `np.random.default_rng(0)` is used to generate the values.

---
*PR created automatically by Jules for task [4414352862021847584](https://jules.google.com/task/4414352862021847584) started by @bardhh*