### PR TITLE
✉️ Hermes: Improve NaN failure reporting in CBF-CLF-QP

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -451,7 +451,8 @@ def cbf_clf_qp_generator(
 
             # Sentinel: Explicitly catch NaN solutions even if solver claims success
             # Also catch if inputs were NaN (solver might return 0 and UNSOLVED status 0)
-            status = jnp.where(jnp.any(jnp.isnan(sol)) | nan_in_inputs, -1, status)
+            status = jnp.where(jnp.any(jnp.isnan(sol)), -1, status)
+            status = jnp.where(nan_in_inputs, -2, status)
 
             # Bolt: Rescale solution back to physical units
             if auto_p_mat:
@@ -464,11 +465,21 @@ def cbf_clf_qp_generator(
             success = status == 1
 
             def _print_failure(status, iter_num, sub_data):
-                jdebug.print(
-                    "⚠️ CBF-CLF-QP Failed! Status: {status} (Iter: {iter}). Output set to NaN.",
-                    status=status,
-                    iter=iter_num,
-                )
+                def _print_generic():
+                    jdebug.print(
+                        "⚠️ CBF-CLF-QP Failed! Status: {status} (Iter: {iter}). Output set to NaN.",
+                        status=status,
+                        iter=iter_num,
+                    )
+
+                def _print_nan_input():
+                    jdebug.print(
+                        "⚠️ CBF-CLF-QP Failed! NaN detected in QP inputs (dynamics or certificates). Status: {status}. Output set to NaN.",
+                        status=status,
+                    )
+
+                lax.cond(status == -2, _print_nan_input, _print_generic)
+
                 if "bfs" in sub_data:
                     jdebug.print("   -> Barrier Values (h): {h}", h=sub_data["bfs"])
                 if "lfs" in sub_data:

--- a/tests/test_controllers/test_cbf_clf_controllers/test_nan_input_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_nan_input_safety.py
@@ -52,9 +52,9 @@ class TestNanInputSafety(unittest.TestCase):
         # 1. Output must be NaN (Fail-Loud)
         self.assertTrue(jnp.isnan(u).all(), f"Controller returned non-NaN value {u} for NaN input. Expected NaNs.")
 
-        # 2. Status code should be -1 (NAN_DETECTED)
+        # 2. Status code should be -2 (NAN_INPUT_DETECTED)
         # This confirms the specific "Sentinel" logic in cbf_clf_qp_generator is active
-        self.assertEqual(data.error_data, -1, f"Controller returned status {data.error_data} instead of -1 for NaN input.")
+        self.assertEqual(data.error_data, -2, f"Controller returned status {data.error_data} instead of -2 for NaN input.")
 
         # 3. Error flag should be True (since status != 1 and != 2)
         self.assertTrue(data.error, "Controller failed to report error for NaN input.")


### PR DESCRIPTION
Improved debuggability for CBF-CLF-QP controllers by introducing a specific status code and error message for NaN inputs.

---
*PR created automatically by Jules for task [17283133716516758272](https://jules.google.com/task/17283133716516758272) started by @bardhh*