### PR TITLE
🚨 Sentinel: Explicit QP Failure Status & Spam Suppression

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -58,9 +58,7 @@ from .generate_constraints import (
 )
 
 
-def _normalize_certificate_collection(
-    cert_collection: Any, name: str
-) -> CertificateCollection:
+def _normalize_certificate_collection(cert_collection: Any, name: str) -> CertificateCollection:
     """Validates and normalizes certificate collection structure.
 
     Accepts:
@@ -139,8 +137,12 @@ def cbf_clf_qp_generator(
     def generate_cbf_clf_controller(
         control_limits: Array,
         dynamics_func: DynamicsCallable,
-        barriers: Optional[Union[CertificateCollection, List[CertificateCollection]]] = EMPTY_CERTIFICATE_COLLECTION,
-        lyapunovs: Optional[Union[CertificateCollection, List[CertificateCollection]]] = EMPTY_CERTIFICATE_COLLECTION,
+        barriers: Optional[
+            Union[CertificateCollection, List[CertificateCollection]]
+        ] = EMPTY_CERTIFICATE_COLLECTION,
+        lyapunovs: Optional[
+            Union[CertificateCollection, List[CertificateCollection]]
+        ] = EMPTY_CERTIFICATE_COLLECTION,
         p_mat: Optional[Union[Array, None]] = None,
         *,
         relaxable_clf: bool = True,
@@ -327,9 +329,9 @@ def cbf_clf_qp_generator(
             if n_bfs > 0:
                 sol_scaling_vector = sol_scaling_vector.at[n_con : n_con + n_bfs].set(scale_cbf)
             if n_lfs > 0:
-                sol_scaling_vector = sol_scaling_vector.at[n_con + n_bfs : n_con + n_bfs + n_lfs].set(
-                    scale_clf
-                )
+                sol_scaling_vector = sol_scaling_vector.at[
+                    n_con + n_bfs : n_con + n_bfs + n_lfs
+                ].set(scale_clf)
 
         # Ensure p_mat is defined for the controller closure
         assert p_mat is not None
@@ -429,13 +431,17 @@ def cbf_clf_qp_generator(
             h_vec = jnp.hstack([h_vec_u, h_vec_c])
 
             # Sentinel: Detect NaNs in QP inputs
-            nan_in_inputs = jnp.any(jnp.isnan(q_vec)) | jnp.any(jnp.isnan(g_mat)) | jnp.any(jnp.isnan(h_vec))
+            nan_in_inputs = (
+                jnp.any(jnp.isnan(q_vec)) | jnp.any(jnp.isnan(g_mat)) | jnp.any(jnp.isnan(h_vec))
+            )
 
             # Solve QP
             solver_params = None
 
             # Cast sub_data to typed version for safe access
-            controller_sub_data = cast(CbfClfQpData, data.sub_data if data.sub_data is not None else {})
+            controller_sub_data = cast(
+                CbfClfQpData, data.sub_data if data.sub_data is not None else {}
+            )
 
             if "solver_params" in controller_sub_data:
                 solver_params = controller_sub_data["solver_params"]
@@ -464,21 +470,45 @@ def cbf_clf_qp_generator(
             success = status == 1
 
             def _print_failure(status, iter_num, sub_data):
-                jdebug.print(
-                    "⚠️ CBF-CLF-QP Failed! Status: {status} (Iter: {iter}). Output set to NaN.",
-                    status=status,
-                    iter=iter_num,
+                # Sentinel: Map status codes to human-readable strings
+                def print_status_msg(msg):
+                    jdebug.print(
+                        "⚠️ CBF-CLF-QP Failed! Status: {status} ({msg}) (Iter: {iter}). Output set to NaN.",
+                        status=status,
+                        msg=msg,
+                        iter=iter_num,
+                    )
+
+                lax.switch(
+                    status + 1,  # Map -1 to index 0
+                    [
+                        lambda: print_status_msg("NAN_DETECTED"),  # -1
+                        lambda: print_status_msg("UNSOLVED"),  # 0
+                        lambda: jdebug.print(
+                            "⚠️ CBF-CLF-QP Succeeded (Unexpected failure call). Status: {status}",
+                            status=status,
+                        ),  # 1 (Should not happen)
+                        lambda: print_status_msg("MAX_ITER_REACHED"),  # 2
+                        lambda: print_status_msg("PRIMAL_INFEASIBLE"),  # 3
+                        lambda: print_status_msg("DUAL_INFEASIBLE"),  # 4
+                        lambda: print_status_msg("MAX_ITER_UNSOLVED"),  # 5
+                    ],
                 )
+
                 if "bfs" in sub_data:
                     jdebug.print("   -> Barrier Values (h): {h}", h=sub_data["bfs"])
                 if "lfs" in sub_data:
                     jdebug.print("   -> Lyapunov Values (V): {V}", V=sub_data["lfs"])
 
-            # Debug hook: Print failure details if solver failed
+            # Sentinel: Only print failure if we weren't already in error state
+            prev_error = data.error if data.error is not None else jnp.array(False)
+            should_print = (success == False) & (prev_error == False)
+
+            # Debug hook: Print failure details if solver failed AND it's a new failure
             lax.cond(
-                success,
-                lambda *_: None,
+                should_print,
                 _print_failure,
+                lambda *_: None,
                 status,
                 iter_num,
                 sub_data,

--- a/tests/test_controllers/test_cbf_clf_controllers/test_failure_handling.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_failure_handling.py
@@ -1,0 +1,71 @@
+import jax.numpy as jnp
+import pytest
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.controllers.cbf_clf.generate_constraints import (
+    generate_compute_zeroing_cbf_constraints,
+    generate_compute_vanilla_clf_constraints,
+)
+from cbfkit.utils.user_types import CertificateCollection, ControllerData
+
+
+def test_qp_solver_failure_handling():
+    """Test that the controller handles QP failures correctly (UNSOLVED/Infeasible)."""
+
+    # 1. Trivial Dynamics (1D)
+    def dynamics(x):
+        return jnp.array([0.0]), jnp.array([[1.0]])
+
+    # 2. Infeasible CBF: h(x) = -1 (always unsafe)
+    def cbf(t, x):
+        return -1.0  # scalar
+
+    def cbf_grad(t, x):
+        return jnp.array([0.0])
+
+    def cbf_hess(t, x):
+        return jnp.array([[0.0]])
+
+    def cbf_partial(t, x):
+        return 0.0
+
+    def cbf_cond(val):
+        return val  # alpha(h) = h. So -1.
+
+    barriers = CertificateCollection([cbf], [cbf_grad], [cbf_hess], [cbf_partial], [cbf_cond])
+
+    # 3. Controller
+    setup_controller = cbf_clf_qp_generator(
+        generate_compute_zeroing_cbf_constraints,
+        generate_compute_vanilla_clf_constraints,
+    )
+
+    controller = setup_controller(
+        control_limits=jnp.array([1.0]),
+        dynamics_func=dynamics,
+        barriers=barriers,
+        slack_bound_cbf=1e-3,
+        relaxable_cbf=False,
+    )
+
+    # 4. Execute one step
+    t = 0.0
+    x = jnp.array([0.0])
+    u_nom = jnp.array([0.0])
+    key = jnp.array([0, 0], dtype=jnp.uint32)
+    data = ControllerData()
+
+    u, new_data = controller(t, x, u_nom, key, data)
+
+    # Check results
+    assert new_data.error == True
+    assert jnp.all(jnp.isnan(u))
+    # Status 0 is UNSOLVED (which is what we got in repro)
+    # The actual status returned by solver might be 0 or 3 depending on solver config/luck
+    # But we expect failure.
+    assert new_data.error_data == 0 or new_data.error_data == 3
+
+    # Check that error propagates
+    # Call again with prev error
+    u2, new_data2 = controller(t, x, u_nom, key, new_data)
+    assert new_data2.error == True
+    assert jnp.all(jnp.isnan(u2))


### PR DESCRIPTION
This PR improves the visibility of CBF-CLF-QP solver failures and prevents log spam during simulations.

**Changes:**
- **Explicit Status:** `_print_failure` now uses `lax.switch` to print readable status strings (e.g., "UNSOLVED", "PRIMAL_INFEASIBLE") instead of just integer codes.
- **Spam Suppression:** The controller now checks `data.error` from the previous step. If the controller is already in an error state, it suppresses further `jdebug.print` calls, ensuring the failure is logged only once (the first time it occurs).
- **Testing:** Added `tests/test_controllers/test_cbf_clf_controllers/test_failure_handling.py` to verify that the controller correctly flags errors and returns NaNs upon infeasibility.

**Verification:**
- Verified with a reproduction script (`repro_fail.py`) that the error message is clear ("UNSOLVED") and appears exactly once during a 20-step simulation of an infeasible problem.
- Unit test passed.

---
*PR created automatically by Jules for task [6889371296050840952](https://jules.google.com/task/6889371296050840952) started by @bardhh*