### PR TITLE
🔧 Forge: Guard import-time side effects

### DIFF
--- a/src/cbfkit/__init__.py
+++ b/src/cbfkit/__init__.py
@@ -7,8 +7,11 @@ in QP solvers (OSQP/JAXopt) and MPPI exponential cost weighting.
 
 from ._version import __version__
 
-from jax import config
+try:
+    from jax import config
 
-# Enable 64-bit float precision for numerical stability
-# This MUST happen before any other JAX imports in user code
-config.update("jax_enable_x64", True)
+    # Enable 64-bit float precision for numerical stability
+    # This MUST happen before any other JAX imports in user code
+    config.update("jax_enable_x64", True)
+except ImportError:
+    pass


### PR DESCRIPTION
Wrapped the `jax` import and configuration in `src/cbfkit/__init__.py` with a `try-except ImportError` block. This prevents the package from crashing immediately upon import if `jax` is missing, which is useful for build tools, linters, or version checking scripts that may run in a lightweight environment without runtime dependencies.

This change constitutes a small packaging improvement that enhances build hygiene and installability robustness.

---
*PR created automatically by Jules for task [4127171802000883773](https://jules.google.com/task/4127171802000883773) started by @bardhh*