### PR TITLE
🔮 Oracle: Fix incorrect cancellation of risk/margin terms in RA-PI CBF

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_cbfs.py
@@ -5,7 +5,7 @@
 from typing import Any, Callable, Dict, Tuple
 
 import jax.numpy as jnp
-from jax import Array, jit, lax, scipy
+from jax import Array, jit, lax
 
 from cbfkit.controllers.cbf_clf.utils.risk_aware_params import RiskAwareParams
 from cbfkit.utils.user_types import (
@@ -43,20 +43,12 @@ def generate_compute_ra_pi_cbf_constraints(
     # Check for Risk-Aware Params object
     if "ra_cbf_params" in kwargs:
         ra_params: RiskAwareParams = kwargs["ra_cbf_params"]  # type: ignore[assignment]
-        assert ra_params.eta is not None
-        assert ra_params.t_max is not None
-        assert ra_params.p_bound is not None
-        assert ra_params.gamma is not None
-        r_buffer = float(
-            ra_params.eta * jnp.sqrt(2 * ra_params.t_max) * scipy.special.erfinv(ra_params.p_bound)
-        )
     else:
         ra_params = RiskAwareParams(
             sigma=lambda x: jnp.zeros((x.shape[0], 1)),
             gamma=jnp.zeros(n_bfs),  # Initialize gamma
             integrator_states=jnp.zeros((n_bfs,)),  # Initialize integrator_states
         )
-        r_buffer = 0.0
 
     ra_params.integrator_states = jnp.zeros((n_bfs,))
 
@@ -74,9 +66,8 @@ def generate_compute_ra_pi_cbf_constraints(
 
         if n_bfs > 0:
             bf_x, bj_x, bh_x, dbf_t, _ = compute_barrier_values(t, x)
-            assert ra_params.gamma is not None
             # Ensure array types for addition
-            w_vals = ra_params.integrator_states + ra_params.gamma + r_buffer
+            w_vals = ra_params.integrator_states
             bc_x = jnp.stack([bc(w_vals[ii]) for ii, bc in enumerate(conditions)])
             traces = jnp.array(
                 [0.5 * jnp.trace(jnp.matmul(jnp.matmul(sigma.T, bh_ii), sigma)) for bh_ii in bh_x]

--- a/tests/test_controllers/test_cbf_clf_controllers/test_risk_aware_path_integral_cbfs.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_risk_aware_path_integral_cbfs.py
@@ -1,0 +1,64 @@
+
+import jax.numpy as jnp
+import jax.scipy.special as jsp
+from cbfkit.certificates.conditions.barrier_conditions.path_integral_barrier import right_hand_side
+from cbfkit.controllers.cbf_clf.generate_constraints.risk_aware_path_integral_cbfs import generate_compute_ra_pi_cbf_constraints
+from cbfkit.controllers.cbf_clf.utils.risk_aware_params import RiskAwareParams
+
+def test_ra_pi_constraints_output():
+    # Setup
+    rho = 0.05
+    gamma = 0.5
+    eta = 2.0
+    time_period = 1.0
+
+    # Dynamics (mock)
+    def dyn_func(x):
+        # f(x) = 0, g(x) = 0
+        return jnp.zeros_like(x), jnp.zeros((x.shape[0], 2))
+
+    # Barrier (mock)
+    # The framework seems to expect (t, x) or handle it.
+    # generate_compute_certificate_values calls lf(t, x).
+    def h(t, x): return x[0]
+    def grad_h(t, x): return jnp.array([1.0, 0.0])
+    def hess_h(t, x): return jnp.zeros((2, 2))
+    def partial_h(t, x): return 0.0 # Time derivative
+
+    condition = right_hand_side(rho, gamma, eta, time_period)
+
+    # CertificateCollection tuple structure: (cbf, grad, hess, partials, conditions)
+    barriers = ([h], [grad_h], [hess_h], [partial_h], [condition])
+
+    control_limits = jnp.array([10.0, 10.0])
+
+    ra_params = RiskAwareParams(
+        t_max=time_period,
+        p_bound=rho,
+        gamma=jnp.array([gamma]),
+        eta=eta,
+        sigma=lambda x: jnp.zeros((x.shape[0], 1))
+    )
+
+    # Generate constraints
+    compute_constraints = generate_compute_ra_pi_cbf_constraints(
+        control_limits=control_limits,
+        dyn_func=dyn_func,
+        barriers=barriers,
+        ra_cbf_params=ra_params
+    )
+
+    t = 0.0
+    x = jnp.array([0.0, 0.0])
+
+    # Run
+    a, b, data = compute_constraints(t, x)
+
+    # Check b
+    # b should match 1 - gamma - term (since integrator_states=0)
+    # This verifies that generate_constraints logic does not incorrectly add offsets.
+
+    term = jnp.sqrt(2 * time_period) * eta * jsp.erfinv(1 - 2 * rho)
+    expected_bc_x = 1 - gamma - term
+
+    assert jnp.abs(b[0] - expected_bc_x) < 1e-5, f"Expected {expected_bc_x}, got {b[0]}"


### PR DESCRIPTION
This PR fixes a critical semantic mismatch in the Risk-Aware Path Integral CBF controller (`risk_aware_path_integral_cbfs.py`).

Previously, the controller was manually adding `gamma` and a risk buffer (`r_buffer`) to the input of the barrier condition function. Since the standard barrier condition function (`path_integral_barrier.right_hand_side`) already accounts for these terms (by subtracting them), adding them back effectively canceled out the safety margins, reducing the constraint to `Lh <= 1 + integral`.

This change:
1.  Removes the manual addition of `gamma` and `r_buffer` to `w_vals`. The integrator state is now passed directly to the condition function.
2.  Removes the calculation of `r_buffer`, which was also using an incorrect argument for `erfinv` (`p_bound` instead of `1 - 2*p_bound` or `1 - 2*rho`).
3.  Adds a regression test verifying that the generated constraint bound correctly reflects the intended risk margins.


---
*PR created automatically by Jules for task [6617702743528453097](https://jules.google.com/task/6617702743528453097) started by @bardhh*