### PR TITLE
🧾 Piper: add missing keys to CbfClfQpData TypedDict

### DIFF
--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -295,12 +295,18 @@ class CbfClfQpData(TypedDict, total=False):
         solver_iter (Union[int, Array]): Number of iterations taken by the solver.
         solver_status (Union[int, Array]): Exit status of the solver.
         complete (bool): Whether the CLF task is complete.
+        bfs (Array): Values of barrier functions.
+        lfs (Array): Values of lyapunov functions.
+        violated (Union[bool, Array]): Whether any barrier function is violated.
     """
 
     solver_params: Tuple[Any, Any]
     solver_iter: Union[int, Array]
     solver_status: Union[int, Array]
     complete: bool
+    bfs: Array
+    lfs: Array
+    violated: Union[bool, Array]
 
 
 class CbfClfQpGenerator(Protocol):


### PR DESCRIPTION
Updated `CbfClfQpData` in `src/cbfkit/utils/user_types.py` to include `bfs`, `lfs`, and `violated` fields. Verified with mypy and existing tests.

---
*PR created automatically by Jules for task [12844083568596645717](https://jules.google.com/task/12844083568596645717) started by @bardhh*