### PR TITLE
⏱️ Chronos: Enforce non-negative tunable CBF parameters

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -428,6 +428,23 @@ def cbf_clf_qp_generator(
             g_mat = jnp.vstack([g_mat_u, g_mat_c])
             h_vec = jnp.hstack([h_vec_u, h_vec_c])
 
+            # Bolt: Enforce non-negativity for tunable Class K parameters to prevent safety inversion
+            if "tunable_class_k" in kwargs and kwargs["tunable_class_k"] and n_bfs > 0:
+                # Constraints: -delta <= 0  (delta >= 0)
+                # tunable parameters are located at indices [n_con : n_con + n_bfs]
+                n_total_vars = n_con + n_bfs + n_lfs
+                g_pos = jnp.zeros((n_bfs, n_total_vars))
+
+                # Set -1.0 for the tunable columns using vector indexing
+                row_indices = jnp.arange(n_bfs)
+                col_indices = n_con + jnp.arange(n_bfs)
+                g_pos = g_pos.at[row_indices, col_indices].set(-1.0)
+
+                h_pos = jnp.zeros((n_bfs,))
+
+                g_mat = jnp.vstack([g_mat, g_pos])
+                h_vec = jnp.hstack([h_vec, h_pos])
+
             # Sentinel: Detect NaNs in QP inputs
             nan_in_inputs = jnp.any(jnp.isnan(q_vec)) | jnp.any(jnp.isnan(g_mat)) | jnp.any(jnp.isnan(h_vec))
 

--- a/tests/test_controllers/test_cbf_clf_controllers/test_tunable_cbf_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_tunable_cbf_safety.py
@@ -1,0 +1,106 @@
+
+import unittest
+import jax.numpy as jnp
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.controllers.cbf_clf.generate_constraints import (
+    generate_compute_zeroing_cbf_constraints,
+    generate_compute_vanilla_clf_constraints,
+)
+from cbfkit.utils.user_types import ControllerData, CertificateCollection
+
+class TestTunableCBFSafety(unittest.TestCase):
+    def test_tunable_parameter_positivity(self):
+        """
+        Verifies that tunable Class K parameters (delta) are constrained to be non-negative.
+        Negative delta allows inverting the safety condition (h_dot >= -alpha*h becomes h_dot >= alpha*|h|),
+        effectively permitting the system to become MORE unsafe when h < 0.
+        """
+        # System: x is scalar.
+        # x_dot = u + drift
+
+        # h(x) = x.
+        # Unsafe if x < 0.
+
+        # Common barrier defs
+        def h(t, x): return x[0]
+        def grad_h(t, x): return jnp.array([1.0])
+        def hess_h(t, x): return jnp.zeros((1, 1))
+        def partial_t(t, x): return 0.0
+        def condition(val): return 1.0 * val # alpha = 1
+
+        barriers = CertificateCollection([h], [grad_h], [hess_h], [partial_t], [condition])
+
+        generator = cbf_clf_qp_generator(
+            generate_compute_zeroing_cbf_constraints,
+            generate_compute_vanilla_clf_constraints
+        )
+
+        t = 0.0
+        x = jnp.array([-1.0]) # h(x) = -1 (Unsafe)
+        u_nom = jnp.array([0.0])
+        key = jnp.array([0, 0], dtype=jnp.uint32)
+        data = ControllerData(
+            error=False, error_data=0, complete=False,
+            sol=jnp.array([]), u=jnp.zeros(1), u_nom=jnp.zeros(1), sub_data={}
+        )
+
+        # --- Scenario 1: Recovery Possible ---
+        # Lfh = -0.5. Lgh = 1.
+        # Constraint: u + (-0.5) + delta * (-1) >= 0 => u >= 0.5 + delta.
+        # u in [-1, 1].
+        # Feasible for delta > 0?
+        # If delta = 0.1 -> u >= 0.6. OK.
+
+        def dynamics_s1(x):
+            return jnp.array([-0.5]), jnp.array([[1.0]])
+
+        controller_s1 = generator(
+            control_limits=jnp.array([1.0]),
+            dynamics_func=dynamics_s1,
+            barriers=barriers,
+            tunable_class_k=True,
+            slack_bound_cbf=100.0,
+            relaxable_clf=False
+        )
+
+        u_s1, new_data_s1 = controller_s1(t, x, u_nom, key, data)
+
+        self.assertFalse(new_data_s1.error, "Scenario 1 should be feasible")
+        sol_s1 = new_data_s1.sol
+        delta_s1 = sol_s1[1]
+
+        # Expect reduced but positive delta
+        self.assertGreater(delta_s1, 0.0)
+        self.assertLess(delta_s1, 1.0) # Nominal is 1.0, must reduce to satisfy u limit
+
+        # --- Scenario 2: Recovery Impossible (without negative delta) ---
+        # Lfh = -2.0.
+        # Constraint: u - 2 - delta >= 0 => u >= 2 + delta.
+        # u_max = 1. => 1 >= 2 + delta => delta <= -1.
+
+        def dynamics_s2(x):
+            return jnp.array([-2.0]), jnp.array([[1.0]])
+
+        controller_s2 = generator(
+            control_limits=jnp.array([1.0]),
+            dynamics_func=dynamics_s2,
+            barriers=barriers,
+            tunable_class_k=True,
+            slack_bound_cbf=100.0,
+            relaxable_clf=False
+        )
+
+        u_s2, new_data_s2 = controller_s2(t, x, u_nom, key, data)
+
+        # If regression exists (no positivity constraint), this solves with delta ~ -1.
+        # We want it to FAIL (return NaNs).
+
+        if not new_data_s2.error:
+             delta_s2 = new_data_s2.sol[1]
+             print(f"Scenario 2 solved unexpectedly with delta={delta_s2}")
+
+        self.assertTrue(new_data_s2.error, f"Scenario 2 should be infeasible! Got u={u_s2}, status={new_data_s2.error_data}")
+        self.assertTrue(jnp.all(jnp.isnan(u_s2)), "Control should be NaN on failure")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Prevents a safety regression where the QP solver could select negative tunable parameters (delta) to satisfy constraints, effectively inverting the safety condition (h_dot >= -alpha*h becomes h_dot >= alpha*|h|) and allowing the system to become more unsafe. Adds explicit inequality constraints to the QP and a regression test confirming failure in impossible recovery scenarios.

---
*PR created automatically by Jules for task [2141737090918199378](https://jules.google.com/task/2141737090918199378) started by @bardhh*