### PR TITLE
📦 Archivist: Warn on implicit global RNG usage in uncertainty utils

### DIFF
--- a/src/cbfkit/utils/uncertainty.py
+++ b/src/cbfkit/utils/uncertainty.py
@@ -1,4 +1,5 @@
 from typing import Any, List, Optional, Tuple, Union
+import warnings
 
 import numpy as np
 from numpy.random import Generator
@@ -62,6 +63,11 @@ def generate_uncertainty_pmf(
     std_uy = np.sqrt(std_uy_ux * (u[0, 0] ** 2) + std_uy_uy * (u[1, 0] ** 2))
 
     if rng is None:
+        warnings.warn(
+            "Using global numpy random state. For reproducible results, pass an explicit rng or seed.",
+            UserWarning,
+            stacklevel=2,
+        )
         rng = np.random
     elif isinstance(rng, int):
         rng = np.random.default_rng(rng)

--- a/tests/test_uncertainty_reproducibility.py
+++ b/tests/test_uncertainty_reproducibility.py
@@ -1,0 +1,58 @@
+
+import pytest
+import numpy as np
+import warnings
+from cbfkit.utils.uncertainty import generate_uncertainty_pmf
+
+def test_generate_uncertainty_pmf_warning():
+    """Test that a warning is issued when rng is None."""
+    u = np.array([1.0, 0.5])
+    x = np.array([0.0, 0.0, 1.0, 0.0])
+    noise_params = [
+        [0.1, 0.1, 0.1, 0.1],
+        [0.01, 0.0, 0.0, 0.01]
+    ]
+    S = 5
+
+    with pytest.warns(UserWarning, match="Using global numpy random state"):
+        generate_uncertainty_pmf(u, x, noise_params, S, rng=None)
+
+def test_generate_uncertainty_pmf_reproducibility():
+    """Test that providing a seed produces reproducible results."""
+    u = np.array([1.0, 0.5])
+    x = np.array([0.0, 0.0, 1.0, 0.0])
+    noise_params = [
+        [0.1, 0.1, 0.1, 0.1],
+        [0.01, 0.0, 0.0, 0.01]
+    ]
+    S = 5
+    seed = 42
+
+    # Run 1
+    pmf1, u1, x1 = generate_uncertainty_pmf(u, x, noise_params, S, rng=seed)
+
+    # Run 2
+    pmf2, u2, x2 = generate_uncertainty_pmf(u, x, noise_params, S, rng=seed)
+
+    np.testing.assert_array_equal(pmf1, pmf2)
+    np.testing.assert_array_equal(u1, u2)
+    np.testing.assert_array_equal(x1, x2)
+
+def test_generate_uncertainty_pmf_randomness():
+    """Test that providing different seeds produces different results."""
+    u = np.array([1.0, 0.5])
+    x = np.array([0.0, 0.0, 1.0, 0.0])
+    noise_params = [
+        [0.1, 0.1, 0.1, 0.1],
+        [0.01, 0.0, 0.0, 0.01]
+    ]
+    S = 5
+
+    # Run 1
+    _, u1, x1 = generate_uncertainty_pmf(u, x, noise_params, S, rng=42)
+
+    # Run 2
+    _, u2, x2 = generate_uncertainty_pmf(u, x, noise_params, S, rng=43)
+
+    assert not np.array_equal(u1, u2)
+    assert not np.array_equal(x1, x2)


### PR DESCRIPTION
This PR addresses a source of implicit non-determinism in `cbfkit`. The `generate_uncertainty_pmf` utility previously defaulted to using the global `numpy.random` state without indication, making it difficult to reproduce results if the user was unaware.

Changes:
1.  **Explicit Warning**: `src/cbfkit/utils/uncertainty.py` now raises a `UserWarning` if `rng` is `None`, informing the user that the global random state is being used and suggesting explicit seeding.
2.  **Verification**: Added `tests/test_uncertainty_reproducibility.py` to test:
    *   The warning is raised when `rng=None`.
    *   Results are identical across runs when a fixed seed is provided.
    *   Results differ when different seeds are provided.
3.  **Validation**: Verified that existing internal usage (e.g., `adaptive_cvar_cbf_controller`) correctly passes an RNG and does not trigger the warning.

---
*PR created automatically by Jules for task [7455211725907779772](https://jules.google.com/task/7455211725907779772) started by @bardhh*