### PR TITLE
Enhance SimulationResults with dictionary-like access

### DIFF
--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -103,6 +103,39 @@ class SimulationResults(NamedTuple):
         """Returns planner data as a dictionary."""
         return dict(zip(self.planner_keys, self.planner_values))
 
+    def __getitem__(self, key: Union[int, str]) -> Any:
+        """Allows dictionary-like access to simulation results.
+
+        Args:
+            key (Union[int, str]): Integer index (tuple access) or string key.
+
+        Returns:
+            Any: The requested data.
+
+        Raises:
+            KeyError: If the key is not found in fields, controller_data, or planner_data.
+
+        Examples:
+            >>> results["states"]  # Access field
+            >>> results["sol"]     # Access controller data
+            >>> results[0]         # Access by index (legacy)
+        """
+        if isinstance(key, int):
+            return tuple.__getitem__(self, key)
+        if isinstance(key, str):
+            if key in self._fields:
+                return getattr(self, key)
+            if key in self.controller_keys:
+                idx = self.controller_keys.index(key)
+                return self.controller_values[idx]
+            if key in self.planner_keys:
+                idx = self.planner_keys.index(key)
+                return self.planner_values[idx]
+            raise KeyError(
+                f"Key '{key}' not found in SimulationResults fields, controller_data, or planner_data."
+            )
+        return tuple.__getitem__(self, key)
+
 
 # Certificate (Barrier, Lyapunov, Barrier-Lyapunov, etc.) Function Callables
 class CertificateInputStyle(str, Enum):

--- a/tests/test_simulation/test_simulation_results_api.py
+++ b/tests/test_simulation/test_simulation_results_api.py
@@ -1,0 +1,83 @@
+
+import jax.numpy as jnp
+import pytest
+from cbfkit.utils.user_types import SimulationResults
+
+def test_simulation_results_api():
+    """Test the dictionary-like access of SimulationResults."""
+
+    states = jnp.array([[0.0, 0.0]])
+    controls = jnp.array([[1.0]])
+    estimates = jnp.array([])
+    covariances = jnp.array([])
+
+    c_keys = ["sol", "status"]
+    c_vals = [jnp.array([0.5]), jnp.array([1])]
+
+    p_keys = ["x_traj"]
+    p_vals = [jnp.array([[0.1, 0.1]])]
+
+    res = SimulationResults(
+        states, controls, estimates, covariances,
+        c_keys, c_vals, p_keys, p_vals
+    )
+
+    # 1. Test field access via string
+    assert jnp.all(res["states"] == states)
+
+    # 2. Test controller data access via string
+    assert jnp.all(res["sol"] == c_vals[0])
+
+    # 3. Test planner data access via string
+    assert jnp.all(res["x_traj"] == p_vals[0])
+
+    # 4. Test legacy unpacking
+    x, u, z, p, ck, cv, pk, pv = res
+    assert jnp.all(x == states)
+
+    # 5. Test index access
+    assert jnp.all(res[0] == states)
+
+    # 6. Test KeyError
+    with pytest.raises(KeyError, match="not found in SimulationResults"):
+        _ = res["non_existent"]
+
+def test_simulation_results_api_collisions():
+    """Test priority order in case of key collisions."""
+    # Priority: fields > controller > planner
+
+    states = jnp.array([1])
+
+    # Controller uses "states" key (collision with field)
+    c_keys = ["states"]
+    c_vals = [jnp.array([2])] # This should be masked
+
+    # Planner uses "states" key (collision with field)
+    p_keys = ["states"]
+    p_vals = [jnp.array([3])] # This should be masked
+
+    res = SimulationResults(
+        states, jnp.array([]), jnp.array([]), jnp.array([]),
+        c_keys, c_vals, p_keys, p_vals
+    )
+
+    # Should get field value
+    assert jnp.all(res["states"] == states)
+
+    # Controller vs Planner collision
+    # Controller uses "unique_c"
+    # Planner uses "unique_c"
+
+    c_keys = ["shared"]
+    c_vals = [jnp.array([10])]
+
+    p_keys = ["shared"]
+    p_vals = [jnp.array([20])]
+
+    res = SimulationResults(
+        states, jnp.array([]), jnp.array([]), jnp.array([]),
+        c_keys, c_vals, p_keys, p_vals
+    )
+
+    # Should get controller value (priority 2)
+    assert jnp.all(res["shared"] == c_vals[0])


### PR DESCRIPTION
This PR enhances `SimulationResults` by implementing `__getitem__`, allowing users to access simulation results as a dictionary/dataframe-like object. This reduces the need for verbose unpacking and brittle index-based access, significantly improving the usability of the simulation API for data analysis. It also solves user confusion regarding the order of return values (e.g., `planner_data_keys` vs `planner_data_values`).

---
*PR created automatically by Jules for task [17759935283704195696](https://jules.google.com/task/17759935283704195696) started by @bardhh*