### PR TITLE
🔮 Oracle: Fix semantic drift in Olfati-Saber unicycle dynamics docstring

### DIFF
--- a/src/cbfkit/systems/unicycle/models/olfatisaber2002approximate/dynamics.py
+++ b/src/cbfkit/systems/unicycle/models/olfatisaber2002approximate/dynamics.py
@@ -7,16 +7,17 @@ def approx_unicycle_dynamics(lam: float = 1.0):
 
     Computes the drift vector 'f' and control matrix 'g' based on the given state.
 
-    Taken from R. Olfati-Saber, "Near-identity diffeomorphisms and exponential e-tracking and
-    6-stabilization of first-order nonholonomic SE (2) vehicles", 2002.
+    Taken from R. Olfati-Saber, "Near-identity diffeomorphisms and exponential epsilon-tracking and
+    delta-stabilization of first-order nonholonomic SE(2) vehicles", 2002.
     """
 
     @jit
     def dynamics(state: Array):
         """Computes the drift vector 'f' and control matrix 'g' based on the given state.
 
-        :param state: A numpy array representing the current state (x, y, theta, l) where x and y
-            are positions, theta is the orientation angle, and l is the wheelbase of the unicycle.
+        :param state: A numpy array representing the current state (x, y, theta) where x and y
+            are positions and theta is the orientation angle. The wheelbase l is defined by
+            the 'lam' parameter passed to the factory function.
         :return: A tuple (f, g) where f is the drift vector and g is the control matrix.
         """
         _, _, theta = state

--- a/tests/test_models/test_olfatisaber_dynamics.py
+++ b/tests/test_models/test_olfatisaber_dynamics.py
@@ -1,0 +1,29 @@
+import pytest
+import jax.numpy as jnp
+from cbfkit.systems.unicycle.models.olfatisaber2002approximate.dynamics import approx_unicycle_dynamics
+
+def test_olfatisaber_dynamics_state_shape():
+    """
+    Verifies that the dynamics function accepts a 3-element state (x, y, theta)
+    and rejects a 4-element state (x, y, theta, l), consistent with the updated docstring.
+    """
+    dynamics_func = approx_unicycle_dynamics(lam=0.5)
+
+    # Test with valid 3-element state
+    state_3 = jnp.array([1.0, 2.0, jnp.pi/4])
+    f, g = dynamics_func(state_3)
+
+    assert f.shape == (3,)
+    assert g.shape == (3, 2)
+
+    # Check values for consistency
+    # f should be [0, 0, 0]
+    assert jnp.allclose(f, jnp.zeros(3))
+
+    # Test with invalid 4-element state
+    state_4 = jnp.array([1.0, 2.0, jnp.pi/4, 0.5])
+
+    # The function unpacks with `_, _, theta = state`
+    # This should raise a ValueError when state has 4 elements.
+    with pytest.raises(ValueError, match="too many values to unpack"):
+        _ = dynamics_func(state_4)


### PR DESCRIPTION
This PR addresses a mismatch between the docstring and implementation of `approx_unicycle_dynamics`. The docstring incorrectly claimed the state included the wheelbase `l`, but the implementation treats `l` as a configuration parameter and expects a 3-element state. The docstring has been updated, and a test case has been added to enforce this behavior.

---
*PR created automatically by Jules for task [13021172485864241210](https://jules.google.com/task/13021172485864241210) started by @bardhh*