### PR TITLE
🧾 Piper: strict typing for certificate inputs

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -42,6 +42,7 @@ from cbfkit.utils.user_types import (
     CbfClfQpData,
     CbfClfQpGenerator,
     CertificateCollection,
+    CertificateInput,
     Control,
     ControllerCallable,
     ControllerCallableReturns,
@@ -58,7 +59,9 @@ from .generate_constraints import (
 )
 
 
-def _normalize_certificate_collection(cert_collection: Any, name: str) -> CertificateCollection:
+def _normalize_certificate_collection(
+    cert_collection: Optional[CertificateInput], name: str
+) -> CertificateCollection:
     """Validates and normalizes certificate collection structure.
 
     Accepts:
@@ -137,12 +140,8 @@ def cbf_clf_qp_generator(
     def generate_cbf_clf_controller(
         control_limits: Array,
         dynamics_func: DynamicsCallable,
-        barriers: Optional[
-            Union[CertificateCollection, List[CertificateCollection]]
-        ] = EMPTY_CERTIFICATE_COLLECTION,
-        lyapunovs: Optional[
-            Union[CertificateCollection, List[CertificateCollection]]
-        ] = EMPTY_CERTIFICATE_COLLECTION,
+        barriers: Optional[CertificateInput] = EMPTY_CERTIFICATE_COLLECTION,
+        lyapunovs: Optional[CertificateInput] = EMPTY_CERTIFICATE_COLLECTION,
         p_mat: Optional[Union[Array, None]] = None,
         *,
         relaxable_clf: bool = True,
@@ -160,10 +159,10 @@ def cbf_clf_qp_generator(
             control_limits (Array): symmetric actuation constraints [u1_bar, u2_bar, etc.].
                 Can be a scalar for 1D systems.
             dynamics_func (DynamicsCallable): function to compute dynamics based on current state
-            barriers (CertificateCollection | List[CertificateCollection]): collection of barrier functions,
-                gradients, hessians, dh/dt, conditions. Can be a single collection or a list of them.
-            lyapunovs (CertificateCollection | List[CertificateCollection]): collection of lyapunov functions,
-                gradients, hessians, dV/dt,  conditions. Can be a single collection or a list of them.
+            barriers (CertificateInput): collection of barrier functions,
+                gradients, hessians, dh/dt, conditions. Can be a single collection, a list of them, or a legacy tuple.
+            lyapunovs (CertificateInput): collection of lyapunov functions,
+                gradients, hessians, dV/dt,  conditions. Can be a single collection, a list of them, or a legacy tuple.
             p_mat (Optional[Union[Array, None]] = None): objective function matrix (quadratic term)
             relaxable_clf (bool): whether to treat CLF as a soft constraint (default: True).
             relaxable_cbf (bool): whether to treat CBF as a soft constraint (default: False).

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -156,6 +156,25 @@ BarrierTuple = CertificateTuple
 LyapunovTuple = CertificateTuple
 
 
+# Legacy Certificate Tuple (matching CertificateCollection components)
+CertificateLegacyTuple = Tuple[
+    List[CertificateCallable],
+    List[CertificateJacobianCallable],
+    List[CertificateHessianCallable],
+    List[CertificatePartialCallable],
+    List[CertificateConditionsCallable],
+]
+
+# Valid input types for certificate collection arguments (barriers, lyapunovs)
+# Supports single collection, list of collections, tuple of collections, or legacy component tuple
+CertificateInput = Union[
+    CertificateCollection,
+    List[CertificateCollection],
+    Tuple[CertificateCollection, ...],
+    CertificateLegacyTuple,
+]
+
+
 # Predictive Barrier Function Callable
 PredictiveBarrierCollectionCallable = Callable[
     [],
@@ -316,12 +335,8 @@ class CbfClfQpGenerator(Protocol):
         self,
         control_limits: Array,
         dynamics_func: DynamicsCallable,
-        barriers: Optional[
-            Union[CertificateCollection, List[CertificateCollection]]
-        ] = EMPTY_CERTIFICATE_COLLECTION,
-        lyapunovs: Optional[
-            Union[CertificateCollection, List[CertificateCollection]]
-        ] = EMPTY_CERTIFICATE_COLLECTION,
+        barriers: Optional[CertificateInput] = EMPTY_CERTIFICATE_COLLECTION,
+        lyapunovs: Optional[CertificateInput] = EMPTY_CERTIFICATE_COLLECTION,
         p_mat: Optional[Array] = None,
         *,
         relaxable_clf: bool = True,


### PR DESCRIPTION
Piper 🧾 Typing Improvement:

**What misuse it prevents:**
Prevents users from passing raw lists of functions (e.g., `[h1, h2]`) to `cbf_clf_qp_generator` where a `CertificateCollection` or a structured tuple is required. This is a common mistake that would otherwise only raise a runtime error (or worse, obscure JAX errors) inside the generator.

**Changes:**
1.  Defined `CertificateInput` Union in `user_types.py` to explicitly list allowed input types:
    - `CertificateCollection`
    - `List[CertificateCollection]` (concatenation)
    - `Tuple[CertificateCollection, ...]` (concatenation)
    - `CertificateLegacyTuple` (legacy structure of 5 lists)
2.  Updated `cbf_clf_qp_generator` and `_normalize_certificate_collection` to use `CertificateInput` instead of `Any` or incomplete Unions.

**Tools run:**
- `mypy`: Verified type consistency.
- `pytest`: Verified `tests/test_controllers/test_cbf_clf_controllers/test_certificate_validation.py` passes (runtime validation preserved).

---
*PR created automatically by Jules for task [4882980547296933323](https://jules.google.com/task/4882980547296933323) started by @bardhh*