### PR TITLE
🚨 Sentinel: Explicitly report NAN_INPUT_DETECTED in QP controller

### DIFF
--- a/reproduce_nan_output.py
+++ b/reproduce_nan_output.py
@@ -1,0 +1,56 @@
+import jax
+import jax.numpy as jnp
+from cbfkit.controllers.cbf_clf.vanilla_cbf_clf_qp_control_laws import vanilla_cbf_clf_qp_controller
+from cbfkit.utils.user_types import ControllerData, CertificateCollection
+
+# Dynamics that return NaNs in f
+def dynamics(x):
+    return jnp.full(2, jnp.nan), jnp.eye(2)
+
+# Barrier
+def h(t, x): return x[0]
+def grad(t, x): return jnp.array([1.0, 0.0])
+def hess(t, x): return jnp.zeros((2, 2))
+def partial_t(t, x): return 0.0
+def condition(val): return 1.0 * val # Class K
+
+# Use tuple for barriers which is accepted and converted
+barriers = ([h], [grad], [hess], [partial_t], [condition])
+
+# Dummy controller
+controller_factory = vanilla_cbf_clf_qp_controller(
+    control_limits=jnp.array([1.0, 1.0]),
+    dynamics_func=dynamics,
+    barriers=barriers,
+    lyapunovs=[],
+    p_mat=jnp.eye(2),
+    relaxable_clf=False,
+    relaxable_cbf=False
+)
+
+# Initialize data
+data = ControllerData(
+    error=jnp.array(False),
+    error_data=None,
+    complete=False,
+    sol=jnp.zeros(2),
+    u=jnp.zeros(2),
+    u_nom=jnp.zeros(2),
+    sub_data={}
+)
+
+# Run with valid u_nom, but dynamics will produce NaNs -> inputs to QP will be NaN
+u_nom = jnp.array([0.0, 0.0])
+x = jnp.zeros(2)
+t = 0.0
+key = jax.random.PRNGKey(0)
+
+print("Running controller with NaN dynamics...")
+jitted_controller = jax.jit(controller_factory)
+
+try:
+    u, new_data = jitted_controller(t, x, u_nom, key, data)
+    u.block_until_ready()
+    print(f"Status in data: {new_data.error_data}")
+except Exception as e:
+    print(f"Exception: {e}")

--- a/reproduce_nan_status.py
+++ b/reproduce_nan_status.py
@@ -1,0 +1,50 @@
+import jax
+import jax.numpy as jnp
+from cbfkit.controllers.cbf_clf.vanilla_cbf_clf_qp_control_laws import vanilla_cbf_clf_qp_controller
+from cbfkit.utils.user_types import ControllerData
+
+# Dummy dynamics: 2 states, 2 controls
+def dynamics(x):
+    return jnp.zeros(2), jnp.eye(2)
+
+# Dummy controller
+# p_mat is identity
+controller_factory = vanilla_cbf_clf_qp_controller(
+    control_limits=jnp.array([1.0, 1.0]),
+    dynamics_func=dynamics,
+    barriers=[],
+    lyapunovs=[],
+    p_mat=jnp.eye(2),
+    relaxable_clf=False,
+    relaxable_cbf=False
+)
+
+# Initialize data
+data = ControllerData(
+    error=jnp.array(False),
+    error_data=None,
+    complete=False,
+    sol=jnp.zeros(2),
+    u=jnp.zeros(2),
+    u_nom=jnp.zeros(2),
+    sub_data={}
+)
+
+# Run with NaN u_nom
+# This should trigger nan_in_inputs -> status -2
+u_nom = jnp.array([jnp.nan, jnp.nan])
+x = jnp.zeros(2)
+t = 0.0
+key = jax.random.PRNGKey(0)
+
+print("Running controller with NaN input...")
+# We use jit to ensure lax.cond/switch are compiled and executed as expected
+jitted_controller = jax.jit(controller_factory)
+
+try:
+    u, new_data = jitted_controller(t, x, u_nom, key, data)
+    # Block until ready to ensure print happens
+    u.block_until_ready()
+    print(f"Status in data: {new_data.error_data}")
+except Exception as e:
+    print(f"Exception: {e}")

--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -481,8 +481,9 @@ def cbf_clf_qp_generator(
                     )
 
                 lax.switch(
-                    status + 1,  # Map -1 to index 0
+                    status + 2,  # Map -2 to index 0
                     [
+                        lambda: print_status_msg("NAN_INPUT_DETECTED"),  # -2
                         lambda: print_status_msg("NAN_DETECTED"),  # -1
                         lambda: print_status_msg("UNSOLVED"),  # 0
                         lambda: jdebug.print(


### PR DESCRIPTION
**Failure Handling Improvement**

Previously, when the CBF-CLF-QP controller received NaN inputs (e.g. from dynamics or `u_nom`), it correctly detected them and assigned status `-2`, but the debug logger mapped this status to "NAN_DETECTED" (status -1) due to an incorrect `lax.switch` index.

This change updates the `_print_failure` function to explicitly handle status `-2` and report `NAN_INPUT_DETECTED`. This distinguishes between "Input is garbage" (upstream failure) and "Solver failed to find solution" (optimization failure).

**Changes:**
- Modified `src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py` to add `NAN_INPUT_DETECTED` to the failure print switch.

**Verification:**
- Verified with reproduction script that status -2 now prints "NAN_INPUT_DETECTED".
- Ran existing `test_nan_input_safety.py` to ensure no regressions.


---
*PR created automatically by Jules for task [3524380222394457033](https://jules.google.com/task/3524380222394457033) started by @bardhh*