### PR TITLE
🏗️ Atlas: Allow scalar roots in rectify_relative_degree

### DIFF
--- a/src/cbfkit/certificates/rectifiers.py
+++ b/src/cbfkit/certificates/rectifiers.py
@@ -82,7 +82,7 @@ def rectify_relative_degree(
     function: Callable[[Array], Array],
     system_dynamics: DynamicsCallable,
     state_dim: int,
-    roots: Union[Array, None] = None,
+    roots: Union[float, Array, None] = None,
     form: str = "exponential",
     certificate_conditions: Optional[CertificateConditionsCallable] = None,
     rng: Optional[Union[int, Array]] = None,
@@ -94,6 +94,10 @@ def rectify_relative_degree(
         function (Callable[[float, Array], Array]): constraint function
         system_dynamics (DynamicsCallable): dynamics function
         state_dim (int): dimension of the state
+        roots (Union[float, Array, None], optional): roots of the polynomial.
+            If a scalar float is provided, it is broadcasted to all required roots.
+            If an array is provided, it is used as the roots (padded/truncated as needed).
+            Defaults to None (generating default roots).
         form (str, optional): type of cascading procedure. Defaults to "exponential".
         certificate_conditions (Optional[CertificateConditionsCallable]): certificate conditions.
             If provided, returns a CertificateCollection directly. Defaults to None.
@@ -120,6 +124,13 @@ def rectify_relative_degree(
     if form == "exponential":
         n_fl = len(function_list)
         n_roots = n_fl - 1
+
+        # Handle scalar roots (Python float/int or 0-d JAX array)
+        if isinstance(roots, (float, int)):
+            roots = jnp.array([float(roots)])
+        elif roots is not None and getattr(roots, "ndim", 0) == 0:
+            roots = jnp.atleast_1d(roots)
+
         if roots is None:
             # Root locations in the left half-plane
             roots = jnp.array([-0.1 * (ii + 1) for ii in range(n_roots)])

--- a/tests/test_rectify_relative_degree_roots.py
+++ b/tests/test_rectify_relative_degree_roots.py
@@ -1,0 +1,64 @@
+import jax.numpy as jnp
+import pytest
+from cbfkit.certificates import rectify_relative_degree
+
+def test_scalar_roots_support():
+    """
+    Verifies that rectify_relative_degree accepts scalar roots (float and 0-d array)
+    and correctly broadcasts them to the required number of roots.
+    """
+
+    # Dynamics: Double integrator
+    # x = [p, v]
+    # dp = v
+    # dv = u
+    def dynamics(x):
+        # f(x) = [x[1], 0]
+        # g(x) = [0, 1]
+        return jnp.array([x[1], 0.0]), jnp.array([[0.0], [1.0]])
+
+    # Barrier: h(x) = p (x[0])
+    # Relative degree is 2.
+    # compute_function_list returns [h, Lfh, Lf^2h] (length 3).
+    # n_roots = 3 - 1 = 2.
+
+    def h(x):
+        return x[0]
+
+    state_dim = 2
+
+    # Case 1: Scalar float
+    roots_float = -1.0
+    cert_float = rectify_relative_degree(
+        function=h,
+        system_dynamics=dynamics,
+        state_dim=state_dim,
+        roots=roots_float,
+        form="exponential"
+    )
+    assert callable(cert_float)
+
+    # Case 2: Scalar 0-d array
+    roots_0d = jnp.array(-2.0)
+    cert_0d = rectify_relative_degree(
+        function=h,
+        system_dynamics=dynamics,
+        state_dim=state_dim,
+        roots=roots_0d,
+        form="exponential"
+    )
+    assert callable(cert_0d)
+
+    # Case 3: 1-d array (existing behavior)
+    roots_1d = jnp.array([-1.0]) # 1 provided, 2 needed -> broadcasts to [-1, -1]
+    cert_1d = rectify_relative_degree(
+        function=h,
+        system_dynamics=dynamics,
+        state_dim=state_dim,
+        roots=roots_1d,
+        form="exponential"
+    )
+    assert callable(cert_1d)
+
+if __name__ == "__main__":
+    test_scalar_roots_support()


### PR DESCRIPTION
Improves `rectify_relative_degree` to accept scalar floats or 0-d arrays for the `roots` argument, reducing boilerplate and confusion for users. Automatically broadcasts the scalar root to all required poles.

---
*PR created automatically by Jules for task [17755177637527057070](https://jules.google.com/task/17755177637527057070) started by @bardhh*