### PR TITLE
🛡️ Aegis: Replace scipy-based block_diag with pure JAX implementation

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/utils/utils.py
+++ b/src/cbfkit/controllers/cbf_clf/utils/utils.py
@@ -1,6 +1,5 @@
 import jax.numpy as jnp
 from jax import Array, random
-from scipy.linalg import block_diag
 
 KEY = random.PRNGKey(758493)  # Random seed is explicit in JAX
 EPS = 1e-1
@@ -8,8 +7,22 @@ INFEASIBLE_AREA = -1e3
 
 
 def block_diag_matrix_from_vec(n_blocks: int) -> Array:
-    block = jnp.array([1, -1])
-    return jnp.array([block_diag(*([block] * n_blocks)).T])[0, :, :]
+    """Constructs a block diagonal matrix for box constraints.
+
+    Creates a matrix A of shape (2*N, N) where each column i corresponds to input u_i,
+    and has entries 1 at row 2i and -1 at row 2i+1.
+    This corresponds to constraints u_i <= b and -u_i <= b.
+
+    Args:
+        n_blocks (int): Number of inputs (N).
+
+    Returns:
+        Array: The constraint matrix A.
+    """
+    # Aegis: Use pure JAX implementation to avoid scipy dependency and implicit conversion issues.
+    # We want columns [1, -1]^T on the diagonal.
+    block = jnp.array([[1.0], [-1.0]])
+    return jnp.kron(jnp.eye(n_blocks), block)
 
 
 def interleave_arrays(a: Array, b: Array) -> Array:

--- a/tests/test_controllers/test_cbf_clf_controllers/test_utils_correctness.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_utils_correctness.py
@@ -1,0 +1,47 @@
+import unittest
+import jax.numpy as jnp
+import numpy as np
+from cbfkit.controllers.cbf_clf.utils.utils import block_diag_matrix_from_vec
+
+class TestUtilsCorrectness(unittest.TestCase):
+    """
+    Test suite for utility functions in cbfkit.controllers.cbf_clf.utils.utils.
+    """
+
+    def test_block_diag_matrix_from_vec_correctness(self):
+        """
+        Verify that block_diag_matrix_from_vec produces the correct block diagonal structure.
+        For n=2, we expect a (4, 2) matrix (transposed from (2, 4)).
+        The diagonal blocks (column-wise) should be [1, -1]^T.
+
+        Expected matrix for n=2:
+        [[ 1,  0],
+         [-1,  0],
+         [ 0,  1],
+         [ 0, -1]]
+        """
+        n_blocks = 2
+        # Act
+        res = block_diag_matrix_from_vec(n_blocks)
+
+        # Assert structure
+        expected_shape = (2 * n_blocks, n_blocks)
+        self.assertEqual(res.shape, expected_shape, f"Expected shape {expected_shape}, got {res.shape}")
+
+        expected_matrix = jnp.array([
+            [ 1.0,  0.0],
+            [-1.0,  0.0],
+            [ 0.0,  1.0],
+            [ 0.0, -1.0]
+        ])
+
+        # Verify values
+        # We assume float comparison, but block_diag might return ints currently?
+        # jax.numpy usually handles type promotion for comparison.
+        np.testing.assert_allclose(res, expected_matrix, rtol=1e-6, err_msg="Matrix content mismatch")
+
+        # Verify type is JAX array
+        self.assertIsInstance(res, jnp.ndarray, "Result should be a JAX array")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Replaced `scipy.linalg.block_diag` with `jnp.kron` in `src/cbfkit/controllers/cbf_clf/utils/utils.py`. The previous implementation relied on implicit JAX-to-Numpy conversion and Scipy's handling of 1D arrays, which was brittle. The new implementation is cleaner, type-safe, and dependency-free for this module. Added a regression test to ensure matrix structure is preserved.

---
*PR created automatically by Jules for task [11766340074086007674](https://jules.google.com/task/11766340074086007674) started by @bardhh*