### PR TITLE
🔧 Forge: Packaging Improvements (jaxlib removal, py.typed, dev deps sync)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
     "jax>=0.4.23",
-    "jaxlib>=0.4.23",
     "cvxopt>=1.3.2,<2.0; platform_machine != 'aarch64' and platform_machine != 'arm64'",
     "kvxopt>=1.3.2.0,<2.0; platform_machine == 'aarch64' or platform_machine == 'arm64'",
     "jaxopt>=0.8.3,<0.9",
@@ -61,7 +60,7 @@ build-backend = "setuptools.build_meta"
 version = {attr = "cbfkit._version.__version__"}
 
 [tool.setuptools.package-data]
-"cbfkit" = ["codegen/templates/*.j2"]
+"cbfkit" = ["codegen/templates/*.j2", "py.typed"]
 
 [tool.black]
 line-length = 100
@@ -88,9 +87,10 @@ system = true
 
 [dependency-groups]
 dev = [
-    "mypy>=1.18.2",
-    "pytest>=9.0.2",
+    "black>=23.12.1,<24.0",
+    "mypy>=1.8.0,<2.0",
+    "jupyter>=1.0.0,<2.0",
+    "pytest>=8.0.2",
+    "ruff>=0.3.4",
     "python-dotenv>=1.2.1",
-    "ruff>=0.14.14",
-    "jupyter>=1.0.0",
 ]


### PR DESCRIPTION
Improved packaging hygiene by removing the redundant `jaxlib` dependency, ensuring `py.typed` is included in the distribution, and synchronizing development dependencies between `pip` extras and `uv` dependency groups.

---
*PR created automatically by Jules for task [10515699354542454516](https://jules.google.com/task/10515699354542454516) started by @bardhh*