### PR TITLE
🚨 Sentinel: Explicit validation in MPPI setup

### DIFF
--- a/src/cbfkit/controllers/mppi/mppi_source.py
+++ b/src/cbfkit/controllers/mppi/mppi_source.py
@@ -21,15 +21,18 @@ def setup_mppi(
     cost_perturbation_coeff=0.1,
 ):
     if dyn_func is None:
-        print("Dynamics function not passed")
-        exit()
+        raise ValueError("Dynamics function must be provided")
     if trajectory_cost_func is None:
         if stage_cost_func is None:
-            print("Neither Trajectury Cost nor Stage Cost function is passed.")
-            exit()
+            raise ValueError(
+                "Either Trajectory Cost or Stage Cost function must be provided. "
+                "Both are currently None."
+            )
         if terminal_cost_func is None:
-            print("Neither Trajectory Cost nor Terminal Cost function is passed")
-            exit()
+            raise ValueError(
+                "Either Trajectory Cost or Terminal Cost function must be provided. "
+                "Both are currently None."
+            )
 
     # Detect terminal_cost_func signature to support both (state) and (state, action) patterns
     terminal_cost_takes_action = False

--- a/tests/test_controllers/test_mppi_setup_validation.py
+++ b/tests/test_controllers/test_mppi_setup_validation.py
@@ -1,0 +1,56 @@
+
+import pytest
+from cbfkit.controllers.mppi.mppi_source import setup_mppi
+
+def test_mppi_setup_missing_dynamics():
+    """Test that setup_mppi raises ValueError when dynamics function is missing."""
+    with pytest.raises(ValueError, match="Dynamics function must be provided"):
+        setup_mppi(dyn_func=None)
+
+def test_mppi_setup_missing_costs():
+    """Test that setup_mppi raises ValueError when costs are missing."""
+    def dummy_dynamics(x):
+        return x, x
+
+    # Case 1: No trajectory cost and no stage cost
+    with pytest.raises(ValueError, match="Either Trajectory Cost or Stage Cost function must be provided"):
+        setup_mppi(
+            dyn_func=dummy_dynamics,
+            trajectory_cost_func=None,
+            stage_cost_func=None,
+            terminal_cost_func=lambda x: 0.0
+        )
+
+    # Case 2: No trajectory cost and no terminal cost
+    with pytest.raises(ValueError, match="Either Trajectory Cost or Terminal Cost function must be provided"):
+        setup_mppi(
+            dyn_func=dummy_dynamics,
+            trajectory_cost_func=None,
+            stage_cost_func=lambda x, u: 0.0,
+            terminal_cost_func=None
+        )
+
+def test_mppi_setup_success():
+    """Test that setup_mppi succeeds with valid inputs."""
+    def dummy_dynamics(x):
+        return x, x
+
+    # Case 1: Trajectory cost provided
+    try:
+        setup_mppi(
+            dyn_func=dummy_dynamics,
+            trajectory_cost_func=lambda *args: 0.0,
+        )
+    except Exception as e:
+        pytest.fail(f"setup_mppi raised exception with valid trajectory cost: {e}")
+
+    # Case 2: Stage and Terminal cost provided
+    try:
+        setup_mppi(
+            dyn_func=dummy_dynamics,
+            trajectory_cost_func=None,
+            stage_cost_func=lambda x, u: 0.0,
+            terminal_cost_func=lambda x: 0.0
+        )
+    except Exception as e:
+        pytest.fail(f"setup_mppi raised exception with valid stage/terminal costs: {e}")


### PR DESCRIPTION
This PR addresses a "Sentinel" finding where the MPPI controller setup would silently terminate the process using `exit()` if configuration arguments were missing.

Changes:
- Modified `src/cbfkit/controllers/mppi/mppi_source.py`:
    - Replaced `exit()` with `raise ValueError(...)`.
    - Improved error message clarity.
    - Fixed a typo ("Trajectury").
- Added `tests/test_controllers/test_mppi_setup_validation.py`:
    - Tests for missing dynamics function.
    - Tests for missing cost functions.
    - Tests for valid configurations.

This change ensures that configuration errors are raised as proper Python exceptions, allowing for better debugging and error handling in applications using `cbfkit`.

---
*PR created automatically by Jules for task [1972491569811276297](https://jules.google.com/task/1972491569811276297) started by @bardhh*