### PR TITLE
🧹 Curator: Remove heavy `control` dependency by implementing lightweight LQR using `scipy`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "cvxopt>=1.3.2,<2.0; platform_machine != 'aarch64' and platform_machine != 'arm64'",
     "kvxopt>=1.3.2.0,<2.0; platform_machine == 'aarch64' or platform_machine == 'arm64'",
     "jaxopt>=0.8.3,<0.9",
-    "control>=0.9.4,<1.0",
+    "scipy>=1.10",
     "tqdm>=4.66.2,<5.0"
 ]
 

--- a/src/cbfkit/systems/quadrotor_6dof/certificates/lyapunov_functions.py
+++ b/src/cbfkit/systems/quadrotor_6dof/certificates/lyapunov_functions.py
@@ -1,7 +1,7 @@
 from typing import Callable, List, Tuple
 
 import jax.numpy as jnp
-from control import lqr
+from cbfkit.utils.lqr import lqr
 from jax import Array, jacfwd, jacrev, jit
 
 from cbfkit.utils.matrix_vector_operations import normalize, vee

--- a/src/cbfkit/systems/quadrotor_6dof/controllers/geometric.py
+++ b/src/cbfkit/systems/quadrotor_6dof/controllers/geometric.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional, Tuple
 
 import jax.numpy as jnp
-from control import lqr
+from cbfkit.utils.lqr import lqr
 from jax import Array, jit
 
 from cbfkit.utils.matrix_vector_operations import hat, normalize, vee

--- a/src/cbfkit/utils/lqr.py
+++ b/src/cbfkit/utils/lqr.py
@@ -1,0 +1,37 @@
+"""LQR controller utility."""
+
+import numpy as np
+from scipy.linalg import solve_continuous_are
+
+
+def lqr(A, B, Q, R):
+    """Solve the continuous time LQR controller.
+
+    dx/dt = A x + B u
+
+    cost = integral x.T*Q*x + u.T*R*u
+
+    Args:
+        A (array_like): Dynamics matrix
+        B (array_like): Input matrix
+        Q (array_like): State cost matrix
+        R (array_like): Input cost matrix
+
+    Returns:
+        K (ndarray): State feedback gain
+        S (ndarray): Solution to Riccati equation
+        E (None): Eigenvalues of the closed loop system (not computed)
+    """
+    # Ensure numpy arrays
+    A_np = np.array(A)
+    B_np = np.array(B)
+    Q_np = np.array(Q)
+    R_np = np.array(R)
+
+    # Solve Algebraic Riccati Equation
+    S = solve_continuous_are(A_np, B_np, Q_np, R_np)
+
+    # Compute gain K = R^-1 B^T S
+    K = np.linalg.inv(R_np) @ B_np.T @ S
+
+    return K, S, None


### PR DESCRIPTION
Replaced `control` dependency with local `scipy`-based implementation of LQR to reduce package bloat and make `matplotlib` truly optional.

Changes:
- Created `src/cbfkit/utils/lqr.py` with `lqr` function using `scipy.linalg.solve_continuous_are`.
- Updated `src/cbfkit/systems/quadrotor_6dof/controllers/geometric.py` to use the new `lqr` utility.
- Updated `src/cbfkit/systems/quadrotor_6dof/certificates/lyapunov_functions.py` to use the new `lqr` utility.
- Updated `pyproject.toml` to remove `control` and add `scipy>=1.10`.

---
*PR created automatically by Jules for task [6856641892050554934](https://jules.google.com/task/6856641892050554934) started by @bardhh*