### PR TITLE
🧾 Piper: Introduce SolverStatus IntEnum

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -50,6 +50,7 @@ from cbfkit.utils.user_types import (
     DynamicsCallable,
     GenerateComputeCertificateConstraintCallable,
     Key,
+    SolverStatus,
     State,
 )
 
@@ -473,8 +474,8 @@ def cbf_clf_qp_generator(
 
             # Sentinel: Explicitly catch NaN solutions even if solver claims success
             # Also catch if inputs were NaN (solver might return 0 and UNSOLVED status 0)
-            status = jnp.where(jnp.any(jnp.isnan(sol)), -1, status)
-            status = jnp.where(nan_in_inputs, -2, status)
+            status = jnp.where(jnp.any(jnp.isnan(sol)), SolverStatus.NAN_DETECTED, status)
+            status = jnp.where(nan_in_inputs, SolverStatus.NAN_INPUT_DETECTED, status)
 
             # Bolt: Rescale solution back to physical units
             if auto_p_mat:
@@ -484,13 +485,13 @@ def cbf_clf_qp_generator(
             # inadvertently violating CBF constraints on the QP-solved path.
             # Sentinel: Only accept SOLVED (1) as success.
             # Status 2 (MAX_ITER) or 5 (MAX_ITER_UNSOLVED) means potentially unconverged/unsafe solution.
-            success = status == 1
+            success = status == SolverStatus.SOLVED
 
             def _print_failure(status, iter_num, sub_data):
                 # Sentinel: Map status codes to human-readable strings
                 def print_status_msg(msg):
                     jdebug.print(
-                        "⚠️ CBF-CLF-QP Failed! Status: {status} (Iter: {iter}). Output set to NaN.\n"
+                        "⚠️ CBF-CLF-QP Failed! Status: {status} ({msg}) (Iter: {iter}). Output set to NaN.\n"
                         "   Config: relax_cbf={relax_cbf}, relax_clf={relax_clf}",
                         status=status,
                         msg=msg,
@@ -502,17 +503,17 @@ def cbf_clf_qp_generator(
                 lax.switch(
                     status + 2,  # Map -2 to index 0
                     [
-                        lambda: print_status_msg("NAN_INPUT_DETECTED"),  # -2
-                        lambda: print_status_msg("NAN_DETECTED"),  # -1
-                        lambda: print_status_msg("UNSOLVED"),  # 0
+                        lambda: print_status_msg("NAN_INPUT_DETECTED"),  # SolverStatus.NAN_INPUT_DETECTED
+                        lambda: print_status_msg("NAN_DETECTED"),  # SolverStatus.NAN_DETECTED
+                        lambda: print_status_msg("UNSOLVED"),  # SolverStatus.UNSOLVED
                         lambda: jdebug.print(
                             "⚠️ CBF-CLF-QP Succeeded (Unexpected failure call). Status: {status}",
                             status=status,
-                        ),  # 1 (Should not happen)
-                        lambda: print_status_msg("MAX_ITER_REACHED"),  # 2
-                        lambda: print_status_msg("PRIMAL_INFEASIBLE"),  # 3
-                        lambda: print_status_msg("DUAL_INFEASIBLE"),  # 4
-                        lambda: print_status_msg("MAX_ITER_UNSOLVED"),  # 5
+                        ),  # SolverStatus.SOLVED (Should not happen)
+                        lambda: print_status_msg("MAX_ITER_REACHED"),  # SolverStatus.MAX_ITER_REACHED
+                        lambda: print_status_msg("PRIMAL_INFEASIBLE"),  # SolverStatus.PRIMAL_INFEASIBLE
+                        lambda: print_status_msg("DUAL_INFEASIBLE"),  # SolverStatus.DUAL_INFEASIBLE
+                        lambda: print_status_msg("MAX_ITER_UNSOLVED"),  # SolverStatus.MAX_ITER_UNSOLVED
                     ],
                 )
 

--- a/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
@@ -6,6 +6,8 @@ import jax.numpy as jnp
 from jax import Array, jit
 from jaxopt import OSQP, EqualityConstrainedQP
 
+from cbfkit.utils.user_types import SolverStatus
+
 # Instantiate QP solver objects
 MAX_ITER = 1000000
 QP = OSQP(maxiter=MAX_ITER, tol=1e-3)
@@ -86,7 +88,7 @@ def solve_inequality_constrained_qp(
     # This allows downstream controllers to fail safely (since 5 != success) but report the specific cause.
     status = jnp.where(
         (status == 0) & (state.iter_num >= MAX_ITER),
-        5,
+        SolverStatus.MAX_ITER_UNSOLVED,
         status,
     )
 
@@ -157,7 +159,7 @@ def solve_with_state(
         h_mat, f_vec, g_mat, h_vec, a_mat, b_vec, init_params
     )
     # Only SOLVED (1) is success. MAX_ITER_REACHED (2) may return non-converged solution.
-    success = status == 1
+    success = status == SolverStatus.SOLVED
     return sol, success, params
 
 

--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -38,6 +38,7 @@ from cbfkit.utils.user_types import (
     PlannerData,
     SensorCallable,
     SimulationResults,
+    SolverStatus,
     State,
     StlTrajectoryCostCallable,
     Time,
@@ -49,14 +50,15 @@ from .simulator_jit import simulator_jit
 from .utils import SimulationStepData
 
 
-SOLVER_STATUS_MAP = {
-    -1: "NAN_DETECTED",
-    0: "UNSOLVED (Likely Infeasible)",
-    1: "SOLVED",
-    2: "MAX_ITER_REACHED",
-    3: "PRIMAL_INFEASIBLE",
-    4: "DUAL_INFEASIBLE",
-    5: "MAX_ITER_REACHED (UNSOLVED)",
+SOLVER_STATUS_MAP: Dict[int, str] = {
+    SolverStatus.NAN_INPUT_DETECTED: "NAN_INPUT_DETECTED",
+    SolverStatus.NAN_DETECTED: "NAN_DETECTED",
+    SolverStatus.UNSOLVED: "UNSOLVED (Likely Infeasible)",
+    SolverStatus.SOLVED: "SOLVED",
+    SolverStatus.MAX_ITER_REACHED: "MAX_ITER_REACHED",
+    SolverStatus.PRIMAL_INFEASIBLE: "PRIMAL_INFEASIBLE",
+    SolverStatus.DUAL_INFEASIBLE: "DUAL_INFEASIBLE",
+    SolverStatus.MAX_ITER_UNSOLVED: "MAX_ITER_REACHED (UNSOLVED)",
 }
 
 
@@ -120,7 +122,7 @@ def _check_simulation_status(
         idx_data = controller_data_keys.index(status_key)
         status_codes = controller_data_values[idx_data]
         # Check for status 2 (MAX_ITER_REACHED)
-        max_iter_mask = status_codes == 2
+        max_iter_mask = status_codes == SolverStatus.MAX_ITER_REACHED
         if jnp.any(max_iter_mask):
             count = int(jnp.sum(max_iter_mask).item())
             print(
@@ -256,7 +258,7 @@ def simulator(
             # Sentinel: Check for NaNs
             if jnp.any(jnp.isnan(x_ret)):
                 controller_data = controller_data._replace(
-                    error=jnp.array(True), error_data=jnp.array(-1)
+                    error=jnp.array(True), error_data=jnp.array(SolverStatus.NAN_DETECTED)
                 )
 
             u = u_ret

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -42,7 +42,7 @@ Examples
 >>> x: State = jnp.array([1, 2, 2.4])
 """
 
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Protocol, Tuple, TypedDict, Union
 
 from jax import Array, random
@@ -135,6 +135,19 @@ class SimulationResults(NamedTuple):
                 f"Key '{key}' not found in SimulationResults fields, controller_data, or planner_data."
             )
         return tuple.__getitem__(self, key)
+
+
+class SolverStatus(IntEnum):
+    """Solver status codes."""
+
+    NAN_INPUT_DETECTED = -2
+    NAN_DETECTED = -1
+    UNSOLVED = 0
+    SOLVED = 1
+    MAX_ITER_REACHED = 2
+    PRIMAL_INFEASIBLE = 3
+    DUAL_INFEASIBLE = 4
+    MAX_ITER_UNSOLVED = 5
 
 
 # Certificate (Barrier, Lyapunov, Barrier-Lyapunov, etc.) Function Callables


### PR DESCRIPTION
Introduced `SolverStatus` IntEnum to replace magic numbers for QP solver status codes. This improves type safety and readability across the controller, solver, and simulator modules. Also fixed a minor bug in debug printing exposed during testing.

---
*PR created automatically by Jules for task [1559482705198384663](https://jules.google.com/task/1559482705198384663) started by @bardhh*