### PR TITLE
✉️ Hermes: Fix missing QP failure messages and NaN status mapping

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -491,7 +491,7 @@ def cbf_clf_qp_generator(
                 # Sentinel: Map status codes to human-readable strings
                 def print_status_msg(msg):
                     jdebug.print(
-                        "⚠️ CBF-CLF-QP Failed! Status: {status} (Iter: {iter}). Output set to NaN.\n"
+                        "⚠️ CBF-CLF-QP Failed! Status: {status} ({msg}) (Iter: {iter}). Output set to NaN.\n"
                         "   Config: relax_cbf={relax_cbf}, relax_clf={relax_clf}",
                         status=status,
                         msg=msg,
@@ -501,8 +501,9 @@ def cbf_clf_qp_generator(
                     )
 
                 lax.switch(
-                    status + 1,  # Map -1 to index 0
+                    status + 2,  # Map -2 to index 0
                     [
+                        lambda: print_status_msg("NAN_INPUT_DETECTED"),  # -2
                         lambda: print_status_msg("NAN_DETECTED"),  # -1
                         lambda: print_status_msg("UNSOLVED"),  # 0
                         lambda: jdebug.print(


### PR DESCRIPTION
This PR addresses a developer experience issue where QP solver failures were not printing their specific error messages (e.g., "PRIMAL_INFEASIBLE") and NaN inputs (status -2) were not correctly identified in the failure logs.

Changes:
1.  **Fix `jax.debug.print` format string:** The `msg` argument was passed to `jax.debug.print` but not used in the format string, causing JAX to raise an `Unused keyword arguments` exception (or silence the message). It is now included as `{msg}`.
2.  **Fix `lax.switch` status mapping:** The previous logic `status + 1` was insufficient for status code `-2` (`NAN_INPUT_DETECTED`). The logic is updated to `status + 2`, and a new branch for `-2` is added at index 0.

Verification:
- Created a reproduction script `reproduce_issue.py` (deleted before submission) that confirmed the crash/missing message and verified the fix.
- Ran `tests/test_controllers/test_cbf_clf_controllers/test_nan_input_safety.py` (PASSED).
- Ran `tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py` (PASSED).
- Ran `tests/test_controllers/test_cbf_clf_controllers/test_solver_failure_safety.py` (PASSED).

---
*PR created automatically by Jules for task [15248295842029030444](https://jules.google.com/task/15248295842029030444) started by @bardhh*