### PR TITLE
📦 Archivist: Prevent Monte Carlo from clobbering global random state

### DIFF
--- a/src/cbfkit/simulation/monte_carlo.py
+++ b/src/cbfkit/simulation/monte_carlo.py
@@ -27,28 +27,37 @@ def _map_function(args):
     """
     func, trial_no, worker_seed, kwargs = args
 
-    # Seed global numpy random for legacy support and ensure diversity
-    if worker_seed is not None:
-        # np.random.seed requires uint32
-        np.random.seed(int(worker_seed % (2**32)))
+    # Save state to restore later, preventing side effects on global random state
+    # (especially important when running sequentially in the main process)
+    rng_state = np.random.get_state()
 
-    # Determine if we can inject JAX key
-    inject_key = False
-    if worker_seed is not None:
-        try:
-            sig = inspect.signature(func)
-            params = sig.parameters
-            if "key" in params or any(p.kind == p.VAR_KEYWORD for p in params.values()):
+    try:
+        # Seed global numpy random for legacy support and ensure diversity
+        if worker_seed is not None:
+            # np.random.seed requires uint32
+            np.random.seed(int(worker_seed % (2**32)))
+
+        # Determine if we can inject JAX key
+        inject_key = False
+        if worker_seed is not None:
+            try:
+                sig = inspect.signature(func)
+                params = sig.parameters
+                if "key" in params or any(p.kind == p.VAR_KEYWORD for p in params.values()):
+                    inject_key = True
+            except (ValueError, TypeError):
+                # Fallback: if we can't inspect, assume compliant with docstring (accepts kwargs)
                 inject_key = True
-        except (ValueError, TypeError):
-            # Fallback: if we can't inspect, assume compliant with docstring (accepts kwargs)
-            inject_key = True
 
-    if inject_key and worker_seed is not None:
-        kwargs = kwargs.copy()
-        kwargs["key"] = random.PRNGKey(worker_seed)
+        if inject_key and worker_seed is not None:
+            kwargs = kwargs.copy()
+            kwargs["key"] = random.PRNGKey(worker_seed)
 
-    return func(trial_no, **kwargs)
+        return func(trial_no, **kwargs)
+
+    finally:
+        # Restore global random state
+        np.random.set_state(rng_state)
 
 
 def conduct_monte_carlo(

--- a/tests/test_simulation/test_monte_carlo_determinism.py
+++ b/tests/test_simulation/test_monte_carlo_determinism.py
@@ -1,0 +1,41 @@
+
+import unittest
+import numpy as np
+from cbfkit.simulation import monte_carlo
+
+def dummy_task(trial_no, **kwargs):
+    return trial_no
+
+class TestMonteCarloDeterminism(unittest.TestCase):
+    def test_global_random_state_preservation(self):
+        """Test that conduct_monte_carlo does not modify the global numpy random state."""
+
+        # Set a known state
+        np.random.seed(42)
+        state_before = np.random.get_state()
+        val1 = np.random.rand()
+
+        # We need to reset to state_before or just check the sequence continues as expected
+        # Let's check that the sequence matches what we expect if MC wasn't run.
+
+        np.random.set_state(state_before)
+        # Advance by 1
+        _ = np.random.rand()
+        val2_expected = np.random.rand()
+
+        # Now do the actual run
+        np.random.set_state(state_before)
+        # Advance by 1 (the val1 above)
+        _ = np.random.rand()
+
+        # Run MC
+        # We use n_processes=1 to ensure it runs in the current process
+        monte_carlo.conduct_monte_carlo(dummy_task, n_trials=5, n_processes=1, seed=123)
+
+        # Check next value
+        val2_actual = np.random.rand()
+
+        self.assertEqual(val2_actual, val2_expected, "Global random state was modified by conduct_monte_carlo")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Prevents `conduct_monte_carlo` from permanently modifying the global `numpy.random` state by saving and restoring it around the trial execution. This ensures that the random state of the caller remains deterministic and unaffected by the internal seeding of the Monte Carlo trials.

---
*PR created automatically by Jules for task [7824825159355579654](https://jules.google.com/task/7824825159355579654) started by @bardhh*