### PR TITLE
🔮 Oracle: Fix Lyapunov stability docstrings and enforce parameter validation

### DIFF
--- a/src/cbfkit/certificates/conditions/lyapunov_conditions/exponential_stability.py
+++ b/src/cbfkit/certificates/conditions/lyapunov_conditions/exponential_stability.py
@@ -59,13 +59,14 @@ from jax import Array, lax
 def e_s(c: float) -> Callable[[Array], Array]:
     """Generates function for computing RHS of Lyapunov conditions for Exponential stability:
 
-    Vdot <= -c1*V
+    Vdot <= -c*V
 
     Args:
-        c1 (float): convergence constant
+        c (float): convergence constant
 
     Returns
     -------
         Callable[[Array], Array]: ES Lyapunov conditions
     """
+    assert c > 0
     return lambda V: lax.cond(V > 0, lambda _fake: -c * V, lambda _fake: 0.0, 0)

--- a/src/cbfkit/certificates/conditions/lyapunov_conditions/finite_time_stability.py
+++ b/src/cbfkit/certificates/conditions/lyapunov_conditions/finite_time_stability.py
@@ -59,14 +59,16 @@ from jax import Array, lax
 def ft_s(c: float, e: float) -> Callable[[Array], Array]:
     """Generates function for computing RHS of Lyapunov conditions for FTS:
 
-    Vdot <= -c1*V**e1
+    Vdot <= -c*V**e
 
     Args:
-        c1 (float): convergence constant
-        e1 (float): exponential constant
+        c (float): convergence constant
+        e (float): exponential constant
 
     Returns
     -------
         Callable[[Array], Array]: FTS Lyapunov conditions
     """
+    assert c > 0
+    assert 0 < e < 1
     return lambda V: lax.cond(V > 0, lambda _fake: -c * V**e, lambda _fake: 0.0, 0)

--- a/src/cbfkit/certificates/conditions/lyapunov_conditions/fixed_time_stability.py
+++ b/src/cbfkit/certificates/conditions/lyapunov_conditions/fixed_time_stability.py
@@ -64,11 +64,15 @@ def fxt_s(c1: float, c2: float, e1: float, e2: float) -> Callable[[Array], Array
     Args:
         c1 (float): convergence constant 1
         c2 (float): convergence constant 2
-        e1 (float): exponential constant 1
-        e2 (float): exponential constant 2
+        e1 (float): exponential constant 1 (0 < e1 < 1)
+        e2 (float): exponential constant 2 (e2 > 1)
 
     Returns
     -------
         Callable[[Array], Array]: FxTS Lyapunov conditions
     """
+    assert c1 > 0
+    assert c2 > 0
+    assert 0 < e1 < 1
+    assert e2 > 1
     return lambda V: lax.cond(V > 0, lambda _fake: -c1 * V**e1 - c2 * V**e2, lambda _fake: 0.0, 0)


### PR DESCRIPTION
This PR aligns the Lyapunov stability condition implementations in `src/cbfkit/certificates/conditions/lyapunov_conditions/` with their documentation and mathematical definitions. Specifically, it corrects variable name mismatches in docstrings and adds runtime assertions to enforce parameter constraints required for finite-time and fixed-time stability (e.g., exponents must be in (0, 1) or > 1). This prevents users from inadvertently creating invalid or unstable controllers.

---
*PR created automatically by Jules for task [7168324263949347501](https://jules.google.com/task/7168324263949347501) started by @bardhh*