### PR TITLE
⚙️ Flux: Improve CI reliability for slow tests

### DIFF
--- a/tests/test_examples_and_tutorials.py
+++ b/tests/test_examples_and_tutorials.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 
@@ -22,7 +23,7 @@ SCRIPTS_TO_TEST = [
 
 @pytest.mark.slow
 @pytest.mark.parametrize("script_path", SCRIPTS_TO_TEST)
-def test_example_script_execution(script_path):
+def test_example_script_execution(script_path, tmp_path):
     """Runs the specified example script as a subprocess and asserts it exits with code 0."""
     # Check if file exists
     if not os.path.exists(script_path):
@@ -32,14 +33,29 @@ def test_example_script_execution(script_path):
     env = os.environ.copy()
     env["MPLBACKEND"] = "Agg"
     env["CBFKIT_TEST_MODE"] = "1"
-    # Ensure src and root (for examples) are in python path
-    env["PYTHONPATH"] = f"{os.getcwd()}{os.pathsep}{os.path.join(os.getcwd(), 'src')}"
+    # Ensure tmp_path (for generated/copied modules), src and root (for examples) are in python path
+    # Prepend tmp_path to PYTHONPATH so that imported modules (like 'tutorials') are loaded
+    # from the temporary directory (where code generation happens) instead of the source tree.
+    env["PYTHONPATH"] = f"{tmp_path}{os.pathsep}{os.getcwd()}{os.pathsep}{os.path.join(os.getcwd(), 'src')}"
+
+    # Copy script parent directory to tmp_path to ensure relative assets/imports work
+    # and to isolate output files.
+    src_dir = os.path.dirname(script_path)
+    dst_dir = tmp_path / src_dir
+
+    # We use dirs_exist_ok=True just in case, though tmp_path should be empty
+    shutil.copytree(src_dir, dst_dir, dirs_exist_ok=True)
 
     try:
         # Run the script
         # We use sys.executable to ensure we use the same python interpreter (venv)
         subprocess.run(
-            [sys.executable, script_path], env=env, capture_output=True, text=True, check=True
+            [sys.executable, script_path],
+            env=env,
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            check=True,
         )
 
     except subprocess.CalledProcessError as e:

--- a/tutorials/mppi_stochastic_cbf_reach_avoid.py
+++ b/tutorials/mppi_stochastic_cbf_reach_avoid.py
@@ -155,7 +155,7 @@ mppi_args = {
     "robot_state_dim": 4,
     "robot_control_dim": 2,
     "prediction_horizon": 80,  # 150,
-    "num_samples": 1000,  # Reduced from 20000 to prevent memory issues with JIT data logging
+    "num_samples": 1000 if not os.getenv("CBFKIT_TEST_MODE") else 100,  # Reduced from 20000 to prevent memory issues with JIT data logging
     "plot_samples": 30,
     "time_step": dt * 2.0,
     "use_GPU": False,

--- a/tutorials/simulate_mppi_cbf.py
+++ b/tutorials/simulate_mppi_cbf.py
@@ -116,7 +116,7 @@ mppi_args = {
     "robot_state_dim": 2,
     "robot_control_dim": 2,
     "prediction_horizon": 80,
-    "num_samples": 20000,
+    "num_samples": 20000 if not os.getenv("CBFKIT_TEST_MODE") else 100,
     "plot_samples": 30,
     "time_step": DT,
     "use_GPU": False,

--- a/tutorials/simulate_mppi_stl.py
+++ b/tutorials/simulate_mppi_stl.py
@@ -197,7 +197,7 @@ mppi_args = {
     "robot_state_dim": 2,
     "robot_control_dim": 2,
     "prediction_horizon": 50,  # 100,  # 150,
-    "num_samples": 10000,
+    "num_samples": 10000 if not os.getenv("CBFKIT_TEST_MODE") else 100,
     "plot_samples": 30,
     "time_step": DT,
     "use_GPU": False,


### PR DESCRIPTION
This PR improves the reliability and speed of the `slow` tests in CI, specifically targeting the example and tutorial scripts.

Changes:
- `tests/test_examples_and_tutorials.py`:
    - Uses `tmp_path` to isolate script execution.
    - Copies script directories to `tmp_path` to preserve relative imports and assets.
    - Prepends `tmp_path` to `PYTHONPATH` so generated modules (like `tutorials.mppi_cbf_si`) can be imported.
- `tutorials/simulate_mppi_cbf.py`, `tutorials/simulate_mppi_stl.py`, `tutorials/mppi_stochastic_cbf_reach_avoid.py`:
    - Reduces `num_samples` from 10k/20k to 100 when `CBFKIT_TEST_MODE` is set. This prevents OOM errors and timeouts in the CI environment.

These changes resolve flakiness due to resource exhaustion and potential file conflicts, while maintaining test coverage.

---
*PR created automatically by Jules for task [13664640129389514944](https://jules.google.com/task/13664640129389514944) started by @bardhh*