### PR TITLE
⚡ Bolt: Avoid double dynamics evaluation in CBF-CLF constraints

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/generating_functions.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/generating_functions.py
@@ -3,6 +3,7 @@
 """
 
 from typing import Any, Callable, Dict, List, Optional, Tuple
+import inspect
 
 import jax.numpy as jnp
 from jax import Array, jit, lax, vmap
@@ -76,6 +77,13 @@ def generate_compute_cbf_clf_constraints(
         control_limits, dyn_func, barriers, lyapunovs, **kwargs
     )
 
+    # Bolt: Check if sub-functions accept pre-computed dynamics (f, g)
+    sig_cbf = inspect.signature(compute_cbf_constraints)
+    pass_fg_cbf = "f" in sig_cbf.parameters and "g" in sig_cbf.parameters
+
+    sig_clf = inspect.signature(compute_clf_constraints)
+    pass_fg_clf = "f" in sig_clf.parameters and "g" in sig_clf.parameters
+
     @jit
     def compute_cbf_clf_constraints(t: float, x: Array) -> Tuple[Array, Array, Dict[str, Any]]:
         """_summary_
@@ -84,8 +92,18 @@ def generate_compute_cbf_clf_constraints(
         -------
             _type_: _description_
         """
-        amat_cbf, bvec_cbf, cbf_data = compute_cbf_constraints(t, x)
-        amat_clf, bvec_clf, clf_data = compute_clf_constraints(t, x)
+        # Bolt: Evaluate dynamics once to avoid double evaluation in sub-functions
+        f, g = dyn_func(x)
+
+        if pass_fg_cbf:
+            amat_cbf, bvec_cbf, cbf_data = compute_cbf_constraints(t, x, f=f, g=g)
+        else:
+            amat_cbf, bvec_cbf, cbf_data = compute_cbf_constraints(t, x)
+
+        if pass_fg_clf:
+            amat_clf, bvec_clf, clf_data = compute_clf_constraints(t, x, f=f, g=g)
+        else:
+            amat_clf, bvec_clf, clf_data = compute_clf_constraints(t, x)
 
         return (
             jnp.vstack([amat_cbf, amat_clf]),

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/vanilla_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/vanilla_clfs.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import jax.numpy as jnp
 from jax import Array, jit, lax
@@ -38,11 +38,20 @@ def generate_compute_vanilla_clf_constraints(
     scale_clf = kwargs.get("scale_clf", 1.0)
 
     @jit
-    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_clf_constraints(
+        t: Time,
+        x: State,
+        f: Optional[Array] = None,
+        g: Optional[Array] = None,
+    ) -> Tuple[Array, Array, Dict[str, Any]]:
         """Computes CBF and CLF constraints."""
         nonlocal a_clf, b_clf
         data: Dict[str, Any] = {}
-        dyn_f, dyn_g = dyn_func(x)
+
+        dyn_f = f
+        dyn_g = g
+        if dyn_f is None or dyn_g is None:
+            dyn_f, dyn_g = dyn_func(x)
 
         if n_lfs > 0:
             lf_x, lj_x, _, dlf_t, lc_x = compute_lyapunov_values(t, x)

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/zeroing_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/zeroing_cbfs.py
@@ -2,7 +2,7 @@
 #! docstring
 """
 
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import jax.numpy as jnp
 from jax import Array, jit, lax
@@ -43,11 +43,20 @@ def generate_compute_zeroing_cbf_constraints(
     scale_cbf = kwargs.get("scale_cbf", 1.0)
 
     @jit
-    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_cbf_constraints(
+        t: Time,
+        x: State,
+        f: Optional[Array] = None,
+        g: Optional[Array] = None,
+    ) -> Tuple[Array, Array, Dict[str, Any]]:
         """Computes CBF and CLF constraints."""
         nonlocal a_cbf, b_cbf
         data: Dict[str, Any] = {}
-        dyn_f, dyn_g = dyn_func(x)
+
+        dyn_f = f
+        dyn_g = g
+        if dyn_f is None or dyn_g is None:
+            dyn_f, dyn_g = dyn_func(x)
 
         if n_bfs > 0:
             bf_x, bj_x, _, dbf_t, bc_x = compute_barrier_values(t, x)


### PR DESCRIPTION
This PR optimizes the CBF-CLF-QP controller constraint generation by eliminating redundant evaluations of the system dynamics.

Previously, `compute_cbf_clf_constraints` would call `compute_cbf_constraints` and `compute_clf_constraints`, each of which would independently call `dyn_func(x)`. This resulted in the dynamics being evaluated twice per control step (or more, depending on the structure).

This change:
1.  Refactors `generate_compute_cbf_clf_constraints` (the aggregator) to evaluate dynamics `f, g = dyn_func(x)` once.
2.  Uses `inspect.signature` at generation time to detect if the inner constraint generators accept pre-computed dynamics (`f` and `g`).
3.  Updates the standard `zeroing_cbfs` and `vanilla_clfs` generators to accept optional `f` and `g` arguments, utilizing them if provided.

This optimization is particularly beneficial for systems with computationally expensive dynamics (e.g., rigid body dynamics with many links) or when using automatic differentiation through complex models.

**Verification:**
- A reproduction script confirmed that "Dynamics called" print statements were reduced from 2 to 1 per step.
- Existing tests pass.
- Backward compatibility is maintained for custom constraint generators that do not accept the new arguments.

---
*PR created automatically by Jules for task [10264780015277411845](https://jules.google.com/task/10264780015277411845) started by @bardhh*