### PR TITLE
fix(examples): correct imports and path in unicycle vanilla cbf example

### DIFF
--- a/examples/unicycle/reach_goal/vanilla_cbf_start_to_goal_main.py
+++ b/examples/unicycle/reach_goal/vanilla_cbf_start_to_goal_main.py
@@ -1,3 +1,10 @@
+import sys
+import os
+
+# Add the project root to the path so we can import examples
+root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+sys.path.insert(0, root_path)
+
 import jax.numpy as jnp
 
 import cbfkit.simulation.simulator as sim
@@ -10,6 +17,7 @@ from cbfkit.certificates.conditions.barrier_conditions import (
     zeroing_barriers,
 )
 from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller as cbf_controller
+import examples.unicycle.common.ellipsoidal_obstacle as ellipsoidal_obstacle
 
 # Simulation parameters
 tf = 10.0
@@ -55,7 +63,7 @@ ellipsoids = [
 
 barriers = [
     rectify_relative_degree(
-        function=unicycle.certificates.barrier_functions.ellipsoidal_obstacle.cbf(obs, ell),
+        function=ellipsoidal_obstacle.cbf(obs, ell),
         system_dynamics=unicycle_dynamics,
         state_dim=len(init_state),
         form="exponential",


### PR DESCRIPTION
This PR fixes a runtime failure in `examples/unicycle/reach_goal/vanilla_cbf_start_to_goal_main.py` caused by a broken import and incorrect `sys.path` setup.

Changes:
- Corrected import path for `ellipsoidal_obstacle`.
- Added `sys.path` manipulation to include repository root, allowing `examples` package imports to work during standalone execution.

Verification:
- The fixed script now runs successfully (Exit Code 0).
- Verified `tutorials/single_integrator_dynamic_obstacles.py` and `tutorials/code_generation_tutorial.ipynb` also pass.

---
*PR created automatically by Jules for task [7063357532267793741](https://jules.google.com/task/7063357532267793741) started by @bardhh*