### PR TITLE
🔧 Relay Worker: Fix batch 11 (2/2 files fixed)

### DIFF
--- a/tutorials/tutorials/mppi_cbf_si/certificate_functions/lyapunov_functions/lyapunov_1.py
+++ b/tutorials/tutorials/mppi_cbf_si/certificate_functions/lyapunov_functions/lyapunov_1.py
@@ -1,9 +1,9 @@
 """
-#! MANUALLY POPULATE (docstring)
+Lyapunov function 1
 """
 import jax.numpy as jnp
 from jax import jit, jacfwd, jacrev, Array, lax
-from typing import List, Callable
+from typing import Callable
 from cbfkit.certificates import certificate_package
 
 N = 2
@@ -14,14 +14,14 @@ N = 2
 ###############################################################################
 
 
-def clf(goal: float, **kwargs) -> Callable[[Array], Array]:
+def clf(goal: Array, **kwargs) -> Callable[[Array], Array]:
     """Super-level set convention.
 
     Args:
-        #! kwargs -- optional to manually populate
+        goal (Array): goal state
 
     Returns:
-        ret (float): value of goal function evaluated at time and state
+        ret (Array): value of goal function evaluated at time and state
 
     """
 
@@ -41,14 +41,14 @@ def clf(goal: float, **kwargs) -> Callable[[Array], Array]:
     return func
 
 
-def clf_grad(goal: float, **kwargs) -> Callable[[Array], Array]:
+def clf_grad(goal: Array, **kwargs) -> Callable[[Array], Array]:
     """Jacobian for the goal function defined by clf.
 
     Args:
-        #! kwargs -- manually populate
+        goal (Array): goal state
 
     Returns:
-        ret (float): value of goal function evaluated at time and state
+        ret (Array): value of goal function evaluated at time and state
 
     """
     jacobian = jacfwd(clf(goal, **kwargs))
@@ -69,14 +69,14 @@ def clf_grad(goal: float, **kwargs) -> Callable[[Array], Array]:
     return func
 
 
-def clf_hess(goal: float, **kwargs) -> Callable[[Array], Array]:
+def clf_hess(goal: Array, **kwargs) -> Callable[[Array], Array]:
     """Hessian for the goal function defined by clf.
 
     Args:
-        #! kwargs -- manually populate
+        goal (Array): goal state
 
     Returns:
-        ret (float): value of goal function evaluated at time and state
+        ret (Array): value of goal function evaluated at time and state
 
     """
     hessian = jacrev(jacfwd(clf(goal, **kwargs)))

--- a/tutorials/tutorials/mppi_cbf_si/controllers/controller_1.py
+++ b/tutorials/tutorials/mppi_cbf_si/controllers/controller_1.py
@@ -1,5 +1,5 @@
 import jax.numpy as jnp
-from typing import *
+from typing import Optional
 from jax import jit, Array, lax
 from cbfkit.utils.user_types import (
     NominalControllerCallable,
@@ -16,7 +16,7 @@ def controller_1(
     Create a controller for the given dynamics.
 
     Args:
-        #! USER-POPULATE
+        k_p (float): proportional gain
 
     Returns:
         controller (Callable): handle to function computing control
@@ -39,7 +39,7 @@ def controller_1(
         """
         # logging data
         u_nom_val = -k_p * (x[0] - xd[0]), -k_p * (x[1] - xd[1])
-        data = ControllerData(u_nom=u_nom_val)
+        data = ControllerData(u_nom=jnp.array(u_nom_val))
 
         return jnp.array(u_nom_val), data
 


### PR DESCRIPTION
Fixed 2 files in tutorials/tutorials/mppi_cbf_si/.
- `certificate_functions/lyapunov_functions/lyapunov_1.py`: Updated `goal` type hint to `Array`, removed unused imports and placeholders.
- `controllers/controller_1.py`: Fixed `ControllerData` instantiation to pass `u_nom` as Array instead of tuple, replaced wildcard import with specific import.

Verified with reproduction scripts.

---
*PR created automatically by Jules for task [9427829159787783201](https://jules.google.com/task/9427829159787783201) started by @bardhh*