### PR TITLE
🔧 Relay Worker: Fix batch 2 (2/2 files fixed)

### DIFF
--- a/examples/pedestrian/head_on_demo.py
+++ b/examples/pedestrian/head_on_demo.py
@@ -6,12 +6,14 @@ Demonstrates the robot navigating a head-on encounter with a pedestrian.
 
 import os
 import sys
+from pathlib import Path
 
 import jax.numpy as jnp
 import numpy as np
 
 # Add project root
-sys.path.append(os.getcwd())
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(PROJECT_ROOT))
 
 from jax import jit
 
@@ -34,7 +36,7 @@ def run_demo():
 
     # Pedestrian moving Left towards robot
     manager.add_pedestrian(
-        init_state=[10.0, 5.0, -1.0, 0.0],
+        init_state=jnp.array([10.0, 5.0, -1.0, 0.0]),
         behavior=social_force_policy(goal=jnp.array([0.0, 5.0]), desired_speed=1.0),
         id="ped_head_on",
     )
@@ -117,7 +119,8 @@ def run_demo():
         verbose=True,
     )
 
-    os.makedirs("examples/pedestrian/results", exist_ok=True)
+    results_dir = Path(__file__).parent / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
     visualize_crowd(
         states=x,
         num_pedestrians=num_peds,
@@ -126,7 +129,7 @@ def run_demo():
         dt=dt,
         p_values=p_values,
         p_keys=p_keys,
-        save_path="examples/pedestrian/results/head_on_demo.mp4",
+        save_path=str(results_dir / "head_on_demo.mp4"),
     )
 
     print("Demo Complete!")

--- a/examples/pedestrian/overtaking_demo.py
+++ b/examples/pedestrian/overtaking_demo.py
@@ -6,12 +6,14 @@ Demonstrates the robot overtaking slower moving pedestrians.
 
 import os
 import sys
+from pathlib import Path
 
 import jax.numpy as jnp
 import numpy as np
 
 # Add project root
-sys.path.append(os.getcwd())
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(PROJECT_ROOT))
 
 from jax import jit
 
@@ -37,13 +39,13 @@ def run_demo():
 
     # Pedestrian 1: Ahead, moving right, slow
     manager.add_pedestrian(
-        init_state=[5.0, 5.0, 0.8, 0.0],
+        init_state=jnp.array([5.0, 5.0, 0.8, 0.0]),
         behavior=social_force_policy(goal=jnp.array([20.0, 5.0]), desired_speed=0.8),
         id="ped_slow_1",
     )
     # Pedestrian 2: Further ahead, slightly offset, moving right, slow
     manager.add_pedestrian(
-        init_state=[9.0, 4.5, 0.7, 0.0],
+        init_state=jnp.array([9.0, 4.5, 0.7, 0.0]),
         behavior=social_force_policy(goal=jnp.array([20.0, 4.5]), desired_speed=0.7),
         id="ped_slow_2",
     )
@@ -126,7 +128,8 @@ def run_demo():
         verbose=True,
     )
 
-    os.makedirs("examples/pedestrian/results", exist_ok=True)
+    results_dir = Path(__file__).parent / "results"
+    results_dir.mkdir(parents=True, exist_ok=True)
     visualize_crowd(
         states=x,
         num_pedestrians=num_peds,
@@ -137,7 +140,7 @@ def run_demo():
             p_values if len(p_keys) > 0 else None
         ),  # Extract from controller data if needed, usually p_values is returned if planner used directly or via wrapper if sim supports it.
         p_keys=p_keys,
-        save_path="examples/pedestrian/results/overtaking_demo.mp4",
+        save_path=str(results_dir / "overtaking_demo.mp4"),
     )
 
     print("Demo Complete!")


### PR DESCRIPTION
Fixed `examples/pedestrian/overtaking_demo.py` and `examples/pedestrian/head_on_demo.py` to be robust against execution directory and strictly type `init_state` as JAX arrays.

Summary of changes:
- Replaced `sys.path.append(os.getcwd())` with `Path(__file__).resolve().parent.parent.parent` to correctly add project root to path.
- Changed `init_state` argument in `add_pedestrian` from list to `jnp.array`.
- Updated results directory creation and file saving to use `Path(__file__).parent / "results"`.
- Verified scripts execute successfully and generate output (GIF/MP4).

---
*PR created automatically by Jules for task [4527643355525333001](https://jules.google.com/task/4527643355525333001) started by @bardhh*