### PR TITLE
Relay Worker: Fix batch 13 (2/3 files fixed, 1 verified)

### DIFF
--- a/examples/van_der_pol/common/visualizations.py
+++ b/examples/van_der_pol/common/visualizations.py
@@ -1,4 +1,5 @@
-# matplotlib.use("macosx")
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 from matplotlib.patches import Ellipse
@@ -139,8 +140,10 @@ def animate(
     )
 
     if save_animation:
+        import os
+        os.makedirs(os.path.dirname(animation_filename), exist_ok=True)
         ani.save(animation_filename, writer="imagemagick", fps=15)
 
-    plt.show()
+    # plt.show()
 
     return fig, ax

--- a/examples/van_der_pol/regulation/ukf_control.py
+++ b/examples/van_der_pol/regulation/ukf_control.py
@@ -90,7 +90,8 @@ if simulate:
             x_traj=jnp.tile(initial_conditions.desired_state.reshape(-1, 1), (1, n_steps + 1)),
             prev_robustness=None,
         ),
-        use_jit=True,
+        sigma=initial_conditions.R,
+        use_jit=False,
     )
 
 else:


### PR DESCRIPTION
Fixed execution issues in batch 13 (van der pol examples).

1. `examples/van_der_pol/regulation/ukf_control.py`:
   - Added `sigma=initial_conditions.R` to `sim.execute` call. This fixes `ValueError` in `unbiased_gaussian_noise` sensor which expects a valid covariance matrix but received dummy empty array.
   - Set `use_jit=False`. The core UKF implementation (`ct_ukf_dtmeas`) attempts to cast a JAX tracer to float, causing `ConcretizationTypeError` during JIT. Disabling JIT allows the example to run.

2. `examples/van_der_pol/common/visualizations.py`:
   - Set matplotlib backend to `Agg` to support headless environments.
   - Commented out `plt.show()` to prevent blocking execution.
   - Added `os.makedirs(..., exist_ok=True)` before `ani.save` to ensure the target directory exists, preventing `FileNotFoundError`.

3. `examples/van_der_pol/common/lyapunov_barrier_functions.py`:
   - Verified that imports are correct and file executes without error.

Verified fixes by running `ukf_control.py` which successfully starts simulation and logs progress.

---
*PR created automatically by Jules for task [2197169964734476122](https://jules.google.com/task/2197169964734476122) started by @bardhh*