### PR TITLE
Relay Worker: Fix batch 21 (3/3 files verified)

### DIFF
--- a/tutorials/tutorials/mppi_cbf_si/cost_functions/stage_cost_function/stage_cost.py
+++ b/tutorials/tutorials/mppi_cbf_si/cost_functions/stage_cost_function/stage_cost.py
@@ -27,18 +27,19 @@ def stage_cost(
     """
 
     @jit
-    def func(state_and_time: Array, action: Array) -> Array:
+    def func(state: Array, action: Array) -> Array:
         """Function to be evaluated.
 
         Args:
-            state_and_time (Array): concatenated state vector and time
+            state (Array): state vector
 
         Returns:
-            Array: cbf value
+            Array: cost value
         """
-        x = state_and_time
-        return 0.2 * ((x[0] - goal[0]) ** 2 + (x[1] - goal[1]) ** 2) + 10.0 / jnp.max(
-            jnp.array([(jnp.linalg.norm(x[0:2] - obstacle[0:2]) - obstacle_radius), 0.01])
+        x = state
+        dist = jnp.linalg.norm(x[0:2] - obstacle[0:2]) - obstacle_radius
+        return 0.2 * ((x[0] - goal[0]) ** 2 + (x[1] - goal[1]) ** 2) + 10.0 / jnp.maximum(
+            dist, 0.01
         )
 
     return func

--- a/tutorials/tutorials/mppi_cbf_si/plant.py
+++ b/tutorials/tutorials/mppi_cbf_si/plant.py
@@ -1,7 +1,6 @@
 import jax.numpy as jnp
 from jax import jit, Array
 from cbfkit.utils.user_types import DynamicsCallable, DynamicsCallableReturns
-from .constants import *
 
 
 def plant(**kwargs) -> DynamicsCallable:
@@ -35,8 +34,8 @@ def plant(**kwargs) -> DynamicsCallable:
         Returns:
             dynamics (DynamicsCallable): takes state as input and returns dynamics components f, g
         """
-        f = jnp.array([0, 0])
-        g = jnp.array([[1, 0], [0, 1]])
+        f = jnp.array([0.0, 0.0])
+        g = jnp.array([[1.0, 0.0], [0.0, 1.0]])
 
         return f, g
 


### PR DESCRIPTION
Relay Worker: Fix batch 21 (3/3 files verified)

Fixed type precision issues and inefficient JAX operations in generated tutorial files.

1.  **`tutorials/tutorials/mppi_cbf_si/plant.py`**:
    *   Changed `jnp.array` initialization to use explicit floats (`0.0`) instead of integers to prevent potential type issues.
    *   Removed unused `from .constants import *` which referred to an empty file.

2.  **`tutorials/tutorials/mppi_cbf_si/cost_functions/stage_cost_function/stage_cost.py`**:
    *   Renamed `state_and_time` argument to `state` to reflect actual usage.
    *   Replaced inefficient `jnp.max(jnp.array([...]))` with `jnp.maximum(...)` for better JIT compatibility.

3.  **`tutorials/code_generation_example.py`**:
    *   Verified execution passed successfully after installing `jinja2` via `pip install ".[codegen]"`. No code changes were necessary.

Passed `pytest` for `tutorials/code_generation_example.py` and `tutorials/simulate_mppi_cbf.py`.

---
*PR created automatically by Jules for task [14246422257910476718](https://jules.google.com/task/14246422257910476718) started by @bardhh*