### PR TITLE
🔧 Relay Worker: Fix batch 5 (2/2 files fixed)

### DIFF
--- a/examples/differential_drive/dynamic_obstacle_cbf.py
+++ b/examples/differential_drive/dynamic_obstacle_cbf.py
@@ -25,9 +25,8 @@ from matplotlib.patches import Arrow, Circle
 
 import cbfkit.simulation.simulator as sim
 import cbfkit.systems.unicycle.models.accel_unicycle as unicycle
-from cbfkit.controllers.cbf_clf.utils.barrier_conditions import zeroing_barriers
-from cbfkit.controllers.cbf_clf.utils.certificate_packager import concatenate_certificates
-from cbfkit.controllers.cbf_clf.utils.rectify_relative_degree import rectify_relative_degree
+from cbfkit.certificates import concatenate_certificates, rectify_relative_degree
+from cbfkit.certificates.conditions.barrier_conditions import zeroing_barriers
 from cbfkit.controllers.cbf_clf.vanilla_cbf_clf_qp_control_laws import (
     vanilla_cbf_clf_qp_controller as cbf_controller,
 )
@@ -174,6 +173,11 @@ def run_simulation():
 def create_visualization(states, controls, goal_state, d_min, num_obstacles, dt):
     """Creates animation and plots."""
     print("Generating visualization...")
+
+    # Convert JAX arrays to NumPy
+    states = np.array(states)
+    controls = np.array(controls)
+    goal_state = np.array(goal_state)
 
     # --- Plot 1: Static Trajectory with Obstacle Trails ---
     fig, ax = plt.subplots(figsize=(12, 8))

--- a/examples/differential_drive/human_aware_mppi_cbf.py
+++ b/examples/differential_drive/human_aware_mppi_cbf.py
@@ -27,9 +27,8 @@ from matplotlib.patches import Arrow, Circle
 
 import cbfkit.simulation.simulator as sim
 import cbfkit.systems.unicycle.models.accel_unicycle as unicycle
-from cbfkit.controllers.cbf_clf.utils.barrier_conditions import zeroing_barriers
-from cbfkit.controllers.cbf_clf.utils.certificate_packager import concatenate_certificates
-from cbfkit.controllers.cbf_clf.utils.rectify_relative_degree import rectify_relative_degree
+from cbfkit.certificates import concatenate_certificates, rectify_relative_degree
+from cbfkit.certificates.conditions.barrier_conditions import zeroing_barriers
 from cbfkit.controllers.cbf_clf.vanilla_cbf_clf_qp_control_laws import (
     vanilla_cbf_clf_qp_controller as cbf_controller,
 )
@@ -265,6 +264,9 @@ def analyze_safety(states, num_humans, d_safe):
     min_dists = []
     collisions = 0
 
+    # Convert to numpy
+    states = np.array(states)
+
     for i in range(len(states)):
         z = states[i]
         p_r = z[:2]
@@ -291,6 +293,11 @@ from matplotlib.collections import LineCollection
 
 def create_animation(states, goal_state, num_humans, d_safe, dt, p_keys, p_values):
     print("Generating Animation...")
+
+    # Convert to numpy
+    states = np.array(states)
+    goal_state = np.array(goal_state)
+    p_values = [np.array(val) for val in p_values]
 
     fig, ax = plt.subplots(figsize=(12, 10))
     ax.set_aspect("equal")


### PR DESCRIPTION
This PR fixes execution issues in Batch 5 examples:
1. `examples/differential_drive/dynamic_obstacle_cbf.py`
2. `examples/differential_drive/human_aware_mppi_cbf.py`

Key changes:
- Updated imports to point to `cbfkit.certificates` instead of deprecated `cbfkit.controllers.cbf_clf.utils`.
- Added explicit `np.array()` conversion for JAX arrays before passing them to Matplotlib to avoid overhead and compatibility issues.
- Verified execution of both scripts.

Verification:
- Both scripts run to completion (exit code 0).
- Animations are generated (fallback to GIF if ffmpeg is missing).
- No regressions in `pytest` (unrelated failures observed).

---
*PR created automatically by Jules for task [4021467085884036540](https://jules.google.com/task/4021467085884036540) started by @bardhh*