### PR TITLE
🔧 Relay Worker: Fix batch 19 (3/3 files fixed)

### DIFF
--- a/examples/unicycle/reach_goal/hybrid_estimation_control.py
+++ b/examples/unicycle/reach_goal/hybrid_estimation_control.py
@@ -4,6 +4,12 @@ via ''python examples/template.py''.
 It does not define any new functions, and primarily loads modules from the src/cbfkit tree.
 """
 
+import os
+import sys
+
+# Add the project root directory to the python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
 import jax.numpy as jnp
 import numpy as np
 from jax import jacfwd
@@ -17,7 +23,7 @@ from cbfkit.utils.user_types import PlannerData
 from examples.unicycle.common.config import ekf_ukf_hybrid_state_estimation as initial_conditions
 
 # Define time parameters
-tf = 5.0
+tf = 5.0 if not os.getenv("CBFKIT_TEST_MODE") else 0.5
 dt = 0.01
 n_steps = int(tf / dt)
 
@@ -51,7 +57,7 @@ estimator = hybrid_ekf_ukf(
 
 # Whether or not to simulate, plot
 simulate = 1
-plot = 1
+plot = 1 if not os.getenv("CBFKIT_TEST_MODE") else 0
 save = 1
 
 if simulate:
@@ -87,7 +93,7 @@ if simulate:
             prev_robustness=None,
         ),
         initial_covariance=initial_covariance,
-        use_jit=True,
+        use_jit=False,
     )
 
 else:

--- a/examples/unicycle/reach_goal/stochastic_cbf_control.py
+++ b/examples/unicycle/reach_goal/stochastic_cbf_control.py
@@ -1,4 +1,8 @@
 import os
+import sys
+
+# Add the project root directory to the python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
 import jax.numpy as jnp
 
@@ -79,6 +83,7 @@ controller = cbf_controller(
     dynamics_func=unicycle_dynamics,
     barriers=barrier_packages,
     sigma=sigma,
+    relaxable_cbf=True,
 )
 
 x, u, z, p, dkeys, dvals, planner_data, planner_data_keys = sim.execute(


### PR DESCRIPTION
Fixed execution issues in unicycle reach_goal examples.

1. `hybrid_estimation_control.py`:
   - Fixed `ModuleNotFoundError` by adding project root to `sys.path`.
   - Fixed `jax.errors.ConcretizationTypeError` by disabling JIT (`use_jit=False`). The UKF implementation in `cbfkit` casts traced time variables to float, which is incompatible with JIT.
   - Added `CBFKIT_TEST_MODE` support to reduce simulation time in CI.

2. `stochastic_cbf_control.py`:
   - Fixed `ModuleNotFoundError` by adding project root to `sys.path`.
   - Fixed `MAX_ITER_REACHED` (Status 5) solver failure by enabling `relaxable_cbf=True`. This allows the QP solver to find a solution even when the strict barrier conditions are slightly infeasible due to initial state or noise, preserving the original scenario parameters (obstacles/sigma).

3. `vanilla_cbf_control.py`:
   - Verified as functioning correctly (imports and execution successful).


---
*PR created automatically by Jules for task [15248926586933877768](https://jules.google.com/task/15248926586933877768) started by @bardhh*