### PR TITLE
🧹 Curator: Replace 'control' dependency with 'scipy' for LQR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "cvxopt>=1.3.2,<2.0; platform_machine != 'aarch64' and platform_machine != 'arm64'",
     "kvxopt>=1.3.2.0,<2.0; platform_machine == 'aarch64' or platform_machine == 'arm64'",
     "jaxopt>=0.8.3,<0.9",
-    "control>=0.9.4,<1.0",
+    "scipy>=1.9,<2.0",
     "tqdm>=4.66.2,<5.0"
 ]
 

--- a/src/cbfkit/systems/quadrotor_6dof/certificates/lyapunov_functions.py
+++ b/src/cbfkit/systems/quadrotor_6dof/certificates/lyapunov_functions.py
@@ -1,9 +1,9 @@
 from typing import Callable, List, Tuple
 
 import jax.numpy as jnp
-from control import lqr
 from jax import Array, jacfwd, jacrev, jit
 
+from cbfkit.utils.lqr import compute_lqr_gain
 from cbfkit.utils.matrix_vector_operations import normalize, vee
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
@@ -687,7 +687,7 @@ def double_integrator_control(
     R = jnp.eye(3)
 
     # Compute LQR gain
-    K, _, _ = lqr(A, B, Q, R)
+    K = compute_lqr_gain(A, B, Q, R)
 
     @jit
     def lqr_control(_t: float, x: Array) -> Tuple[Array, Array, Array]:

--- a/src/cbfkit/systems/quadrotor_6dof/controllers/geometric.py
+++ b/src/cbfkit/systems/quadrotor_6dof/controllers/geometric.py
@@ -1,9 +1,9 @@
 from typing import Callable, Optional, Tuple
 
 import jax.numpy as jnp
-from control import lqr
 from jax import Array, jit
 
+from cbfkit.utils.lqr import compute_lqr_gain
 from cbfkit.utils.matrix_vector_operations import hat, normalize, vee
 from cbfkit.utils.user_types import (
     ControllerCallable,
@@ -272,7 +272,7 @@ def lqr_control(xd: Array, dt: float) -> Callable[[float, Array], Tuple[Array, A
     R = jnp.eye(3)
 
     # Compute LQR gain
-    K, _, _ = lqr(A, B, Q, R)
+    K = compute_lqr_gain(A, B, Q, R)
 
     # @jit
     def controller(_t: float, x: Array) -> Tuple[Array, Array, Array]:

--- a/src/cbfkit/utils/lqr.py
+++ b/src/cbfkit/utils/lqr.py
@@ -1,0 +1,44 @@
+"""LQR utility module."""
+
+import jax.numpy as jnp
+import numpy as np
+from scipy.linalg import solve_continuous_are
+from jax import Array
+
+
+def compute_lqr_gain(A: Array, B: Array, Q: Array, R: Array) -> Array:
+    """Computes the LQR gain matrix K for the system dx/dt = Ax + Bu.
+
+    Minimizes the cost function:
+        J = integral(x.T * Q * x + u.T * R * u) dt
+
+    The optimal control is u = -K * x.
+
+    Args:
+        A (Array): System matrix
+        B (Array): Input matrix
+        Q (Array): State cost matrix
+        R (Array): Input cost matrix
+
+    Returns
+    -------
+        Array: Gain matrix K
+    """
+    # Convert JAX arrays to NumPy arrays for SciPy
+    A_np = np.array(A)
+    B_np = np.array(B)
+    Q_np = np.array(Q)
+    R_np = np.array(R)
+
+    # Solve Continuous Algebraic Riccati Equation (CARE)
+    # A.T * P + P * A - P * B * R^-1 * B.T * P + Q = 0
+    P = solve_continuous_are(A_np, B_np, Q_np, R_np)
+
+    # Compute gain K = R^-1 * B.T * P
+    # Note: solve_continuous_are assumes u = -Kx form implicitly for stability,
+    # but strictly returns P.
+    # K = inv(R) * B.T * P
+    R_inv = np.linalg.inv(R_np)
+    K_np = R_inv @ B_np.T @ P
+
+    return jnp.array(K_np)


### PR DESCRIPTION
Replaced the heavy `control` dependency (which pulls in `matplotlib`) with a lightweight implementation of LQR gain computation using `scipy.linalg.solve_continuous_are`. `scipy` is already a transitive dependency of `jax`. This allows for a lighter core installation.

- Created `src/cbfkit/utils/lqr.py` with `compute_lqr_gain`
- Updated `geometric.py` and `lyapunov_functions.py` to use new LQR utility
- Removed `control` from `pyproject.toml`
- Added `scipy` to `pyproject.toml`

---
*PR created automatically by Jules for task [16814969964117178655](https://jules.google.com/task/16814969964117178655) started by @bardhh*