### PR TITLE
⚙️ Flux: Fix broken tests and skip missing dependencies

### DIFF
--- a/tests/test_controllers/test_adaptive_cvar_cbf.py
+++ b/tests/test_controllers/test_adaptive_cvar_cbf.py
@@ -1,5 +1,10 @@
 import unittest
 
+try:
+    import casadi
+except ImportError:
+    casadi = None
+
 import jax.numpy as jnp
 import jax.random as random
 import numpy as np
@@ -16,6 +21,7 @@ class MockObstacle:
         self.noise = [[0.01] * 4, [0.01] * 4]
 
 
+@unittest.skipIf(casadi is None, "CasADi not installed")
 class TestAdaptiveCVaRController(unittest.TestCase):
     def test_controller_factory_and_execution(self):
         # Setup

--- a/tests/test_controllers/test_cbf_clf_controllers/test_vanishing_gradient_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_vanishing_gradient_safety.py
@@ -34,7 +34,7 @@ def test_vanishing_gradient_infeasibility():
 
     controller = generator(
         control_limits=control_limits,
-        dynamics_func=lambda t, x: (jnp.zeros(1), jnp.eye(1)),
+        dynamics_func=lambda x: (jnp.zeros(1), jnp.eye(1)),
         barriers=([], [], [], [], []),
         lyapunovs=([], [], [], [], []),
         relaxable_cbf=False
@@ -81,7 +81,7 @@ def test_vanishing_gradient_spurious():
 
     controller = generator(
         control_limits=control_limits,
-        dynamics_func=lambda t, x: (jnp.zeros(1), jnp.eye(1)),
+        dynamics_func=lambda x: (jnp.zeros(1), jnp.eye(1)),
         barriers=([], [], [], [], []),
         lyapunovs=([], [], [], [], []),
         relaxable_cbf=False

--- a/tests/test_controllers/test_discontinuity_fix.py
+++ b/tests/test_controllers/test_discontinuity_fix.py
@@ -41,7 +41,7 @@ def test_discontinuity_fix():
 
     controller = generator(
         control_limits=control_limits,
-        dynamics_func=lambda t, x: (jnp.zeros(1), jnp.eye(1)),
+        dynamics_func=lambda x: (jnp.zeros(1), jnp.eye(1)),
         barriers=([], [], [], [], []),
         lyapunovs=([], [], [], [], []),
     )

--- a/tests/test_controllers/test_noise_amplification.py
+++ b/tests/test_controllers/test_noise_amplification.py
@@ -39,7 +39,7 @@ def test_noise_amplification():
     # Create controller
     controller = generator(
         control_limits=control_limits,
-        dynamics_func=lambda t, x: (jnp.zeros(2), jnp.eye(2)), # Dummy
+        dynamics_func=lambda x: (jnp.zeros(2), jnp.eye(2)), # Dummy
         barriers=([], [], [], [], []),
         lyapunovs=([], [], [], [], []),
     )

--- a/tests/test_uncertainty_determinism.py
+++ b/tests/test_uncertainty_determinism.py
@@ -72,6 +72,7 @@ class DummyObstacle:
         self.noise = [[0.01]*4, [0.01]*4]
 
 def test_controller_determinism():
+    pytest.importorskip("casadi")
     # Setup
     dynamics_model = {
         "dt": 0.1,


### PR DESCRIPTION
This PR improves CI reliability by fixing broken tests and handling optional dependencies gracefully.

**Changes:**
1.  **Skip CasADi-dependent tests:** Tests in `tests/test_controllers/test_adaptive_cvar_cbf.py` and `tests/test_uncertainty_determinism.py` are now skipped if the `casadi` library is not installed, preventing failures in environments that don't have this optional dependency.
2.  **Fix `dynamics_func` signature:** Tests for `cbf_clf_qp_generator` (`test_discontinuity_fix.py`, `test_noise_amplification.py`, `test_vanishing_gradient_safety.py`) were incorrectly passing a lambda with signature `(t, x)` instead of `(x)`. This caused `TypeError` during JIT compilation. The signature has been corrected to `(x)`.

**Verification:**
-   Run `pytest tests` to verify all tests pass (or skip correctly).
-   Confirmed that `TypeError`s are resolved.
-   Confirmed that `casadi` tests are skipped when `casadi` is missing.

---
*PR created automatically by Jules for task [5979509833868368972](https://jules.google.com/task/5979509833868368972) started by @bardhh*