### PR TITLE
🧮 Janus: fix vanishing constraints on large gradients via stable normalization

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -415,9 +415,25 @@ def cbf_clf_qp_generator(
             # Janus: Avoid normalizing noise vectors. If norm < tol, do NOT scale up.
             # Input constraints (box limits) are already normalized (row norm = 1).
             if auto_p_mat:
-                # Aegis: Use safe norm (sqrt(sum(sq) + eps)) to prevent NaN gradients at 0.
-                row_sq_sums = jnp.sum(g_mat_c**2, axis=1)
-                row_norms_c = jnp.sqrt(row_sq_sums + 1e-20)
+                # Janus: Compute norm safely to avoid overflow for large gradients.
+                # Naive sqrt(sum(sq)) overflows if elements > 1e19 (float32).
+                # We scale by max(abs(x)) to keep squares in range.
+                row_max = jnp.max(jnp.abs(g_mat_c), axis=1)
+                # Avoid division by zero
+                row_max_safe = jnp.where(row_max > 0, row_max, 1.0)
+
+                # Scale the matrix
+                g_mat_c_scaled = g_mat_c / row_max_safe[:, None]
+
+                # Compute norm of scaled matrix
+                row_norms_scaled = jnp.linalg.norm(g_mat_c_scaled, axis=1)
+
+                # Recover true norm
+                row_norms_c = row_norms_scaled * row_max_safe
+
+                # Add epsilon for safety in division
+                row_norms_c = row_norms_c + 1e-20
+
                 # Janus: Normalize constraints robustly.
                 # Use a clamped scaling factor (max 1e8) to:
                 # 1. Enforce constraints with small gradients (e.g. 1e-10) to catch gross infeasibility (Safety).

--- a/tests/test_controllers/test_normalization_overflow.py
+++ b/tests/test_controllers/test_normalization_overflow.py
@@ -1,0 +1,104 @@
+
+import jax
+import jax.numpy as jnp
+import pytest
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.controllers.cbf_clf.generate_constraints import (
+    generate_compute_zeroing_cbf_constraints,
+    generate_compute_vanilla_clf_constraints,
+)
+from cbfkit.utils.user_types import CertificateCollection, ControllerData
+
+# Force float32 to reproduce overflow
+jax.config.update("jax_enable_x64", False)
+
+def test_normalization_overflow():
+    """
+    Verifies that large gradients (triggering float32 overflow in naive norm)
+    do not cause constraints to vanish.
+
+    Case: Lg h = 2e20, Lf h = -2e20.
+    Constraint: Lf h + Lg h * u >= 0  =>  -2e20 + 2e20 * u >= 0  => u >= 1.
+    Nominal u = 0.
+
+    Expected: u = 1.
+    Failure mode (vanished constraint): u = 0.
+    """
+
+    # 1. Define Dynamics
+    # Force inputs to be float32
+    scale = 2.0e20
+
+    def dynamics(x):
+        f = jnp.array([-scale, 0.0], dtype=jnp.float32)
+        g = jnp.array([[scale, 0.0], [0.0, 1.0]], dtype=jnp.float32)
+        return f, g
+
+    def h(t, x): return x[0]
+    def grad_h(t, x): return jnp.array([1.0, 0.0], dtype=jnp.float32)
+    def hess_h(t, x): return jnp.zeros((2, 2), dtype=jnp.float32)
+    def partial_t(t, x): return 0.0
+    def class_k(val): return 0.0
+
+    barriers = ([h], [grad_h], [hess_h], [partial_t], [class_k])
+
+    # 3. Create Controller
+    control_limits = jnp.array([10.0, 10.0], dtype=jnp.float32)
+
+    gen_controller = cbf_clf_qp_generator(
+        generate_compute_zeroing_cbf_constraints,
+        generate_compute_vanilla_clf_constraints
+    )
+
+    controller = gen_controller(
+        control_limits=control_limits,
+        dynamics_func=dynamics,
+        barriers=barriers,
+        lyapunovs=None,
+        relaxable_cbf=False,
+        relaxable_clf=False,
+    )
+
+    # 4. Run Controller
+    t = 0.0
+    x = jnp.array([0.0, 0.0], dtype=jnp.float32)
+    u_nom = jnp.array([0.0, 0.0], dtype=jnp.float32)
+    key = None
+    data = ControllerData(
+        error=jnp.array(False),
+        error_data=jnp.array(0),
+        complete=jnp.array(False),
+        sol=jnp.zeros((2,), dtype=jnp.float32),
+        u=jnp.zeros((2,), dtype=jnp.float32),
+        u_nom=u_nom,
+        sub_data={},
+    )
+
+    # Run twice to ensure JIT compilation happens
+    # First run might be slow
+    print("Running controller (1st pass)...")
+    u_actual, data_out = controller(t, x, u_nom, key, data)
+
+    print(f"Computed Control: {u_actual}")
+    print(f"Solver Status: {data_out.sub_data.get('solver_status')}")
+
+    # Check Result
+    # Expect u[0] >= 1.0 (approx 1.0)
+    # If constraint vanished, u[0] == 0.0
+
+    if jnp.any(jnp.isnan(u_actual)):
+        pytest.fail(f"Computed control contains NaNs: {u_actual}")
+
+    assert u_actual[0] > 0.9, f"Constraint failed! Expected u[0] >= 1.0, got {u_actual[0]}"
+    assert u_actual[0] < 1.1, f"Control overly aggressive? Got {u_actual[0]}"
+
+if __name__ == "__main__":
+    try:
+        test_normalization_overflow()
+        print("Test Passed!")
+    except AssertionError as e:
+        print(f"Test Failed: {e}")
+        exit(1)
+    except Exception as e:
+        print(f"Exception: {e}")
+        exit(1)


### PR DESCRIPTION
- **Fix**: Replaced naive `sqrt(sum(sq))` with stable norm logic using `max(abs(row))` scaling in `src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py`.
- **Test**: Added `tests/test_controllers/test_normalization_overflow.py` which reproduces the vanishing constraint issue with large gradients ($2 \times 10^{20}$) and verifies the fix.
- **Verification**: Verified that the new test passes and confirms correct control output ($u \approx 1$) instead of unsafe default ($u=0$). Verified that existing normalization test `test_normalization_robustness.py` still passes. Note: Some existing controller tests fail due to unrelated pre-existing `TypeError` issues with `dynamics_func` signatures.

---
*PR created automatically by Jules for task [519152422482271350](https://jules.google.com/task/519152422482271350) started by @bardhh*