### PR TITLE
🧾 Piper: Use `CbfClfQpData` TypedDict in constraint generators

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/activated_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/activated_cbfs.py
@@ -6,6 +6,7 @@ from jax import Array, jit, lax
 from cbfkit.controllers.cbf_clf.utils.barrier_activation import compute_activation_weights
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -26,7 +27,7 @@ def generate_compute_activated_cbf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     Generates compute function for Activated CBF constraints.
     Scales constraints by activation weights based on proximity.
@@ -51,10 +52,10 @@ def generate_compute_activated_cbf_constraints(
         pass
 
     @jit
-    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints with activation."""
         nonlocal a_cbf, b_cbf
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
 
         if n_bfs > 0:

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/consolidated_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/consolidated_cbfs.py
@@ -7,6 +7,7 @@ from cbfkit.certificates import certificate_package
 from cbfkit.certificates.conditions.barrier_conditions.zeroing_barriers import linear_class_k
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCallable,
     CertificateCollection,
     DynamicsCallable,
@@ -108,7 +109,7 @@ def generate_compute_consolidated_cbf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -131,10 +132,10 @@ def generate_compute_consolidated_cbf_constraints(
     )
 
     @jit
-    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_cbf, b_cbf
-        data = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
 
         if n_bfs > 0:

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/generating_functions.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/generating_functions.py
@@ -2,7 +2,7 @@
 #! docstring
 """
 
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 import inspect
 
 import jax.numpy as jnp
@@ -10,6 +10,7 @@ from jax import Array, jit, lax, vmap
 
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     ComputeCertificateConstraintFunctionGenerator,
     DynamicsCallable,
@@ -55,7 +56,7 @@ def generate_compute_cbf_clf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs,
-) -> Callable[[float, Array], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[float, Array], Tuple[Array, Array, CbfClfQpData]]:
     """_summary_
 
     Args:
@@ -68,7 +69,7 @@ def generate_compute_cbf_clf_constraints(
 
     Returns
     -------
-        Callable[[float, Array], Tuple[Array, Array, Dict[str, Any]]]: _description_
+        Callable[[float, Array], Tuple[Array, Array, CbfClfQpData]]: _description_
     """
     compute_cbf_constraints = generate_compute_cbf_constraints(
         control_limits, dyn_func, barriers, lyapunovs, **kwargs
@@ -85,7 +86,7 @@ def generate_compute_cbf_clf_constraints(
     pass_fg_clf = "f" in sig_clf.parameters and "g" in sig_clf.parameters
 
     @jit
-    def compute_cbf_clf_constraints(t: float, x: Array) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_cbf_clf_constraints(t: float, x: Array) -> Tuple[Array, Array, CbfClfQpData]:
         """_summary_
 
         Returns
@@ -108,7 +109,7 @@ def generate_compute_cbf_clf_constraints(
         return (
             jnp.vstack([amat_cbf, amat_clf]),
             jnp.hstack([bvec_cbf, bvec_clf]),
-            {**cbf_data, **clf_data},
+            cast(CbfClfQpData, {**cbf_data, **clf_data}),
         )
 
     return compute_cbf_clf_constraints

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_cbfs.py
@@ -11,6 +11,7 @@ from cbfkit.controllers.cbf_clf.utils.risk_aware_params import RiskAwareParams
 
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -32,7 +33,7 @@ def generate_compute_ra_cbf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """Placeholder.
 
     Theory still in development.
@@ -58,10 +59,10 @@ def generate_compute_ra_cbf_constraints(
         ra_params = RiskAwareParams(sigma=lambda x: jnp.zeros((x.shape[0], 1)))
 
     @jit
-    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_cbf, b_cbf
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         assert ra_params.sigma is not None
         sigma = ra_params.sigma(x)
@@ -99,7 +100,7 @@ def generate_compute_estimate_feedback_ra_cbf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -127,10 +128,10 @@ def generate_compute_estimate_feedback_ra_cbf_constraints(
         r_buffer = 0.0
 
     @jit
-    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_clf, b_clf
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         # Get K matrix from kwargs (passed from estimator state)
         k_mat = kwargs.get("kalman_gain", jnp.zeros((x.shape[0], x.shape[0])))

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_clfs.py
@@ -11,6 +11,7 @@ from cbfkit.controllers.cbf_clf.utils.risk_aware_params import RiskAwareParams
 
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -31,7 +32,7 @@ def generate_compute_ra_clf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -56,10 +57,10 @@ def generate_compute_ra_clf_constraints(
         r_buffer = 0.0
 
     @jit
-    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_clf, b_clf
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         assert ra_params.sigma is not None
         sigma = ra_params.sigma(x)
@@ -95,7 +96,7 @@ def generate_compute_estimate_feedback_ra_clf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -123,10 +124,10 @@ def generate_compute_estimate_feedback_ra_clf_constraints(
         r_buffer = 0.0
 
     @jit
-    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_clf, b_clf
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         # Get K matrix from kwargs (passed from estimator state)
         k_mat = kwargs.get("kalman_gain", jnp.zeros((x.shape[0], x.shape[0])))

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_cbfs.py
@@ -10,6 +10,7 @@ from jax import Array, jit, lax
 from cbfkit.controllers.cbf_clf.utils.risk_aware_params import RiskAwareParams
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -30,7 +31,7 @@ def generate_compute_ra_pi_cbf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -53,10 +54,10 @@ def generate_compute_ra_pi_cbf_constraints(
     ra_params.integrator_states = jnp.zeros((n_bfs,))
 
     @jit
-    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_cbf, b_cbf, ra_params
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         assert ra_params.sigma is not None
         sigma = ra_params.sigma(x)

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_clfs.py
@@ -10,6 +10,7 @@ from jax import Array, jit, lax, scipy
 from cbfkit.controllers.cbf_clf.utils.risk_aware_params import RiskAwareParams
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -30,7 +31,7 @@ def generate_compute_ra_pi_clf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -61,10 +62,10 @@ def generate_compute_ra_pi_clf_constraints(
     ra_params.integrator_states = jnp.zeros((n_lfs,))
 
     @jit
-    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_clf, b_clf, ra_params
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         assert ra_params.sigma is not None
         sigma = ra_params.sigma(x)

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/robust_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/robust_cbfs.py
@@ -9,6 +9,7 @@ from jax import Array, jit, lax
 
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -30,7 +31,7 @@ def generate_compute_robust_cbf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -58,10 +59,10 @@ def generate_compute_robust_cbf_constraints(
         robustness_term = robustness_sup_norm(disturbance_norm_bound)
 
     @jit
-    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_cbf, b_cbf
-        data = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
 
         if n_bfs > 0:

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/robust_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/robust_clfs.py
@@ -9,6 +9,7 @@ from jax import Array, jit, lax
 
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -30,7 +31,7 @@ def generate_compute_robust_clf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -56,10 +57,10 @@ def generate_compute_robust_clf_constraints(
         robustness_term = robustness_sup_norm(disturbance_norm_bound)
 
     @jit
-    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_clf, b_clf
-        data = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
 
         if n_lfs > 0:

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_cbfs.py
@@ -9,6 +9,7 @@ from jax import Array, jit, lax
 
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -29,7 +30,7 @@ def generate_compute_stochastic_cbf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -46,10 +47,10 @@ def generate_compute_stochastic_cbf_constraints(
         raise ValueError("sigma must be of type Callable[[Array], Array]!")
 
     @jit
-    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_cbf, b_cbf
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         s = sigma(x)
 

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/stochastic_clfs.py
@@ -9,6 +9,7 @@ from jax import Array, jit, lax
 
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -30,7 +31,7 @@ def generate_compute_stochastic_clf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """Placeholder.
 
     Theory still in development.
@@ -51,10 +52,10 @@ def generate_compute_stochastic_clf_constraints(
         raise ValueError("sigma must be of type Callable[[Array], Array]!")
 
     @jit
-    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, Dict[str, Any]]:
+    def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_clf, b_clf
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         s = sigma(x)
 

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/vanilla_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/vanilla_clfs.py
@@ -5,6 +5,7 @@ from jax import Array, jit, lax
 
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -25,7 +26,7 @@ def generate_compute_vanilla_clf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -43,10 +44,10 @@ def generate_compute_vanilla_clf_constraints(
         x: State,
         f: Optional[Array] = None,
         g: Optional[Array] = None,
-    ) -> Tuple[Array, Array, Dict[str, Any]]:
+    ) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_clf, b_clf
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
 
         dyn_f = f
         dyn_g = g

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/zeroing_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/zeroing_cbfs.py
@@ -9,6 +9,7 @@ from jax import Array, jit, lax
 
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
+    CbfClfQpData,
     CertificateCollection,
     DynamicsCallable,
     State,
@@ -29,7 +30,7 @@ def generate_compute_zeroing_cbf_constraints(
     barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
-) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
+) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     """
     #! To Do: docstring
     """
@@ -48,10 +49,10 @@ def generate_compute_zeroing_cbf_constraints(
         x: State,
         f: Optional[Array] = None,
         g: Optional[Array] = None,
-    ) -> Tuple[Array, Array, Dict[str, Any]]:
+    ) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
         nonlocal a_cbf, b_cbf
-        data: Dict[str, Any] = {}
+        data: CbfClfQpData = {}
 
         dyn_f = f
         dyn_g = g

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -295,22 +295,6 @@ QpSolverCallable = Callable[
 ]
 
 
-# CBF-CLF-QP-Generators
-class GenerateComputeCertificateConstraintCallable(Protocol):
-    """Protocol for generating compute certificate constraint function."""
-
-    def __call__(
-        self,
-        control_limits: Array,
-        dyn_func: DynamicsCallable,
-        barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-        lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
-        **kwargs: Any,
-    ) -> Callable[[Time, State], Tuple[Array, Array, Dict[str, Any]]]:
-        """Call method."""
-        ...
-
-
 class CbfClfQpConfig(TypedDict, total=False):
     """Configuration for CBF-CLF-QP controllers.
 
@@ -358,7 +342,25 @@ class CbfClfQpData(TypedDict, total=False):
     complete: bool
     bfs: Array
     lfs: Array
+    lfs_nom: Array
     violated: Union[bool, Array]
+    activation_weights: Array
+
+
+# CBF-CLF-QP-Generators
+class GenerateComputeCertificateConstraintCallable(Protocol):
+    """Protocol for generating compute certificate constraint function."""
+
+    def __call__(
+        self,
+        control_limits: Array,
+        dyn_func: DynamicsCallable,
+        barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
+        lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
+        **kwargs: Any,
+    ) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
+        """Call method."""
+        ...
 
 
 class CbfClfQpGenerator(Protocol):
@@ -396,7 +398,7 @@ class ComputeCertificateConstraintFunctionGenerator(Protocol):
         barriers: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
         lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
         **kwargs: Any,
-    ) -> Callable[[Time, Array], Tuple[Array, Array, Dict[str, Any]]]:
+    ) -> Callable[[Time, Array], Tuple[Array, Array, CbfClfQpData]]:
         """Call method."""
         ...
 

--- a/tests/test_controllers/test_cbf_clf_controllers/test_vanishing_gradient_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_vanishing_gradient_safety.py
@@ -34,7 +34,7 @@ def test_vanishing_gradient_infeasibility():
 
     controller = generator(
         control_limits=control_limits,
-        dynamics_func=lambda t, x: (jnp.zeros(1), jnp.eye(1)),
+        dynamics_func=lambda x: (jnp.zeros(1), jnp.eye(1)),
         barriers=([], [], [], [], []),
         lyapunovs=([], [], [], [], []),
         relaxable_cbf=False
@@ -81,7 +81,7 @@ def test_vanishing_gradient_spurious():
 
     controller = generator(
         control_limits=control_limits,
-        dynamics_func=lambda t, x: (jnp.zeros(1), jnp.eye(1)),
+        dynamics_func=lambda x: (jnp.zeros(1), jnp.eye(1)),
         barriers=([], [], [], [], []),
         lyapunovs=([], [], [], [], []),
         relaxable_cbf=False

--- a/tests/test_controllers/test_discontinuity_fix.py
+++ b/tests/test_controllers/test_discontinuity_fix.py
@@ -41,7 +41,7 @@ def test_discontinuity_fix():
 
     controller = generator(
         control_limits=control_limits,
-        dynamics_func=lambda t, x: (jnp.zeros(1), jnp.eye(1)),
+        dynamics_func=lambda x: (jnp.zeros(1), jnp.eye(1)),
         barriers=([], [], [], [], []),
         lyapunovs=([], [], [], [], []),
     )

--- a/tests/test_controllers/test_noise_amplification.py
+++ b/tests/test_controllers/test_noise_amplification.py
@@ -39,7 +39,7 @@ def test_noise_amplification():
     # Create controller
     controller = generator(
         control_limits=control_limits,
-        dynamics_func=lambda t, x: (jnp.zeros(2), jnp.eye(2)), # Dummy
+        dynamics_func=lambda x: (jnp.zeros(2), jnp.eye(2)), # Dummy
         barriers=([], [], [], [], []),
         lyapunovs=([], [], [], [], []),
     )


### PR DESCRIPTION
Piper for cbfkit: Replace `Dict[str, Any]` with `CbfClfQpData` in constraint generators.

This PR improves type safety by replacing the generic dictionary return type with a TypedDict `CbfClfQpData` across all CBF-CLF-QP constraint generation functions.

Changes:
- Modified `src/cbfkit/utils/user_types.py` to include `lfs_nom` and `activation_weights` in `CbfClfQpData` and update protocols.
- Updated return type annotations in `src/cbfkit/controllers/cbf_clf/generate_constraints/*.py`.
- Fixed test failures in `test_controllers` caused by incorrect lambda signatures in test mocks.

Verification:
- `mypy` passes for modified files.
- `pytest tests/test_controllers/` passes.

---
*PR created automatically by Jules for task [518746125236716038](https://jules.google.com/task/518746125236716038) started by @bardhh*