### PR TITLE
🚨 Sentinel: Freeze simulation state on NaN detection

### DIFF
--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -184,10 +184,14 @@ def simulator_jit(
         def _hold(_):
             return key, x
 
-        key, x_next = lax.cond(stop, _hold, _integrate, operand=None)
+        key, x_next_candidate = lax.cond(stop, _hold, _integrate, operand=None)
 
         # Sentinel: Check for NaNs in the next state to prevent divergent simulation
-        nan_in_next = jnp.any(jnp.isnan(x_next))
+        nan_in_next = jnp.any(jnp.isnan(x_next_candidate))
+
+        # If NaN is detected, revert to previous state to freeze simulation at last valid point
+        x_next = jnp.where(nan_in_next, x, x_next_candidate)
+
         # If NaN is detected, force controller error to True.
         # This ensures the next iteration's 'stop' condition is triggered.
         current_error = controller_data.error

--- a/tests/test_simulation/test_nan_safety.py
+++ b/tests/test_simulation/test_nan_safety.py
@@ -65,15 +65,17 @@ def test_nan_detection_jit_loop(capsys):
         use_jit=True
     )
 
-    # JIT returns full size array but logic should flag error
+    # JIT returns full size array.
+    # Sentinel fix: NaNs should be prevented (frozen state), but error flagged.
     assert results.states.shape[0] == 10
-    assert jnp.any(jnp.isnan(results.states))
+    assert not jnp.any(jnp.isnan(results.states))
+
+    # Verify trajectory is frozen
+    assert jnp.allclose(results.states, x0)
 
     captured = capsys.readouterr()
-    assert "Sentinel: Simulation failed due to NaNs" in captured.out
-    # JIT loop might not print "CONTROLLER ERROR: NAN_DETECTED" because error_data is None?
-    # In my verify run, I saw:
-    # Sentinel: Simulation failed due to NaNs in state trajectory.
-    # Warning: Simulation stopped early due to controller error at step 0.
+    # "Sentinel: Simulation failed due to NaNs" is only printed if NaNs are present in the final trajectory.
+    # Since we prevent them, this message is NOT printed.
 
+    # However, controller error must be flagged.
     assert "Simulation stopped early due to controller error" in captured.out


### PR DESCRIPTION
This PR improves the handling of divergent simulations (NaNs) in the JIT-compiled simulator (`simulator_jit`).

Previously, if a simulation step produced NaNs (e.g., due to unstable dynamics or controller failure), these NaNs would propagate through the remaining steps, resulting in a trajectory filled with NaNs. This made it difficult to inspect the state of the system at the moment of failure.

This change introduces a check for NaNs in the candidate next state. If NaNs are detected:
1. The next state is set to the current state (freezing the simulation).
2. The controller error flag is set to True (which triggers the stop condition for subsequent steps).

This ensures that the returned trajectory contains valid numbers up to the point of failure, and then stays constant, providing a clear indication of where and when the divergence occurred.

The existing test `tests/test_simulation/test_nan_safety.py` was updated to assert this new behavior (no NaNs in output, trajectory frozen) instead of the previous behavior (NaNs present).

---
*PR created automatically by Jules for task [5115616158345855188](https://jules.google.com/task/5115616158345855188) started by @bardhh*