### PR TITLE
✉️ Hermes: Improve QP solver error messages for shape mismatches

### DIFF
--- a/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
@@ -119,6 +119,34 @@ def solve_with_details(
     -------
         QpSolution: Solution, raw status (int), and solver parameters.
     """
+    if f_vec.ndim != 1:
+        raise ValueError(
+            f"Linear cost 'f_vec' must be a 1D array of shape (n_vars,), but got {f_vec.shape}. "
+            "Ensure it is a flat array, not a column vector."
+        )
+    if h_mat.ndim != 2:
+        raise ValueError(
+            f"Quadratic cost 'h_mat' must be a 2D array of shape (n_vars, n_vars), but got {h_mat.shape}."
+        )
+    if h_vec is not None and h_vec.ndim != 1:
+        raise ValueError(
+            f"Inequality constraint bounds 'h_vec' must be a 1D array of shape (n_ineq,), but got {h_vec.shape}. "
+            "Ensure it is a flat array, not a column vector."
+        )
+    if g_mat is not None and g_mat.ndim != 2:
+        raise ValueError(
+            f"Inequality constraint matrix 'g_mat' must be a 2D array of shape (n_ineq, n_vars), but got {g_mat.shape}."
+        )
+    if b_vec is not None and b_vec.ndim != 1:
+        raise ValueError(
+            f"Equality constraint bounds 'b_vec' must be a 1D array of shape (n_eq,), but got {b_vec.shape}. "
+            "Ensure it is a flat array, not a column vector."
+        )
+    if a_mat is not None and a_mat.ndim != 2:
+        raise ValueError(
+            f"Equality constraint matrix 'a_mat' must be a 2D array of shape (n_eq, n_vars), but got {a_mat.shape}."
+        )
+
     params_obj = (h_mat, 0.5 * f_vec)
     params_eq = None if (a_mat is None or b_vec is None) else (a_mat, b_vec)
     params_ineq = None if (g_mat is None or h_vec is None) else (g_mat, h_vec)

--- a/tests/test_qp_solver_shapes.py
+++ b/tests/test_qp_solver_shapes.py
@@ -1,0 +1,77 @@
+
+import jax.numpy as jnp
+import pytest
+from cbfkit.optimization.quadratic_program.qp_solver_jaxopt import solve_with_details
+
+def test_qp_solver_correct_shapes():
+    # 2 variables
+    P = jnp.eye(2)
+    q = jnp.array([1.0, 1.0]) # 1D
+
+    # Inequality Constraints: x <= 0
+    G = jnp.eye(2)
+    h = jnp.array([0.0, 0.0]) # 1D
+
+    # Equality Constraints: x[0] = 0
+    A = jnp.array([[1.0, 0.0]])
+    b = jnp.array([0.0]) # 1D
+
+    sol, status, _ = solve_with_details(P, q, G, h, A, b)
+    # Just check it runs without error
+    assert sol.shape == (2,)
+
+def test_qp_solver_incorrect_q_shape():
+    P = jnp.eye(2)
+    q = jnp.array([[1.0], [1.0]]) # 2D Column vector (Wrong)
+    G = jnp.eye(2)
+    h = jnp.array([0.0, 0.0])
+
+    with pytest.raises(ValueError, match="Linear cost 'f_vec' must be a 1D array"):
+        solve_with_details(P, q, G, h)
+
+def test_qp_solver_incorrect_h_shape():
+    P = jnp.eye(2)
+    q = jnp.array([1.0, 1.0])
+    G = jnp.eye(2)
+    h = jnp.array([[0.0], [0.0]]) # 2D Column vector (Wrong)
+
+    with pytest.raises(ValueError, match="Inequality constraint bounds 'h_vec' must be a 1D array"):
+        solve_with_details(P, q, G, h)
+
+def test_qp_solver_incorrect_b_shape():
+    P = jnp.eye(2)
+    q = jnp.array([1.0, 1.0])
+    G = jnp.eye(2)
+    h = jnp.array([0.0, 0.0])
+    A = jnp.array([[1.0, 0.0]])
+    b = jnp.array([[0.0]]) # 2D Column vector (Wrong)
+
+    with pytest.raises(ValueError, match="Equality constraint bounds 'b_vec' must be a 1D array"):
+        solve_with_details(P, q, G, h, A, b)
+
+def test_qp_solver_incorrect_P_shape():
+    P = jnp.eye(2).reshape(2, 2, 1) # 3D (Wrong)
+    q = jnp.array([1.0, 1.0])
+
+    with pytest.raises(ValueError, match="Quadratic cost 'h_mat' must be a 2D array"):
+        solve_with_details(P, q)
+
+def test_qp_solver_incorrect_G_shape():
+    P = jnp.eye(2)
+    q = jnp.array([1.0, 1.0])
+    G = jnp.eye(2).reshape(2, 2, 1) # 3D (Wrong)
+    h = jnp.array([0.0, 0.0])
+
+    with pytest.raises(ValueError, match="Inequality constraint matrix 'g_mat' must be a 2D array"):
+        solve_with_details(P, q, G, h)
+
+def test_qp_solver_incorrect_A_shape():
+    P = jnp.eye(2)
+    q = jnp.array([1.0, 1.0])
+    G = jnp.eye(2)
+    h = jnp.array([0.0, 0.0])
+    A = jnp.array([[1.0, 0.0]]).reshape(1, 2, 1) # 3D (Wrong)
+    b = jnp.array([0.0])
+
+    with pytest.raises(ValueError, match="Equality constraint matrix 'a_mat' must be a 2D array"):
+        solve_with_details(P, q, G, h, A, b)


### PR DESCRIPTION
This PR improves the developer experience by adding explicit shape validation to the `solve_with_details` function in `src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py`.

Previously, passing column vectors (N, 1) for 1D parameters (like `h_vec`, `f_vec`) could lead to confusing broadcasting errors deep within the JAX/JaxOpt stack or incorrect results if broadcasting happened silently.

Now, `ValueError` is raised with a clear message if:
- `f_vec`, `h_vec`, `b_vec` are not 1D arrays.
- `h_mat`, `g_mat`, `a_mat` are not 2D arrays.

This change does not affect valid inputs but catches common configuration errors early. A new test file `tests/test_qp_solver_shapes.py` is included to verify the validation logic.

---
*PR created automatically by Jules for task [454270851055142523](https://jules.google.com/task/454270851055142523) started by @bardhh*