### PR TITLE
🔮 Oracle: Align unbiased_gaussian_noise semantics with docstring

### DIFF
--- a/src/cbfkit/sensors/full_state.py
+++ b/src/cbfkit/sensors/full_state.py
@@ -36,6 +36,9 @@ def unbiased_gaussian_noise(
 ) -> Array:
     """Senses the state subject to additive, unbiased (zero-mean), Gaussian noise.
 
+    Note: Previous versions averaged 10 samples at t=0. This behavior has been removed
+    for consistency with the noise model definition.
+
     Args:
         t (float): time (sec)
         x (Array): state vector (ground truth)
@@ -63,25 +66,12 @@ def unbiased_gaussian_noise(
         sigma,
     )
 
-    def sample_mean(num_samples, rng_key):
-        # Generate samples: (num_samples, dim)
-        # random.normal creates (num_samples, dim) directly
-        samples = random.normal(rng_key, shape=(num_samples, dim))
+    # Generate random vector z ~ N(0, I)
+    z = random.normal(key, shape=(dim,))
 
-        # Transform: (chol @ samples.T).T -> samples @ chol.T
-        transformed = jnp.dot(samples, chol.T)
-
-        # Mean across samples
-        vec = jnp.mean(transformed, axis=0)
-        return vec
-
-    # Logic: if t == 0, take 10 samples, else 1 sample
-    # We rely on lax.cond for JIT compatibility
-    n_initial_meas = 10
-
-    sampled_random_vector = lax.cond(
-        t == 0.0, lambda k: sample_mean(n_initial_meas, k), lambda k: sample_mean(1, k), key
-    )
+    # Transform to y ~ N(0, Sigma) via y = L @ z
+    # chol is lower triangular L such that L @ L.T = Sigma
+    sampled_random_vector = jnp.dot(chol, z)
 
     sampled_random_vector = sampled_random_vector.reshape(x.shape)
 

--- a/tests/test_sensor_semantics.py
+++ b/tests/test_sensor_semantics.py
@@ -1,0 +1,38 @@
+
+import jax.numpy as jnp
+from jax import random, vmap
+from cbfkit.sensors.full_state import unbiased_gaussian_noise
+import pytest
+
+def test_sensor_variance_consistency():
+    """
+    Verifies that unbiased_gaussian_noise produces noise consistent with the specified sigma,
+    regardless of the time t.
+    """
+    key = random.PRNGKey(42)
+    sigma = jnp.eye(1) * 1.0  # Variance = 1.0
+    x = jnp.array([0.0])
+
+    # Run many trials to estimate variance robustly
+    n_trials = 10000
+    keys = random.split(key, n_trials)
+
+    # Test at t = 1.0 (should be Variance = 1.0)
+    results_t1 = vmap(lambda k: unbiased_gaussian_noise(1.0, x, sigma=sigma, key=k))(keys)
+    var_t1 = jnp.var(results_t1)
+
+    # Test at t = 0.0 (should be Variance = 1.0 per docstring, but currently ~0.1 due to implementation)
+    results_t0 = vmap(lambda k: unbiased_gaussian_noise(0.0, x, sigma=sigma, key=k))(keys)
+    var_t0 = jnp.var(results_t0)
+
+    print(f"Variance at t=1.0: {var_t1:.4f}")
+    print(f"Variance at t=0.0: {var_t0:.4f}")
+
+    # Allow some statistical fluctuation, but 0.1 is way off 1.0
+    assert abs(var_t1 - 1.0) < 0.1, f"Variance at t=1.0 ({var_t1}) deviated from expected (1.0)"
+
+    # This assertion will fail with the current implementation
+    assert abs(var_t0 - 1.0) < 0.1, f"Variance at t=0.0 ({var_t0}) deviated from expected (1.0). Current implementation averages 10 samples at t=0, reducing variance."
+
+if __name__ == "__main__":
+    test_sensor_variance_consistency()


### PR DESCRIPTION
Spec text vs behavior: The docstring for `unbiased_gaussian_noise` claims "Senses the state subject to additive, unbiased (zero-mean), Gaussian noise" with covariance `sigma`. However, the implementation averaged 10 samples at `t=0`, reducing the effective variance by a factor of 10.

What changed:
- Modified `src/cbfkit/sensors/full_state.py` to remove the `t=0` averaging logic. Now it consistently returns a single sample (or mean of 1 sample) for all time steps.
- Added a note to the docstring about the change.
- Added `tests/test_sensor_semantics.py` to verify variance consistency.

Tests run:
- `pytest tests/test_sensor_semantics.py` (Passed)
- `pytest tests/test_simulation/test_unicycle_montecarlo.py` (Passed)
- `pytest tests/test_simulation/test_monte_carlo_unit.py` (Passed)
- `pytest tests/test_simulation/test_simulator_jit_rk4.py` (Passed)

---
*PR created automatically by Jules for task [10067021991408796162](https://jules.google.com/task/10067021991408796162) started by @bardhh*