### PR TITLE
✉️ Hermes: Report integration NaNs in simulator_jit

### DIFF
--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -6,6 +6,9 @@ import jax.debug as jdebug
 import jax.numpy as jnp
 from jax import lax, random
 
+# Hermes: Error code for NaN detected during integration
+INTEGRATION_NAN_ERROR = -10
+
 from cbfkit.integration.forward_euler import forward_euler
 from cbfkit.integration.runge_kutta import runge_kutta_4
 from cbfkit.utils.user_types import (
@@ -203,6 +206,22 @@ def simulator_jit(
         current_error = controller_data.error
         new_error = current_error | nan_in_next
         controller_data = controller_data._replace(error=new_error)
+
+        # Hermes: If NaN is detected and error_data exists, report Integration NaN error.
+        if controller_data.error_data is not None:
+            new_error_data = jnp.where(
+                nan_in_next, INTEGRATION_NAN_ERROR, controller_data.error_data
+            )
+            controller_data = controller_data._replace(error_data=new_error_data)
+
+        # Hermes: Print warning if NaN detected
+        lax.cond(
+            nan_in_next,
+            lambda: jdebug.print(
+                "⚠️ Simulation stopped: NaN detected during integration at t={t}", t=t
+            ),
+            lambda: None,
+        )
 
         if progress_callback is not None and progress_interval > 0:
             should_report = jnp.logical_or(


### PR DESCRIPTION
Detailed Description:
The `simulator_jit` function currently detects NaNs in the next state candidate and sets the `controller_data.error` flag to True. However, it did not provide specific information about the cause of the error (integration failure vs controller failure) in the `error_data` field, nor did it print any warning to the console.

This change adds:
1.  A constant `INTEGRATION_NAN_ERROR = -10`.
2.  Logic to update `controller_data.error_data` to this constant if a NaN is detected in the integration step.
3.  A `jax.debug.print` statement to warn the user with the simulation time `t` when a NaN is detected.

This makes it much easier to debug simulations that diverge or explode due to numerical instability or incorrect dynamics.

Testing:
- Verified with a reproduction script that forces a NaN in dynamics.
- Confirmed that `error_data` is set to -10 and the warning message is printed.

---
*PR created automatically by Jules for task [14153282653247529034](https://jules.google.com/task/14153282653247529034) started by @bardhh*