### PR TITLE
📝 Scribe: Clarify simulator.execute return values in tutorial

### DIFF
--- a/tutorials/unicycle_reach_avoid.py
+++ b/tutorials/unicycle_reach_avoid.py
@@ -110,7 +110,7 @@ controller = vanilla_cbf_clf_qp_controller(
 )
 
 # Simulation
-x_sim, u_sim, z_sim, p_sim, dkeys, dvals, planner_data, planner_data_keys = simulator.execute(
+x_sim, u_sim, z_sim, p_sim, controller_keys, controller_values, planner_keys, planner_values = simulator.execute(
     x0=initial_state,
     dt=dt,
     num_steps=num_steps,


### PR DESCRIPTION
Improved variable naming in `tutorials/unicycle_reach_avoid.py` to match the actual return values of `simulator.execute`. The previous names were misleading (`planner_data` for keys, `planner_data_keys` for values). Used `controller_keys`, `controller_values`, `planner_keys`, `planner_values` for clarity. Confirmed the script is runnable.

---
*PR created automatically by Jules for task [4046357556658714877](https://jules.google.com/task/4046357556658714877) started by @bardhh*