### PR TITLE
⚙️ Flux: Fix NaN gradients at zero actuation in cbf_clf_qp_generator

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -422,11 +422,21 @@ def cbf_clf_qp_generator(
                 # Avoid division by zero
                 row_max_safe = jnp.where(row_max > 0, row_max, 1.0)
 
+                # Check if row is effectively zero (to avoid nan gradients at 0)
+                is_zero_row = row_max < 1e-12
+
                 # Scale the matrix
                 g_mat_c_scaled = g_mat_c / row_max_safe[:, None]
 
                 # Compute norm of scaled matrix
-                row_norms_scaled = jnp.linalg.norm(g_mat_c_scaled, axis=1)
+                # Fix: Ensure we don't compute norm of zero vector, which has undefined gradient
+                g_mat_c_safe_norm = jnp.where(
+                    is_zero_row[:, None],
+                    jnp.ones_like(g_mat_c_scaled),
+                    g_mat_c_scaled,
+                )
+
+                row_norms_scaled = jnp.linalg.norm(g_mat_c_safe_norm, axis=1)
 
                 # Recover true norm
                 row_norms_c = row_norms_scaled * row_max_safe
@@ -438,7 +448,10 @@ def cbf_clf_qp_generator(
                 # Use a clamped scaling factor (max 1e8) to:
                 # 1. Enforce constraints with small gradients (e.g. 1e-10) to catch gross infeasibility (Safety).
                 # 2. Allow normalization of small signals (e.g. 2e-8) for solver convergence.
-                safe_scales_c = jnp.minimum(1.0 / row_norms_c, 1e8)
+                safe_scales_c = jnp.where(
+                    is_zero_row, 1.0, jnp.minimum(1.0 / row_norms_c, 1e8)
+                )
+
                 g_mat_c = g_mat_c * safe_scales_c[:, None]
                 h_vec_c = h_vec_c * safe_scales_c
 


### PR DESCRIPTION
Flux: Fix NaN gradients at zero actuation in cbf_clf_qp_generator

- **Before**: `tests/test_controllers/test_cbf_clf_controllers/test_autodiff_safety.py` failed with `AssertionError: Gradient contains NaNs!`.
- **After**: The test passes, and the CI signal is improved (Red -> Green).
- **Change**: Modified `src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py` to handle zero-norm rows gracefully by skipping normalization and using safe vectors for norm computation in the computational graph.
- **Runtime**: No significant impact on runtime (verification suite ran in ~62s).

---
*PR created automatically by Jules for task [15494474343725104956](https://jules.google.com/task/15494474343725104956) started by @bardhh*