### PR TITLE
🔧 Forge: Deduplicate dev dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,16 +50,11 @@ test = [
     "python-dotenv>=1.2.1",
 ]
 dev = [
+    "cbfkit[vis,codegen,test,casadi]",
     "black>=23.12.1,<24.0",
     "mypy>=1.8.0,<2.0",
     "jupyter>=1.0.0,<2.0",
-    "pytest>=8.0.2",
     "ruff>=0.3.4",
-    "python-dotenv>=1.2.1",
-    "pytest-cov",
-    "casadi>=3.6.4,<4.0",
-    "matplotlib>=3.8.2,<4.0",
-    "jinja2>=3.0.0",
 ]
 
 [build-system]


### PR DESCRIPTION
Refactors the `dev` optional dependency group in `pyproject.toml` to reference `vis`, `codegen`, `test`, and `casadi` extras instead of manually duplicating their contents. This improves maintainability and ensures a single source of truth for dependencies. Verified with `pip install .[dev]` and `python -m build`.

Note: Kept `license = "BSD-3-Clause"` as changing it to a table triggers `SetuptoolsDeprecationWarning` in newer setuptools versions following PEP 639.

---
*PR created automatically by Jules for task [8139077163652791066](https://jules.google.com/task/8139077163652791066) started by @bardhh*