### PR TITLE
🚨 Sentinel: Fix contradictory warnings and improve failure status reporting

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -52,6 +52,7 @@ from .utils import SimulationStepData
 
 
 SOLVER_STATUS_MAP = {
+    -2: "NAN_INPUT_DETECTED",
     -1: "NAN_DETECTED",
     0: "UNSOLVED (Likely Infeasible)",
     1: "SOLVED",
@@ -123,6 +124,15 @@ def _check_simulation_status(
         status_codes = controller_data_values[idx_data]
         # Check for status 2 (MAX_ITER_REACHED)
         max_iter_mask = status_codes == 2
+
+        # Sentinel: Filter out cases where error occurred (avoid confusing "accepted" message)
+        if "error" in controller_data_keys:
+            idx_err = controller_data_keys.index("error")
+            errors = controller_data_values[idx_err]
+            # Ensure errors array matches shape (it should, as both are stacked per-step)
+            # errors is boolean mask of errors
+            max_iter_mask = max_iter_mask & (~errors)
+
         if jnp.any(max_iter_mask):
             count = int(jnp.sum(max_iter_mask).item())
             print_warning(

--- a/tests/test_simulation/test_error_reporting.py
+++ b/tests/test_simulation/test_error_reporting.py
@@ -2,6 +2,8 @@ import pytest
 from cbfkit.simulation.simulator import _format_error_status
 
 def test_format_error_status():
+    assert _format_error_status(-1) == "NAN_DETECTED (Status: -1)"
+    assert _format_error_status(-2) == "NAN_INPUT_DETECTED (Status: -2)"
     assert _format_error_status(0) == "UNSOLVED (Likely Infeasible) (Status: 0)"
     assert _format_error_status(1) == "SOLVED (Status: 1)"
     assert _format_error_status(2) == "MAX_ITER_REACHED (Status: 2)"
@@ -9,3 +11,55 @@ def test_format_error_status():
     assert _format_error_status(4) == "DUAL_INFEASIBLE (Status: 4)"
     assert _format_error_status(999) == "Status: 999"
     assert _format_error_status("Unknown") == "Unknown"
+
+import jax.numpy as jnp
+from cbfkit.simulation.simulator import _check_simulation_status
+
+def test_check_simulation_status_suppresses_contradictory_warning(capsys):
+    """Test that MAX_ITER warning is suppressed if error is True at the same step."""
+
+    # Setup data where error=True and status=2 (MAX_ITER) at step 0
+    controller_keys = ["error", "error_data"]
+    controller_values = [
+        jnp.array([True]),  # error=True
+        jnp.array([2])      # status=2
+    ]
+    planner_keys = []
+    planner_values = []
+
+    _check_simulation_status(
+        controller_keys, controller_values,
+        planner_keys, planner_values
+    )
+
+    captured = capsys.readouterr()
+    # Should warn about controller error
+    assert "Simulation stopped early due to controller error" in captured.out or \
+           "Simulation stopped early due to controller error" in captured.err
+
+    # Should NOT warn about "Solutions were accepted"
+    assert "Solutions were accepted" not in captured.out
+    assert "Solutions were accepted" not in captured.err
+
+def test_check_simulation_status_warns_on_accepted_max_iter(capsys):
+    """Test that MAX_ITER warning is SHOWN if error is False."""
+
+    # Setup data where error=False and status=2 (MAX_ITER) at step 0
+    # Note: simulator.py looks for "sub_data_solver_status" or "error_data" for status code
+    controller_keys = ["error", "error_data"]
+    controller_values = [
+        jnp.array([False]), # error=False
+        jnp.array([2])      # status=2
+    ]
+    planner_keys = []
+    planner_values = []
+
+    _check_simulation_status(
+        controller_keys, controller_values,
+        planner_keys, planner_values
+    )
+
+    captured = capsys.readouterr()
+    # Should Warn about "Solutions were accepted"
+    assert "Solutions were accepted" in captured.out or \
+           "Solutions were accepted" in captured.err


### PR DESCRIPTION
Addresses ambiguous and contradictory warnings during simulation failure. Specifically, when the QP solver reaches MAX_ITER and the controller flags an error, the simulator previously emitted a warning that solutions were "accepted but suboptimal", which was false. This change suppresses that warning when an error flag is present. It also adds an explicit status string for NAN_INPUT_DETECTED (-2).

---
*PR created automatically by Jules for task [17567525990957807586](https://jules.google.com/task/17567525990957807586) started by @bardhh*