### PR TITLE
🏗️ Atlas: Simplify certificate function inputs in rectify_relative_degree

### DIFF
--- a/src/cbfkit/certificates/rectifiers.py
+++ b/src/cbfkit/certificates/rectifiers.py
@@ -44,7 +44,8 @@ Example
 >>>     constraint(r1, r2),
 >>>     dynamics,
 >>>     6,
->>>     certificate_conditions=zeroing_barriers.linear_class_k(1.0)
+>>>     certificate_conditions=zeroing_barriers.linear_class_k(1.0),
+>>>     input_style="state",
 >>> )
 """
 
@@ -58,6 +59,7 @@ from cbfkit.certificates import certificate_package
 from cbfkit.utils.user_types import (
     CertificateCollection,
     CertificateConditionsCallable,
+    CertificateInputStyle,
     DynamicsCallable,
 )
 
@@ -86,6 +88,7 @@ def rectify_relative_degree(
     form: str = "exponential",
     certificate_conditions: Optional[CertificateConditionsCallable] = None,
     rng: Optional[Union[int, Array]] = None,
+    input_style: Union[str, CertificateInputStyle] = "concatenated",
 ) -> Union[Callable[..., CertificateCollection], CertificateCollection]:
     """Rectifies the relative degree of the provided constraint function with respect to the system
     dynamics deriving a new exponential- or high-order-CBF.
@@ -103,6 +106,10 @@ def rectify_relative_degree(
             If provided, returns a CertificateCollection directly. Defaults to None.
         rng (Optional[Union[int, Array]]): random seed or key for relative degree sampling.
             Defaults to None (using global default).
+        input_style (Union[str, CertificateInputStyle], optional): input signature of the function.
+            - "concatenated" (default): function(state_and_time) -> value
+            - "state": function(state) -> value
+            - "separated": function(time, state) -> value
 
     Returns
     -------
@@ -116,6 +123,29 @@ def rectify_relative_degree(
         subkey = random.PRNGKey(rng)  # type: ignore[assignment]
     else:
         subkey = rng  # type: ignore[assignment]
+
+    # Normalize input_style
+    if isinstance(input_style, str):
+        try:
+            input_style = CertificateInputStyle(input_style)
+        except ValueError:
+            valid_styles = [e.value for e in CertificateInputStyle]
+            raise ValueError(
+                f"Invalid input_style '{input_style}'. Must be one of {valid_styles}"
+            ) from None
+
+    # Wrap function to ensure concatenated (state + time) signature for compute_function_list
+    if input_style == CertificateInputStyle.STATE:
+        _orig_func_state = function
+
+        def function(xt: Array) -> Array:
+            return _orig_func_state(xt[:-1])
+
+    elif input_style == CertificateInputStyle.SEPARATED:
+        _orig_func_sep = function
+
+        def function(xt: Array) -> Array:
+            return _orig_func_sep(xt[-1], xt[:-1])
 
     function_list = compute_function_list(
         function, system_dynamics, state_dim + 1, form, subkey=subkey

--- a/tests/test_rectify_relative_degree_api.py
+++ b/tests/test_rectify_relative_degree_api.py
@@ -62,5 +62,55 @@ def test_rectify_relative_degree_api():
 
     print("API verification passed: Legacy and New usages produce identical results.")
 
+def test_rectify_relative_degree_input_style():
+    """Test the input_style argument for rectify_relative_degree."""
+
+    # Dynamics: x_dot = u
+    def dynamics(x):
+        return jnp.zeros(2), jnp.eye(2)
+
+    # Strict unpacking function that only accepts state (size 2)
+    def h_strict(x):
+        p, v = x
+        return p
+
+    # This should fail if we don't specify input_style="state" (default is concatenated -> passes size 3)
+    # But JAX unpacking might be flexible?
+    # Actually, if x is size 3, "p, v = x" raises "too many values to unpack (expected 2)"
+
+    # 1. Verify it works with input_style="state"
+    cert = rectify_relative_degree(
+        function=h_strict,
+        system_dynamics=dynamics,
+        state_dim=2,
+        form="exponential",
+        certificate_conditions=zeroing_barriers.linear_class_k(1.0),
+        input_style="state"
+    )
+
+    # Verify it works
+    x_sample = jnp.array([0.5, 0.2])
+    t_sample = 1.0
+    val = cert.functions[0](t_sample, x_sample)
+
+    # h = x[0] = 0.5. For rel deg 1, rectified function is just h(x).
+    assert jnp.allclose(val, 0.5)
+
+    # 2. Verify it FAILS without input_style="state" (default is concatenated)
+    try:
+        rectify_relative_degree(
+            function=h_strict,
+            system_dynamics=dynamics,
+            state_dim=2,
+            form="exponential",
+            certificate_conditions=zeroing_barriers.linear_class_k(1.0)
+        )
+        assert False, "Should have failed with strict unpacking"
+    except Exception as e:
+        # We expect a failure during jacfwd call inside compute_function_list
+        print(f"Caught expected error: {e}")
+        pass
+
 if __name__ == "__main__":
     test_rectify_relative_degree_api()
+    test_rectify_relative_degree_input_style()


### PR DESCRIPTION
Previously, `rectify_relative_degree` implicitly assumed that the provided `function` accepted a single argument containing both state and time concatenated. If a user provided a state-only function (e.g., `h(x)` where `x` is just state), it would fail with a shape mismatch or unpacking error when `compute_function_list` passed it a state+time vector.

This PR adds an `input_style` argument to `rectify_relative_degree`, accepting values from `CertificateInputStyle` ("concatenated", "separated", "state"). It automatically wraps the user function to the required "concatenated" signature if needed, reducing boilerplate for users.

Tests were added to verify:
1. Backward compatibility (default behavior).
2. Correct handling of `input_style="state"` for state-only functions.
3. Strict failure when `input_style="concatenated"` (default) is used with a strict state-only function.

---
*PR created automatically by Jules for task [1018646282228852720](https://jules.google.com/task/1018646282228852720) started by @bardhh*