### PR TITLE
Scout: Add JIT compilation diagnostic tool

### DIFF
--- a/examples/diagnostics/jit_recompile_check.py
+++ b/examples/diagnostics/jit_recompile_check.py
@@ -1,0 +1,95 @@
+"""
+Scout Diagnostic: JIT Recompilation Check.
+
+This script verifies that the JIT compiler is behaving as expected:
+1. Compiling once for the first run.
+2. Reusing the compiled function for subsequent runs with identical static arguments.
+3. Recompiling when static arguments change (e.g. dynamics function).
+
+Command to run:
+    python examples/diagnostics/jit_recompile_check.py
+"""
+
+import jax
+import jax.numpy as jnp
+from cbfkit.simulation import simulator
+from cbfkit.integration import forward_euler
+from cbfkit.utils.jit_monitor import JitMonitor
+
+def run_simulation(dynamics_func):
+    """Runs a minimal simulation."""
+    x0 = jnp.array([0.0, 0.0])
+    dt = 0.01
+    num_steps = 10
+
+    simulator.execute(
+        x0=x0,
+        dt=dt,
+        num_steps=num_steps,
+        dynamics=dynamics_func,
+        integrator=forward_euler,
+        use_jit=True,
+        verbose=False
+    )
+
+def main():
+    print("🔍 Scout: Checking JIT compilation behavior...")
+
+    # Reset monitor
+    JitMonitor.reset()
+
+    # ---------------------------------------------------------
+    # Scenario 1: First Run
+    # ---------------------------------------------------------
+    def dynamics_v1(x):
+        return jnp.zeros_like(x), jnp.zeros((2, 1))
+
+    print("\n[1] Running Simulation 1 (First Call)...")
+    run_simulation(dynamics_v1)
+
+    counts = JitMonitor.get_counts()
+    sim_jit_count = counts.get("simulator_jit", 0)
+    print(f"    -> Compilation Counts: {counts}")
+
+    if sim_jit_count != 1:
+        print(f"❌ FAILED: Expected 1 compilation, got {sim_jit_count}")
+        exit(1)
+
+    # ---------------------------------------------------------
+    # Scenario 2: Second Run (Identical)
+    # ---------------------------------------------------------
+    print("\n[2] Running Simulation 2 (Identical Call)...")
+    run_simulation(dynamics_v1)
+
+    counts = JitMonitor.get_counts()
+    sim_jit_count_2 = counts.get("simulator_jit", 0)
+    print(f"    -> Compilation Counts: {counts}")
+
+    if sim_jit_count_2 != 1:
+        print(f"❌ FAILED: Expected count to remain 1, got {sim_jit_count_2}. Redundant recompilation detected!")
+        exit(1)
+
+    # ---------------------------------------------------------
+    # Scenario 3: Third Run (Changed Dynamics - should recompile)
+    # ---------------------------------------------------------
+    print("\n[3] Running Simulation 3 (New Dynamics Function)...")
+
+    # Even if code is same, a new function object is a new static arg
+    def dynamics_v2(x):
+        return jnp.zeros_like(x), jnp.zeros((2, 1))
+
+    run_simulation(dynamics_v2)
+
+    counts = JitMonitor.get_counts()
+    sim_jit_count_3 = counts.get("simulator_jit", 0)
+    print(f"    -> Compilation Counts: {counts}")
+
+    if sim_jit_count_3 != 2:
+        print(f"❌ FAILED: Expected count to increase to 2, got {sim_jit_count_3}. Failed to detect new function.")
+        exit(1)
+
+    print("\n✅ SUCCESS: JIT compilation monitoring is working correctly.")
+    print("   Run this tool to detect redundant recompilations in your loops.")
+
+if __name__ == "__main__":
+    main()

--- a/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
@@ -6,6 +6,8 @@ import jax.numpy as jnp
 from jax import Array, jit
 from jaxopt import OSQP, EqualityConstrainedQP
 
+from cbfkit.utils.jit_monitor import JitMonitor
+
 # Instantiate QP solver objects
 MAX_ITER = 1000000
 QP = OSQP(maxiter=MAX_ITER, tol=1e-3)
@@ -119,6 +121,8 @@ def solve_with_details(
     -------
         QpSolution: Solution, raw status (int), and solver parameters.
     """
+    JitMonitor.increment("qp_solver_jaxopt.solve_with_details")
+
     if f_vec.ndim != 1:
         raise ValueError(
             f"Linear cost 'f_vec' must be a 1D array of shape (n_vars,), but got {f_vec.shape}. "

--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -8,6 +8,7 @@ from jax import lax, random
 
 from cbfkit.integration.forward_euler import forward_euler
 from cbfkit.integration.runge_kutta import runge_kutta_4
+from cbfkit.utils.jit_monitor import JitMonitor
 from cbfkit.utils.user_types import (
     ControllerCallable,
     ControllerData,
@@ -72,6 +73,7 @@ def simulator_jit(
         xs, us, zs, cs, c_datas (stacked), p_datas (stacked)
     """
     print(f"JIT COMPILATION: simulator_jit (dt={dt}, num_steps={num_steps})")
+    JitMonitor.increment("simulator_jit")
 
     # Define the scan step function
     def scan_step(carry, step_idx):

--- a/src/cbfkit/utils/jit_monitor.py
+++ b/src/cbfkit/utils/jit_monitor.py
@@ -1,0 +1,26 @@
+import collections
+import threading
+from typing import DefaultDict, Dict
+
+class JitMonitor:
+    """Tracks JIT compilation events across the library."""
+    _counts: DefaultDict[str, int] = collections.defaultdict(int)
+    _lock = threading.Lock()
+
+    @classmethod
+    def increment(cls, key: str) -> None:
+        """Increment the compilation count for a given key (function name)."""
+        with cls._lock:
+            cls._counts[key] += 1
+
+    @classmethod
+    def get_counts(cls) -> Dict[str, int]:
+        """Return a copy of the current compilation counts."""
+        with cls._lock:
+            return dict(cls._counts)
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset all counts to zero."""
+        with cls._lock:
+            cls._counts.clear()


### PR DESCRIPTION
Scout: JIT Compilation Diagnostic Tool

Added a lightweight, dependency-free diagnostic tool to track and count JAX JIT compilation events in the simulator and QP solver. This helps developers identify performance bottlenecks caused by unintended recompilations (e.g., passing new function objects to the simulator loop).

Changes:
- New module `src/cbfkit/utils/jit_monitor.py` with `JitMonitor` class.
- Instrumentation in `simulator_jit.py` and `qp_solver_jaxopt.py`.
- New diagnostic script `examples/diagnostics/jit_recompile_check.py`.

Command to run diagnostic:
`python examples/diagnostics/jit_recompile_check.py`

---
*PR created automatically by Jules for task [12173818579535801366](https://jules.google.com/task/12173818579535801366) started by @bardhh*