### PR TITLE
fix(examples): resolve ModuleNotFoundError in example scripts

### DIFF
--- a/examples/fixed_wing/reach_drop_point/ekf_control.py
+++ b/examples/fixed_wing/reach_drop_point/ekf_control.py
@@ -1,7 +1,10 @@
 """This module simulates a 6 degree-of-freedom dynamic quadrotor model as it seeks to reach a goal
 region while avoiding dynamic obstacles."""
-
+import sys
 import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
+
 import pickle
 from typing import List, Callable
 

--- a/examples/single_integrator/reach_goal/ekf_control.py
+++ b/examples/single_integrator/reach_goal/ekf_control.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 from typing import List, Tuple
 
 import jax.numpy as jnp
@@ -264,7 +268,6 @@ def execute(
 # Simulate total number of trials
 if __name__ == "__main__":
     import pickle
-    import os
 
     # Execute numerous trials sim
     results = conduct_monte_carlo(execute, n_trials=setup.n_trials)

--- a/examples/single_integrator/reach_goal/perfect_sensing.py
+++ b/examples/single_integrator/reach_goal/perfect_sensing.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 import pickle
 from typing import List, Tuple
 
@@ -120,7 +124,6 @@ def execute(
 
 # Simulate total number of trials
 if __name__ == "__main__":
-    import os
     import pickle
 
     # Execute numerous trials sim

--- a/examples/single_integrator/reach_goal/ukf_control.py
+++ b/examples/single_integrator/reach_goal/ukf_control.py
@@ -1,5 +1,9 @@
 """This module simulates a 6 degree-of-freedom dynamic quadrotor model as it seeks to reach a goal
 region while avoiding dynamic obstacles."""
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 
 from typing import List, Tuple
 
@@ -217,7 +221,6 @@ def execute(ii: int = 0) -> Tuple[Array, Array, Array, Array, List[str], List[Ar
 # Simulate total number of trials
 if __name__ == "__main__":
     import pickle
-    import os
 
     # Execute numerous trials sim
     results = conduct_monte_carlo(execute, n_trials=setup.n_trials)

--- a/examples/unicycle/reach_goal/ekf_control.py
+++ b/examples/unicycle/reach_goal/ekf_control.py
@@ -3,6 +3,10 @@ via ''python examples/template.py''.
 
 It does not define any new functions, and primarily loads modules from the src/cbfkit tree.
 """
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 
 import jax.numpy as jnp
 import numpy as np

--- a/examples/unicycle/reach_goal/nominal_control_ukf_estimation_main.py
+++ b/examples/unicycle/reach_goal/nominal_control_ukf_estimation_main.py
@@ -6,8 +6,11 @@ It does not define any new functions, and primarily loads modules from the
 src/cbfkit tree.
 
 """
-
+import sys
 import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
+
 
 import jax.numpy as jnp
 import numpy as np

--- a/examples/unicycle/reach_goal/perfect_sensing.py
+++ b/examples/unicycle/reach_goal/perfect_sensing.py
@@ -3,6 +3,10 @@ via ''python examples/template.py''.
 
 It does not define any new functions, and primarily loads modules from the src/cbfkit tree.
 """
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 
 import jax.numpy as jnp
 import numpy as np

--- a/examples/unicycle/reach_goal/risk_aware_cbf_control.py
+++ b/examples/unicycle/reach_goal/risk_aware_cbf_control.py
@@ -1,4 +1,7 @@
+import sys
 import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 
 import jax.numpy as jnp
 

--- a/examples/unicycle/reach_goal/risk_aware_cbf_monte_carlo_main.py
+++ b/examples/unicycle/reach_goal/risk_aware_cbf_monte_carlo_main.py
@@ -1,4 +1,7 @@
+import sys
 import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 import pickle
 from typing import Any, List, Optional, Tuple
 

--- a/examples/unicycle/reach_goal/ukf_control.py
+++ b/examples/unicycle/reach_goal/ukf_control.py
@@ -3,6 +3,10 @@ via ''python examples/template.py''.
 
 It does not define any new functions, and primarily loads modules from the src/cbfkit tree.
 """
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 
 import jax.numpy as jnp
 import numpy as np

--- a/examples/unicycle/reach_goal/vanilla_cbf_start_to_goal_main.py
+++ b/examples/unicycle/reach_goal/vanilla_cbf_start_to_goal_main.py
@@ -1,5 +1,7 @@
 import sys
 import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 
 # Add the project root to the path so we can import examples
 root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))

--- a/examples/van_der_pol/regulation/perfect_sensing.py
+++ b/examples/van_der_pol/regulation/perfect_sensing.py
@@ -1,3 +1,7 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 import matplotlib
 
 # Hack to prevent matplotlib.use("macosx") error in imported modules

--- a/examples/van_der_pol/regulation/perfect_state_measurements/main.py
+++ b/examples/van_der_pol/regulation/perfect_state_measurements/main.py
@@ -3,6 +3,10 @@ This module simulates a 6 degree-of-freedom dynamic quadrotor model as it seeks
 to reach a goal region while avoiding dynamic obstacles.
 
 """
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../../')))
+
 import matplotlib
 
 # Hack to prevent matplotlib.use("macosx") error in imported modules

--- a/examples/van_der_pol/regulation/ukf_control.py
+++ b/examples/van_der_pol/regulation/ukf_control.py
@@ -3,6 +3,10 @@ via ''python examples/template.py''.
 
 It does not define any new functions, and primarily loads modules from the src/cbfkit tree.
 """
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 
 import jax.numpy as jnp
 import numpy as np

--- a/examples/van_der_pol/regulation/ukf_estimation.py
+++ b/examples/van_der_pol/regulation/ukf_estimation.py
@@ -6,6 +6,10 @@ It does not define any new functions, and primarily loads modules from the
 src/cbfkit tree.
 
 """
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
 import matplotlib
 
 # Hack to prevent matplotlib.use("macosx") error in imported modules
@@ -105,7 +109,6 @@ else:
     pass
 
 if plot:
-    import os
     from examples.unicycle.common.visualizations import animate
 
     if save:


### PR DESCRIPTION
This PR fixes runtime failures in several example scripts caused by `ModuleNotFoundError`. The scripts assumed they were being run as modules or with the project root in `PYTHONPATH`. This change adds a standard `sys.path.append` block to the top of the affected scripts to ensure they can be executed directly. It also cleans up some duplicate imports.

Files modified:
- examples/unicycle/reach_goal/risk_aware_cbf_monte_carlo_main.py
- examples/van_der_pol/regulation/perfect_state_measurements/main.py
- and others (see diff).

Verified by manually running key failing scripts (`risk_aware_cbf_monte_carlo_main.py`, `perfect_state_measurements/main.py`) and confirming they now execute successfully. Confirmed `ruff check examples` passes.

---
*PR created automatically by Jules for task [2088766356881490064](https://jules.google.com/task/2088766356881490064) started by @bardhh*