### PR TITLE
🧹 Curator: Reduce scipy dependency overhead

### DIFF
--- a/src/cbfkit/integration/solve_ivp.py
+++ b/src/cbfkit/integration/solve_ivp.py
@@ -33,7 +33,6 @@ from typing import Callable
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
-from scipy.integrate import solve_ivp as solve
 
 
 def solve_ivp(x: Array, vector_field: Callable[[Array], Array], dt: float) -> Array:
@@ -49,6 +48,7 @@ def solve_ivp(x: Array, vector_field: Callable[[Array], Array], dt: float) -> Ar
     -------
         new_state
     """
+    from scipy.integrate import solve_ivp as solve
 
     # Wrap the vector field for scipy (which expects f(t, y) and uses numpy arrays)
     def fun(t, y):

--- a/src/cbfkit/utils/lqr.py
+++ b/src/cbfkit/utils/lqr.py
@@ -2,7 +2,6 @@
 
 import jax.numpy as jnp
 import numpy as np
-from scipy.linalg import solve_continuous_are
 from jax import Array
 
 
@@ -24,6 +23,8 @@ def compute_lqr_gain(A: Array, B: Array, Q: Array, R: Array) -> Array:
     -------
         Array: Gain matrix K
     """
+    from scipy.linalg import solve_continuous_are
+
     # Convert JAX arrays to NumPy arrays for SciPy
     A_np = np.array(A)
     B_np = np.array(B)

--- a/src/cbfkit/utils/uncertainty.py
+++ b/src/cbfkit/utils/uncertainty.py
@@ -3,14 +3,17 @@ import warnings
 
 import numpy as np
 from numpy.random import Generator
-from scipy.stats import norm
 
 
 def _pdf_or_ones(values, std):
     if std == 0:
         return np.ones((len(values), 1))
     else:
-        return norm.pdf(values, 0, std).reshape(-1, 1)
+        # Manual calculation of Gaussian PDF to avoid scipy dependency
+        # f(x) = (1 / (std * sqrt(2*pi))) * exp(-0.5 * ((x - mean) / std)^2)
+        # Here mean is 0.
+        pdf_values = (1 / (std * np.sqrt(2 * np.pi))) * np.exp(-0.5 * (values / std) ** 2)
+        return pdf_values.reshape(-1, 1)
 
 
 def generate_uncertainty_pmf(


### PR DESCRIPTION
This PR improves dependency hygiene by reducing the import-time overhead of `scipy`. 

Changes:
1.  **`src/cbfkit/utils/uncertainty.py`**: Replaced `scipy.stats.norm` with a manual NumPy implementation of the Gaussian PDF. This removes `scipy` as a dependency for this module.
2.  **`src/cbfkit/utils/lqr.py`**: Moved `from scipy.linalg import solve_continuous_are` inside `compute_lqr_gain`. This function is not used in standard simulation loops, so deferring the import prevents `scipy` from loading by default.
3.  **`src/cbfkit/integration/solve_ivp.py`**: Moved `from scipy.integrate import solve_ivp as solve` inside `solve_ivp`. This function is an alternative integrator, and deferring its import prevents `scipy` from loading when using the default integrators (e.g., `forward_euler`, `runge_kutta_4`).

These changes ensure that `cbfkit.simulation` and its core dependencies can be imported without triggering a `scipy` import, making the library lighter for basic usage.


---
*PR created automatically by Jules for task [3776099676542795399](https://jules.google.com/task/3776099676542795399) started by @bardhh*