### PR TITLE
🚨 Sentinel: Explicit NaN/Inf handling in simulation loops

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -52,6 +52,7 @@ from .utils import SimulationStepData
 
 
 SOLVER_STATUS_MAP = {
+    -10: "INTEGRATION_ERROR (NaN/Inf)",
     -2: "NAN_INPUT_DETECTED",
     -1: "NAN_DETECTED",
     0: "UNSOLVED (Likely Infeasible)",
@@ -88,7 +89,7 @@ def _check_simulation_status(
     """Checks for simulation errors and prints warnings if found."""
     # Sentinel: Explicit check for NaNs
     if nan_detected:
-        print_error("Simulation failed due to NaNs in state trajectory.")
+        print_error("Simulation failed due to NaNs/Infs in state trajectory.")
 
     # Check controller errors
     if "error" in controller_data_keys:
@@ -265,16 +266,21 @@ def simulator(
                 dt * s, x, u, z, c, controller_data, planner_data
             )
 
-            # Sentinel: Check for NaNs
-            if jnp.any(jnp.isnan(x_ret)):
-                controller_data = controller_data._replace(
-                    error=jnp.array(True), error_data=jnp.array(-1)
-                )
-
+            # Update auxiliary variables regardless of integration success
             u = u_ret
             z = z_ret
             c = c_ret
-            x = x_ret
+
+            # Sentinel: Check for NaNs
+            # Hermes: Check for both NaN and Inf to prevent divergent simulation
+            if jnp.any(jnp.isnan(x_ret)) or jnp.any(jnp.isinf(x_ret)):
+                controller_data = controller_data._replace(
+                    error=jnp.array(True), error_data=jnp.array(-10)
+                )
+                # Hermes: Freeze simulation at last valid state
+                # Do NOT update x to the invalid values.
+            else:
+                x = x_ret
 
             # Efficient accumulation
             xs_list.append(x.reshape(-1, 1))
@@ -621,7 +627,7 @@ def execute(
             planner_data_keys.append(key_str)
             planner_data_values.append(val)
 
-        nan_detected = jnp.any(jnp.isnan(xs))
+        nan_detected = jnp.any(jnp.isnan(xs)) | jnp.any(jnp.isinf(xs))
         _check_simulation_status(
             controller_data_keys,
             controller_data_values,
@@ -684,7 +690,9 @@ def execute(
     # Check states for NaNs
     nan_detected = False
     if len(formatted_data.states) > 0:
-        nan_detected = jnp.any(jnp.isnan(formatted_data.states))
+        nan_detected = jnp.any(jnp.isnan(formatted_data.states)) | jnp.any(
+            jnp.isinf(formatted_data.states)
+        )
 
     _check_simulation_status(
         controller_data_keys,

--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -197,10 +197,12 @@ def simulator_jit(
 
         key, x_next_candidate = lax.cond(stop, _hold, _integrate, operand=None)
 
-        # Sentinel: Check for NaNs in the next state to prevent divergent simulation
-        nan_in_next = jnp.any(jnp.isnan(x_next_candidate))
+        # Sentinel: Check for NaNs/Infs in the next state to prevent divergent simulation
+        nan_in_next = jnp.any(jnp.isnan(x_next_candidate)) | jnp.any(
+            jnp.isinf(x_next_candidate)
+        )
 
-        # If NaN is detected, revert to previous state to freeze simulation at last valid point
+        # If NaN/Inf is detected, revert to previous state to freeze simulation at last valid point
         x_next = jnp.where(nan_in_next, x, x_next_candidate)
 
         # If NaN is detected, force controller error to True.
@@ -216,11 +218,11 @@ def simulator_jit(
             )
             controller_data = controller_data._replace(error_data=new_error_data)
 
-        # Hermes: Print warning if NaN detected
+        # Hermes: Print warning if NaN/Inf detected
         lax.cond(
             nan_in_next,
             lambda: jdebug.print(
-                "⚠️ Simulation stopped: NaN detected during integration at t={t}", t=t
+                "⚠️ Simulation stopped: NaN/Inf detected during integration at t={t}", t=t
             ),
             lambda: None,
         )

--- a/tests/test_simulation/test_nan_safety.py
+++ b/tests/test_simulation/test_nan_safety.py
@@ -41,12 +41,20 @@ def test_nan_detection_python_loop(capsys):
     # So 1 element.
 
     assert results.states.shape[0] == 1
-    assert jnp.any(jnp.isnan(results.states))
+
+    # Updated behavior: State is frozen at last valid value, not NaN
+    assert not jnp.any(jnp.isnan(results.states))
+    assert jnp.allclose(results.states, x0)
 
     # Check captured stderr for error/warning messages (rich Console writes to stderr)
     captured = capsys.readouterr()
-    assert "Simulation failed due to NaNs" in captured.err
-    assert "CONTROLLER ERROR: NAN_DETECTED" in captured.err
+
+    # "Simulation failed due to NaNs" is only printed if NaNs are present in the trajectory.
+    # Since we prevent them, this is NOT printed.
+    # assert "Simulation failed due to NaNs" in captured.err
+
+    # Controller error MUST be flagged with correct status (-10)
+    assert "CONTROLLER ERROR: INTEGRATION_ERROR" in captured.err
 
 def test_nan_detection_jit_loop(capsys):
     """Test that NaNs are detected in the JIT simulation loop."""


### PR DESCRIPTION
Improved simulation robustness by adding explicit checks for Inf values (in addition to NaNs) and ensuring the simulation state freezes at the last valid point rather than propagating invalid values. This makes failures easier to diagnose.

---
*PR created automatically by Jules for task [9318818045159223799](https://jules.google.com/task/9318818045159223799) started by @bardhh*