### PR TITLE
Introduce MppiParameters TypedDict for better MPPI config typing

### DIFF
--- a/src/cbfkit/controllers/mppi/mppi_generator.py
+++ b/src/cbfkit/controllers/mppi/mppi_generator.py
@@ -47,6 +47,7 @@ from cbfkit.utils.user_types import (
     DynamicsCallable,
     Key,
     MppiGenerator,
+    MppiParameters,
     PlannerCallable,
     PlannerCallableReturns,
     PlannerData,
@@ -76,7 +77,7 @@ def mppi_generator() -> MppiGenerator:
         stage_cost: Optional[StageCostCallable] = None,
         terminal_cost: Optional[TerminalCostCallable] = None,
         trajectory_cost: Optional[TrajectoryCostCallable] = None,
-        mppi_args: Any = None,
+        mppi_args: Optional[MppiParameters] = None,
         **kwargs: Dict[str, Any],
     ) -> PlannerCallable:
         """Produces the function to deploy a MPPI control law.
@@ -93,6 +94,9 @@ def mppi_generator() -> MppiGenerator:
         -------
             PlannerCallable: function for computing control input based on MPPI
         """
+        if mppi_args is None:
+            raise ValueError("mppi_args must be provided")
+
         complete = False
         n_con = len(control_limits)
 

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -473,6 +473,32 @@ GenerateComputeTerminalCostCallable = Callable[
 ]
 
 
+class MppiParameters(TypedDict, total=False):
+    """Parameters for MPPI controller generation.
+
+    Attributes:
+        robot_state_dim (int): Dimension of the robot state.
+        robot_control_dim (int): Dimension of the robot control input.
+        prediction_horizon (int): Prediction horizon length.
+        num_samples (int): Number of trajectory samples.
+        time_step (float): Time step duration.
+        use_GPU (bool): Whether to use GPU acceleration.
+        costs_lambda (float): Temperature parameter for cost weighting.
+        cost_perturbation (float): Coefficient for control cost.
+        plot_samples (int): Number of samples to plot (optional).
+    """
+
+    robot_state_dim: int
+    robot_control_dim: int
+    prediction_horizon: int
+    num_samples: int
+    time_step: float
+    use_GPU: bool
+    costs_lambda: float
+    cost_perturbation: float
+    plot_samples: int
+
+
 class MppiGenerator(Protocol):
     """Protocol for MPPI generator."""
 
@@ -483,7 +509,7 @@ class MppiGenerator(Protocol):
         stage_cost: Optional[StageCostCallable] = None,
         terminal_cost: Optional[TerminalCostCallable] = None,
         trajectory_cost: Optional[TrajectoryCostCallable] = None,
-        mppi_args: Any = None,
+        mppi_args: Optional[MppiParameters] = None,
         **kwargs: Any,
     ) -> PlannerCallable:
         """Call method."""


### PR DESCRIPTION
Introduced `MppiParameters` TypedDict to type-hint `mppi_args` in MPPI controller generation. This improves type safety and documentation for MPPI configuration. Also added a runtime check to ensure `mppi_args` is not None.

---
*PR created automatically by Jules for task [5486495761080927862](https://jules.google.com/task/5486495761080927862) started by @bardhh*