### PR TITLE
⚙️ Flux: Fix flaky control loop test and speed up CI

### DIFF
--- a/tests/test_simulation/test_control_loop.py
+++ b/tests/test_simulation/test_control_loop.py
@@ -22,9 +22,9 @@ To run all tests in this module (from the root of the repository):
 import time
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from jax import jacfwd, random
-from numpy.random import uniform
 
 # Simulation-specific
 import cbfkit.systems.unicycle.models.olfatisaber2002approximate as unicycle
@@ -121,12 +121,13 @@ def initial_state():
     """Fixture to generate a valid initial state."""
     invalid_initial_condition = True
     state = None
+    rng = np.random.default_rng(42)  # Seeded random generator for reproducibility
 
     # Generate random initial condition
     while invalid_initial_condition:
-        x_rand = uniform(low=-x_max, high=x_max)
-        y_rand = uniform(low=-y_max, high=y_max)
-        a_rand = uniform(low=-jnp.pi, high=jnp.pi)
+        x_rand = rng.uniform(low=-x_max, high=x_max)
+        y_rand = rng.uniform(low=-y_max, high=y_max)
+        a_rand = rng.uniform(low=-jnp.pi, high=jnp.pi)
         state = jnp.array([x_rand, y_rand, a_rand])
 
         invalid_initial_condition = any(
@@ -150,7 +151,7 @@ def test_execution_performance_jit(initial_state):
     sim.execute(
         x0=initial_state,
         dt=DT,
-        num_steps=10,
+        num_steps=N_STEPS,
         dynamics=DYNAMICS,
         integrator=integrator,
         planner=None,

--- a/tests/test_simulation/test_simulator_jit_rk4.py
+++ b/tests/test_simulation/test_simulator_jit_rk4.py
@@ -3,7 +3,6 @@ import time
 import jax.numpy as jnp
 import pytest
 from jax import random
-from numpy.random import uniform
 
 import cbfkit.systems.unicycle.models.olfatisaber2002approximate as unicycle
 from cbfkit.certificates import concatenate_certificates


### PR DESCRIPTION
Flux: Fix flaky control loop test and speed up CI

This commit addresses nondeterminism in `tests/test_simulation/test_control_loop.py` by:
1.  Using a seeded `numpy.random.default_rng(42)` in the `initial_state` fixture, ensuring consistent initial conditions across test runs.
2.  Aligning the JIT warmup phase (`num_steps=N_STEPS`) with the benchmark phase to prevent redundant JIT recompilation during the timed execution.

Additionally, it removes an unused import (`uniform`) from `tests/test_simulation/test_simulator_jit_rk4.py`.

These changes improve CI reliability by eliminating flaky failures caused by random initial states and ensuring accurate performance benchmarking.

---
*PR created automatically by Jules for task [11305292245290936562](https://jules.google.com/task/11305292245290936562) started by @bardhh*