### PR TITLE
feat(certificates): Enforce state dimension consistency in certificate_package

### DIFF
--- a/src/cbfkit/certificates/packager.py
+++ b/src/cbfkit/certificates/packager.py
@@ -218,11 +218,39 @@ def certificate_package(
 
         @jit
         def j_(t: float, x: Array) -> Array:
+            # Aegis: Verify state dimension matches n
+            if x.ndim == 0:
+                x_dim = 1
+            else:
+                x_dim = x.shape[0]
+
+            if x_dim != n:
+                # This will raise a ValueError during tracing if dimensions mismatch
+                raise ValueError(
+                    f"State dimension mismatch in certificate function: "
+                    f"expected n={n}, but got input with dimension {x_dim}. "
+                    "Ensure 'n' passed to certificate_package matches your state dimension."
+                )
+
             # Gradient w.r.t x is the first n elements
             return j_func(jnp.hstack([x, t]))[:n]
 
         @jit
         def h_(t: float, x: Array) -> Array:
+            # Aegis: Verify state dimension matches n
+            if x.ndim == 0:
+                x_dim = 1
+            else:
+                x_dim = x.shape[0]
+
+            if x_dim != n:
+                # This will raise a ValueError during tracing if dimensions mismatch
+                raise ValueError(
+                    f"State dimension mismatch in certificate function: "
+                    f"expected n={n}, but got input with dimension {x_dim}. "
+                    "Ensure 'n' passed to certificate_package matches your state dimension."
+                )
+
             # Hessian w.r.t x is the top-left nxn block
             return h_func(jnp.hstack([x, t]))[:n, :n]
 

--- a/tests/test_certificates/test_certificate_shape_safety.py
+++ b/tests/test_certificates/test_certificate_shape_safety.py
@@ -1,0 +1,60 @@
+
+import pytest
+import jax.numpy as jnp
+from cbfkit.certificates import certificate_package
+from cbfkit.certificates.conditions.barrier_conditions import zeroing_barriers
+
+def test_certificate_n_mismatch():
+    """Verifies that certificate_package raises ValueError when input state dimension
+    does not match the specified 'n'."""
+
+    # Define a simple barrier h(x) = x[0] - 1.0
+    def cbf_factory():
+        def cbf(xt):
+            return xt[0] - 1.0
+        return cbf
+
+    # Package with n=0 (default) or wrong n
+    # Case 1: n=0 (trap)
+    pkg_zero = certificate_package(cbf_factory, n=0)
+    conditions = zeroing_barriers.linear_class_k(1.0)
+    coll_zero = pkg_zero(conditions)
+    grad_func_zero = coll_zero.jacobians[0]
+
+    t = 0.0
+    x = jnp.array([2.0, 3.0]) # dim 2
+
+    # This should raise ValueError with the fix.
+    # Currently it returns empty array (silent failure).
+    try:
+        g = grad_func_zero(t, x)
+        # If we are here, it didn't raise.
+        # Check if it returned empty array (current behavior)
+        if g.size == 0:
+            pytest.fail("Silent failure: n=0 resulted in empty gradient instead of raising ValueError.")
+        else:
+            # If it returned something else, it's unexpected behavior?
+            pass
+    except ValueError as e:
+        assert "dimension mismatch" in str(e).lower()
+
+    # Case 2: n=1 (wrong dimension, but > 0)
+    pkg_wrong = certificate_package(cbf_factory, n=1)
+    coll_wrong = pkg_wrong(conditions)
+    grad_func_wrong = coll_wrong.jacobians[0]
+
+    try:
+        g = grad_func_wrong(t, x)
+        # Currently it returns gradient sliced to size 1: [1.0]
+        # This is WRONG for 2D system.
+        pytest.fail("Silent failure: n=1 resulted in sliced gradient instead of raising ValueError.")
+    except ValueError as e:
+        assert "dimension mismatch" in str(e).lower()
+
+if __name__ == "__main__":
+    # Manually run if executed as script
+    try:
+        test_certificate_n_mismatch()
+        print("Test passed!")
+    except Exception as e:
+        print(f"Test failed: {e}")


### PR DESCRIPTION
🛡️ Aegis: Enforce state dimension consistency in `certificate_package`

**What failed and why:**
The `certificate_package` function defaults the system state dimension `n` to 0. If a user omits `n` (or provides an incorrect one), the automatically generated gradient (`j_`) and Hessian (`h_`) functions silently slice the full derivative vector (w.r.t state and time) using `[:n]`.
For `n=0`, this results in an empty array `[]` regardless of the actual state dimension. Downstream controllers (like `cbf_clf_qp_generator`) process this empty gradient without error (due to JAX's handling of 0-dim `matmul` or `hstack` in some contexts, or simply ignoring the constraint), leading to the control barrier function being effectively disabled.

**The Fix:**
I added a runtime check inside the JIT-compiled wrapper functions `j_` and `h_`. It compares the first dimension of the input state `x` (resolved at tracing time) with the configured `n`.
If they mismatch (e.g., `x` has size 2 but `n=0`), it raises a descriptive `ValueError`. This ensures that `certificate_package` fails loudly and explicitly when configured incorrectly, rather than failing silently and dangerously during control execution.

**Verification:**
- Added `tests/test_certificates/test_certificate_shape_safety.py` which reproduces the issue (previously passed silently with empty gradients, now catches the expected `ValueError`).
- Ran existing tests in `tests/test_certificates/` and `tests/test_controllers/` to ensure no regressions for correct usage.

---
*PR created automatically by Jules for task [1228031998687058657](https://jules.google.com/task/1228031998687058657) started by @bardhh*