### PR TITLE
Fix random generator inconsistency in uncertainty utils

### DIFF
--- a/src/cbfkit/utils/uncertainty.py
+++ b/src/cbfkit/utils/uncertainty.py
@@ -73,7 +73,9 @@ def generate_uncertainty_pmf(
         )
         rng = np.random
     elif isinstance(rng, int):
-        rng = np.random.default_rng(rng)
+        # Use RandomState to ensure consistency with global numpy state (legacy MT19937)
+        # when rng is None. Passing a Generator object (default_rng) is still supported.
+        rng = np.random.RandomState(rng)
 
     # Sample Control Noise
     # samples_u shape: (S, 2, 1)

--- a/tests/test_uncertainty_reproducibility.py
+++ b/tests/test_uncertainty_reproducibility.py
@@ -56,3 +56,28 @@ def test_generate_uncertainty_pmf_randomness():
 
     assert not np.array_equal(u1, u2)
     assert not np.array_equal(x1, x2)
+
+def test_legacy_reproducibility_consistency():
+    """
+    Test that passing an integer seed produces results consistent with legacy rng=None (seeded).
+
+    This ensures that users can reproduce legacy runs (where rng=None was used with global seeding)
+    by passing the seed explicitly, avoiding the mismatch between MT19937 (legacy) and PCG64 (default_rng).
+    """
+    u = np.array([0.0, 0.0])
+    x = np.array([0.0, 0.0, 0.0, 0.0])
+    # Ensure standard deviation is non-zero so we get random numbers
+    noise_params = [[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1]]
+    S = 10
+    SEED = 42
+
+    # Case 1: Global seed + rng=None (Legacy behavior)
+    np.random.seed(SEED)
+    with pytest.warns(UserWarning, match="Using global numpy random state"):
+        pmf1, u1, x1 = generate_uncertainty_pmf(u, x, noise_params, S, rng=None)
+
+    # Case 2: rng=SEED (int)
+    # Should use RandomState(SEED) -> MT19937 -> Match Case 1
+    pmf2, u2, x2 = generate_uncertainty_pmf(u, x, noise_params, S, rng=SEED)
+
+    np.testing.assert_allclose(x1, x2, err_msg="Explicit integer seed failed to reproduce global seed results")


### PR DESCRIPTION
This PR addresses a reproducibility inconsistency in `cbfkit.utils.uncertainty.generate_uncertainty_pmf`.

Previously, if a user relied on `np.random.seed(42)` and called the function with `rng=None` (default), they received a sequence generated by the legacy MT19937 algorithm (via global `np.random`). However, if they attempted to "explicitly" reproduce this run by passing `rng=42`, the function internally created a `default_rng(42)` which uses the PCG64 algorithm, resulting in different values.

This change modifies the function to use `np.random.RandomState(rng)` when `rng` is an integer, ensuring it uses the same algorithm (MT19937) as the global state fallback. This makes explicit seeding a reliable way to reproduce legacy/global-seeded runs.

Support for passing a `Generator` object (e.g. `default_rng(42)`) remains unchanged.

Added `test_legacy_reproducibility_consistency` to `tests/test_uncertainty_reproducibility.py` to enforce this behavior.

---
*PR created automatically by Jules for task [18370202065162412397](https://jules.google.com/task/18370202065162412397) started by @bardhh*