### PR TITLE
🧹 Curator: Suppress jaxopt deprecation warning

### DIFF
--- a/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
@@ -1,10 +1,14 @@
 """Quadratic program solver using the Jaxopt library."""
 
+import warnings
 from typing import Any, NamedTuple, Optional, Tuple, Union
 
 import jax.numpy as jnp
 from jax import Array, jit
-from jaxopt import OSQP, EqualityConstrainedQP
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module="jaxopt")
+    from jaxopt import OSQP, EqualityConstrainedQP
 
 from cbfkit.utils.jit_monitor import JitMonitor
 


### PR DESCRIPTION
Suppressed `DeprecationWarning` from `jaxopt` in `qp_solver_jaxopt.py`.
Verified that the warning is no longer emitted when running tests or importing the module.
Running `pytest` with `PYTHONPATH` set to the source directory confirmed the fix.

---
*PR created automatically by Jules for task [15053459673908025588](https://jules.google.com/task/15053459673908025588) started by @bardhh*