### PR TITLE
🧮 Janus: Improve constraint normalization for small gradients

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -451,7 +451,7 @@ def cbf_clf_qp_generator(
                 row_max_safe = jnp.where(row_max > 0, row_max, 1.0)
 
                 # Check if row is effectively zero (to avoid nan gradients at 0)
-                is_zero_row = row_max < 1e-20
+                is_zero_row = row_max < 1e-30
 
                 # Scale the matrix
                 g_mat_c_scaled = g_mat_c / row_max_safe[:, None]
@@ -470,14 +470,14 @@ def cbf_clf_qp_generator(
                 row_norms_c = row_norms_scaled * row_max_safe
 
                 # Add epsilon for safety in division
-                row_norms_c = row_norms_c + 1e-20
+                row_norms_c = row_norms_c + 1e-30
 
                 # Janus: Normalize constraints robustly.
-                # Use a clamped scaling factor (max 1e15) to:
-                # 1. Enforce constraints with small gradients (e.g. 1e-13) to catch gross infeasibility (Safety).
-                # 2. Allow normalization of small signals (e.g. 1e-15) for solver convergence.
+                # Use a clamped scaling factor (max 1e30) to:
+                # 1. Enforce constraints with small gradients (e.g. 1e-25) to catch gross infeasibility (Safety).
+                # 2. Allow normalization of small signals (e.g. 1e-25) for solver convergence.
                 safe_scales_c = jnp.where(
-                    is_zero_row, 1.0, jnp.minimum(1.0 / row_norms_c, 1e15)
+                    is_zero_row, 1.0, jnp.minimum(1.0 / row_norms_c, 1e30)
                 )
 
                 g_mat_c = g_mat_c * safe_scales_c[:, None]

--- a/tests/test_optimization/test_robust_normalization.py
+++ b/tests/test_optimization/test_robust_normalization.py
@@ -1,0 +1,55 @@
+
+import pytest
+import jax.numpy as jnp
+from jax import random
+from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+from cbfkit.utils.user_types import ControllerData
+
+def test_sub_atomic_gradient_normalization():
+    """
+    Test that the controller robustly normalizes extremely small gradients (1e-25).
+    This simulates constraints at sub-atomic scales or with poor unit scaling.
+    Constraint: 1e-25 * u >= 1e-25  => u >= 1.0
+    Cost: u^2
+    Expected: u = 1.0
+    """
+    # 1D system: x_dot = u
+    def dynamics(x):
+        return jnp.array([0.0]), jnp.array([[1.0]])
+
+    # Barrier: h(x)
+    # Lfh = 0
+    # Lgh = 1e-25
+    # alpha(h) = -1e-25 (forcing u >= 1)
+
+    scale = 1e-25
+
+    def h(t, x): return -scale
+    def dhdx(t, x): return jnp.array([scale]) # Gradient is 1e-25
+    def d2hdx2(t, x): return jnp.zeros((1,1))
+    def partial_t(t, x): return 0.0
+    def condition(val): return 1.0 * val
+
+    barriers = ([h], [dhdx], [d2hdx2], [partial_t], [condition])
+
+    # We use relaxable_cbf=False to force strict satisfaction
+    controller = vanilla_cbf_clf_qp_controller(
+        control_limits=jnp.array([10.0]), # Large enough
+        dynamics_func=dynamics,
+        barriers=barriers,
+        relaxable_cbf=False
+    )
+
+    x = jnp.array([0.0])
+    t = 0.0
+    u_nom = jnp.array([0.0])
+    key = random.PRNGKey(0)
+    data = ControllerData()
+
+    # Run controller
+    u, data = controller(t, x, u_nom, key, data)
+
+    assert not data.error, f"Controller failed with status {data.error_data}"
+    # The solver should find u approx 1.0.
+    # Without normalization, it finds u approx 0.0 (tolerating 1e-25 violation).
+    assert jnp.allclose(u, 1.0, atol=1e-3), f"Expected u=1.0, got {u}. Robust normalization failed for scale {scale}."


### PR DESCRIPTION
This PR addresses numerical instability in the QP controller when dealing with constraints that have extremely small gradients (e.g., $10^{-25}$). Previously, a hardcoded threshold of `1e-20` caused such constraints to skip normalization, allowing the solver (with default tolerance `1e-3`) to treat them as satisfied even when grossly violated. The fix lowers the thresholds and increases the maximum scaling factor to support sub-atomic scales, ensuring robust safety enforcement. A new regression test `tests/test_optimization/test_robust_normalization.py` is added.


---
*PR created automatically by Jules for task [9514927926776594129](https://jules.google.com/task/9514927926776594129) started by @bardhh*