### PR TITLE
Relay: Fix tutorial timeouts and execution failures

### DIFF
--- a/tutorials/multi_robot_test.py
+++ b/tutorials/multi_robot_test.py
@@ -26,7 +26,7 @@ def main():
     INITIAL_STATE = np.zeros(2 * num_robots)
     goals = np.zeros(2 * num_robots)
     DT = 0.1
-    TF = 10
+    TF = 10 if not os.getenv("CBFKIT_TEST_MODE") else 1.0
     N_STEPS = int(TF / DT) + 1
     ACTUATION_LIMITS = 100 * jnp.ones(2 * num_robots)
 

--- a/tutorials/simulate_mppi_stl.py
+++ b/tutorials/simulate_mppi_stl.py
@@ -17,7 +17,7 @@ model_name = "mppi_cbf_stl"
 # Simulation Parameters
 SAVE_FILE = target_directory + f"/{model_name}/simulation_data"
 DT = 0.1  # 1e-2
-TF = 10  # 0  # 20  # 0  # 10.0
+TF = 10 if not os.getenv("CBFKIT_TEST_MODE") else 1.0
 N_STEPS = int(TF / DT) + 1
 INITIAL_STATE = jnp.array([0.0, 0.0])
 ACTUATION_LIMITS = jnp.array([5.0, 5.0])  # Box control input constraint, i.e., -100 <= u <= 100

--- a/tutorials/single_integrator_reach_avoid_dyn_obs.py
+++ b/tutorials/single_integrator_reach_avoid_dyn_obs.py
@@ -199,10 +199,11 @@ from cbfkit.sensors import perfect as sensor
 from cbfkit.simulation import simulator
 
 # Simulate the closed-loop system
+num_steps = 1000 if not os.getenv("CBFKIT_TEST_MODE") else 100
 x, u, z, p, dkeys, dvals, _, _ = simulator.execute(
     x0=initial_state,
     dt=1e-2,
-    num_steps=1000,
+    num_steps=num_steps,
     dynamics=dynamics,
     integrator=runge_kutta_4,
     nominal_controller=nominal_controller,
@@ -213,6 +214,9 @@ x, u, z, p, dkeys, dvals, _, _ = simulator.execute(
 
 #####################################################################
 #####################################################################
+
+if os.getenv("CBFKIT_TEST_MODE"):
+    sys.exit(0)
 
 import matplotlib.animation as animation
 import matplotlib.patches as patches


### PR DESCRIPTION
- Fixed `tutorials/single_integrator_reach_avoid_dyn_obs.py` by adding `CBFKIT_TEST_MODE` support to skip animation/plotting and reduce simulation steps.
- Fixed `tutorials/simulate_mppi_stl.py` by adding `CBFKIT_TEST_MODE` support to reduce simulation horizon `TF`.
- Fixed `tutorials/multi_robot_test.py` by adding `CBFKIT_TEST_MODE` support to reduce simulation horizon `TF`.
- Verified all examples and tutorials pass when dependencies (`codegen`, `cvxopt`, `casadi`) are installed.

---
*PR created automatically by Jules for task [128418090634507272](https://jules.google.com/task/128418090634507272) started by @bardhh*