### PR TITLE
feat: add `goal` argument to simulator.execute

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -372,6 +372,7 @@ def execute(
     filepath: Optional[str] = None,
     verbose: Optional[bool] = True,
     controller_data: Optional[Union[ControllerData, Dict[str, Any]]] = None,
+    goal: Optional[State] = None,
     planner_data: Optional[Union[PlannerData, Dict[str, Any]]] = None,
     initial_covariance: Optional[Covariance] = None,
     stl_trajectory_cost: Optional[StlTrajectoryCostCallable] = None,
@@ -405,6 +406,9 @@ def execute(
         filepath (Optional[str], optional): Path to save log file. Defaults to None.
         verbose (Optional[bool], optional): Print progress/status. Defaults to True.
         controller_data (ControllerData, optional): Initial controller data. Defaults to None.
+        goal (State, optional): Constant reference state (e.g., target pose).
+            If provided, creates a constant trajectory in planner_data.
+            Mutually exclusive with `planner_data.x_traj`. Defaults to None.
         planner_data (PlannerData, optional): Initial planner data. Defaults to None.
         initial_covariance (Optional[Covariance], optional): Initial estimator covariance.
         Defaults to None.
@@ -447,6 +451,26 @@ def execute(
         controller_data = ControllerData()
     elif isinstance(controller_data, dict):
         controller_data = ControllerData(**controller_data)
+
+    # Process goal
+    if goal is not None:
+        goal_arr = jnp.atleast_1d(jnp.array(goal))
+        if goal_arr.ndim == 1:
+            goal_arr = goal_arr.reshape(-1, 1)
+
+        if planner_data is None:
+            planner_data = PlannerData(x_traj=goal_arr)
+        elif isinstance(planner_data, dict):
+            if planner_data.get("x_traj") is not None:
+                raise ValueError(
+                    "Cannot specify both 'goal' and 'planner_data[\"x_traj\"]'."
+                )
+            planner_data["x_traj"] = goal_arr
+            # Convert to NamedTuple later
+        elif isinstance(planner_data, PlannerData):
+            if planner_data.x_traj is not None:
+                raise ValueError("Cannot specify both 'goal' and 'planner_data.x_traj'.")
+            planner_data = planner_data._replace(x_traj=goal_arr)
 
     if planner_data is None:
         planner_data = PlannerData()

--- a/tests/test_simulation/test_simulator_goal_api.py
+++ b/tests/test_simulation/test_simulator_goal_api.py
@@ -1,0 +1,121 @@
+
+import jax.numpy as jnp
+import pytest
+from cbfkit.simulation import simulator
+from cbfkit.utils.user_types import PlannerData
+
+def test_goal_sets_xtraj():
+    """Test that passing 'goal' correctly populates planner_data.x_traj."""
+    goal = jnp.array([1.0, 2.0, 3.0])
+
+    # Run execute with just goal (mocking other required args with minimal values)
+    # We don't need to run full simulation, just check the argument processing.
+    # However, 'execute' runs the simulation. We can use a dummy dynamics/integrator
+    # and 0 steps to just check initialization if we could inspect it, but execute returns results.
+    # Instead, we can't easily inspect internal state of 'execute' without running it.
+    # But we can verify that it runs without error and produces a result where
+    # the planner data might be reflected if we had a planner.
+
+    # Better approach: We can check the logic by calling execute with a dummy system
+    # and checking if it raises error or runs.
+    # But to verify x_traj is set, we might need to rely on the fact that if we provide
+    # a nominal controller that uses x_des, it receives the goal.
+
+    # Let's mock a nominal controller that asserts the reference state matches goal.
+
+    goal_arr = jnp.array([10.0, 20.0])
+
+    def dynamics(x):
+        return jnp.zeros_like(x), jnp.zeros((x.shape[0], 1))
+
+    def integrator(x, f, dt):
+        return x
+
+    def nominal_controller(t, x, key, ref):
+        # ref should match goal (reshaped)
+        assert ref is not None
+        # ref comes from planner_data.x_traj slicing
+        # Simulation logic: x_des = traj[:, idx]
+        # Since traj is constant, ref should be goal
+        assert jnp.allclose(ref.flatten(), goal_arr)
+        return jnp.zeros(1), {}
+
+    # 1. Test with goal only
+    simulator.execute(
+        x0=jnp.zeros(2),
+        dt=0.1,
+        num_steps=1,
+        dynamics=dynamics,
+        integrator=integrator,
+        nominal_controller=nominal_controller,
+        goal=goal_arr
+    )
+
+def test_goal_with_empty_planner_data():
+    """Test goal works when planner_data is provided but empty."""
+    goal_arr = jnp.array([5.0])
+
+    def dynamics(x):
+        return jnp.zeros_like(x), jnp.zeros((x.shape[0], 1))
+
+    def integrator(x, f, dt):
+        return x
+
+    def nominal_controller(t, x, key, ref):
+        assert jnp.allclose(ref.flatten(), goal_arr)
+        return jnp.zeros(1), {}
+
+    simulator.execute(
+        x0=jnp.zeros(1),
+        dt=0.1,
+        num_steps=1,
+        dynamics=dynamics,
+        integrator=integrator,
+        nominal_controller=nominal_controller,
+        goal=goal_arr,
+        planner_data=PlannerData() # Empty
+    )
+
+    # Also test with dict
+    simulator.execute(
+        x0=jnp.zeros(1),
+        dt=0.1,
+        num_steps=1,
+        dynamics=dynamics,
+        integrator=integrator,
+        nominal_controller=nominal_controller,
+        goal=goal_arr,
+        planner_data={} # Empty dict
+    )
+
+def test_goal_conflict_raises_error():
+    """Test that providing both goal and x_traj raises ValueError."""
+    goal_arr = jnp.array([1.0])
+    traj = jnp.array([[2.0]])
+
+    def dynamics(x): return jnp.zeros_like(x), jnp.zeros((x.shape[0], 1))
+    def integrator(x, f, dt): return x
+
+    # Case 1: PlannerData object
+    with pytest.raises(ValueError, match="Cannot specify both 'goal' and 'planner_data.x_traj'"):
+        simulator.execute(
+            x0=jnp.zeros(1),
+            dt=0.1,
+            num_steps=1,
+            dynamics=dynamics,
+            integrator=integrator,
+            goal=goal_arr,
+            planner_data=PlannerData(x_traj=traj)
+        )
+
+    # Case 2: Dict
+    with pytest.raises(ValueError, match="Cannot specify both 'goal' and 'planner_data"):
+        simulator.execute(
+            x0=jnp.zeros(1),
+            dt=0.1,
+            num_steps=1,
+            dynamics=dynamics,
+            integrator=integrator,
+            goal=goal_arr,
+            planner_data={"x_traj": traj}
+        )


### PR DESCRIPTION
This PR adds a `goal` argument to the `simulator.execute` function, allowing users to easily specify a constant reference state (e.g., for point stabilization) without manually constructing a `PlannerData` object with a trajectory. This simplifies the API for common use cases.

The changes include:
- Modification of `src/cbfkit/simulation/simulator.py` to accept and process `goal`.
- Logic to ensure `goal` and `planner_data.x_traj` are mutually exclusive.
- A new test file `tests/test_simulation/test_simulator_goal_api.py` verifying the new functionality and error handling.

---
*PR created automatically by Jules for task [10213905069954169384](https://jules.google.com/task/10213905069954169384) started by @bardhh*