### PR TITLE
✉️ Hermes: Improve simulator error messages for state shape mismatches

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -428,6 +428,30 @@ def execute(
             - planner_keys (List[str]): Names of logged planner data fields.
             - planner_values (List[Array]): Logged planner data values.
     """
+    # Sentinel: Validate initial state shape and dynamics consistency
+    # This prevents obscure broadcasting errors deep in the simulation loop.
+    try:
+        f_check, g_check = dynamics(x0)
+    except Exception as e:
+        raise ValueError(
+            f"Dynamics evaluation failed for initial state 'x0' with shape {x0.shape}.\n"
+            f"Ensure 'x0' has the correct dimensions for the system.\n"
+            f"Original error: {e}"
+        ) from e
+
+    if f_check.shape != x0.shape:
+        msg = (
+            f"Shape mismatch: Initial state 'x0' has shape {x0.shape}, "
+            f"but dynamics drift 'f' has shape {f_check.shape}.\n"
+            "The state vector must match the dynamics output shape."
+        )
+        if x0.ndim == 2 and x0.shape[1] == 1 and f_check.ndim == 1:
+            msg += "\nTip: Pass a 1D array for 'x0' (e.g., use x0.ravel() or x0.flatten())."
+        elif x0.shape[0] < f_check.shape[0]:
+            msg += f"\nTip: System expects {f_check.shape[0]} states, but got {x0.shape[0]}."
+
+        raise ValueError(msg)
+
     # Setup callbacks
     callbacks: List[SimulationCallback] = []
     if verbose:

--- a/tests/test_dx_improvements.py
+++ b/tests/test_dx_improvements.py
@@ -1,0 +1,59 @@
+
+import pytest
+import jax.numpy as jnp
+from cbfkit.systems.unicycle.models.accel_unicycle import plant
+from cbfkit.simulation import simulator
+from cbfkit.integration import forward_euler
+
+def test_simulator_shape_mismatch_column_vector():
+    """Test that simulator.execute raises ValueError when x0 is a column vector (N, 1)."""
+    dynamics = plant()
+    # Accel unicycle has 4 states
+    # Passing (4, 1) causes dynamics evaluation failure (JAX error wrapped in ValueError)
+    x0 = jnp.array([[0.0], [0.0], [1.0], [0.0]])
+
+    with pytest.raises(ValueError, match="Dynamics evaluation failed for initial state 'x0'"):
+        simulator.execute(
+            x0=x0,
+            dt=0.1,
+            num_steps=10,
+            dynamics=dynamics,
+            integrator=forward_euler,
+            planner=None,
+            nominal_controller=None,
+        )
+
+def test_simulator_shape_mismatch_wrong_dimension():
+    """Test that simulator.execute raises ValueError when x0 has wrong number of states."""
+    dynamics = plant()
+    # Accel unicycle has 4 states
+    # Passing 3 states should trigger wrong dimension error
+    x0 = jnp.array([0.0, 0.0, 1.0])
+
+    with pytest.raises(ValueError, match="Shape mismatch: Initial state 'x0' has shape"):
+        simulator.execute(
+            x0=x0,
+            dt=0.1,
+            num_steps=10,
+            dynamics=dynamics,
+            integrator=forward_euler,
+            planner=None,
+            nominal_controller=None,
+        )
+
+def test_simulator_valid_input():
+    """Test that simulator.execute works with correct shape."""
+    dynamics = plant()
+    x0 = jnp.array([0.0, 0.0, 1.0, 0.0])
+
+    # Should not raise
+    simulator.execute(
+        x0=x0,
+        dt=0.1,
+        num_steps=10,
+        dynamics=dynamics,
+        integrator=forward_euler,
+        planner=None,
+        nominal_controller=lambda t, x, k, r: (jnp.zeros(2), {}),
+        use_jit=True,
+    )


### PR DESCRIPTION
Implements a "fail-fast" validation in `cbfkit.simulation.simulator.execute` to detect and report initial state shape mismatches.
This prevents cryptic `TypeError: add got incompatible shapes for broadcasting` errors deep in the simulation loop when users accidentally pass column vectors `(N, 1)` or incorrect dimensions `(N-1,)`.

The validation:
1. Calls `dynamics(x0)` once to verify computability.
2. Checks if the output drift vector `f` matches `x0` shape.
3. Raises `ValueError` with actionable advice (e.g., "Pass a 1D array", "System expects N states").

Verified with new regression tests `tests/test_dx_improvements.py`.

---
*PR created automatically by Jules for task [17633330302724317273](https://jules.google.com/task/17633330302724317273) started by @bardhh*