### PR TITLE
🧹 Curator: make rich an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "jax>=0.4.23",
     "jaxopt>=0.8.3,<0.9",
     "scipy>=1.9,<2.0",
-    "rich>=13.0,<15.0"
 ]
 
 
@@ -41,6 +40,7 @@ casadi = [
 ]
 vis = [
     "matplotlib>=3.8.2,<4.0",
+    "rich>=13.0,<15.0",
 ]
 codegen = [
     "black>=23.12.1,<24.0",

--- a/src/cbfkit/simulation/callbacks.py
+++ b/src/cbfkit/simulation/callbacks.py
@@ -1,6 +1,13 @@
-from typing import Any, Dict, List, Optional, Protocol, Union
+from typing import Any, Dict, List, Optional, Protocol, Union, TYPE_CHECKING
 
-from rich.progress import Progress, TaskID
+if TYPE_CHECKING:
+    from rich.progress import Progress, TaskID
+else:
+    try:
+        from rich.progress import Progress, TaskID
+    except ImportError:
+        Progress = Any
+        TaskID = Any
 
 from cbfkit.simulation.utils import SimulationStepData
 from cbfkit.utils.logger import write_log

--- a/src/cbfkit/simulation/ui.py
+++ b/src/cbfkit/simulation/ui.py
@@ -7,38 +7,84 @@ file logging (no ANSI codes).
 
 from __future__ import annotations
 
+import re
+import sys
 from typing import Optional
 
-from rich.console import Console
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    SpinnerColumn,
-    TaskID,
-    TaskProgressColumn,
-    TextColumn,
-    TimeElapsedColumn,
-    TimeRemainingColumn,
-)
-from rich.theme import Theme
+try:
+    from rich.console import Console
+    from rich.progress import (
+        BarColumn,
+        MofNCompleteColumn,
+        Progress,
+        SpinnerColumn,
+        TaskID,
+        TaskProgressColumn,
+        TextColumn,
+        TimeElapsedColumn,
+        TimeRemainingColumn,
+    )
+    from rich.theme import Theme
+
+    HAS_RICH = True
+except ImportError:
+    HAS_RICH = False
+
+    # Dummy classes
+    class Console:  # type: ignore
+        def __init__(self, stderr=False, theme=None):
+            self.stderr = stderr
+
+        def print(self, *args, **kwargs):
+            msg = " ".join(str(x) for x in args)
+            # Only strip tags that look like rich markup (start with a letter)
+            # This avoids stripping [1, 2] or [ 1. 2.]
+            clean_msg = re.sub(r"\[/?[a-z][^\]]*\]", "", msg)
+            file = sys.stderr if self.stderr else sys.stdout
+            print(clean_msg, file=file)
+
+    class Progress:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+        def stop(self):
+            pass
+
+        def add_task(self, *args, **kwargs):
+            return 0
+
+        def update(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    TaskID = int  # type: ignore
 
 # -- Singleton console --------------------------------------------------
 
-_CBFKIT_THEME = Theme(
-    {
-        "info": "cyan",
-        "warning": "yellow bold",
-        "error": "red bold",
-        "success": "green bold",
-        "jit": "magenta",
-    }
-)
-
-# The console auto-detects TTY. When stderr is not a terminal (piped or
-# redirected) force_terminal=False ensures plain text. When it IS a TTY,
-# rich renders colors and live updates.
-console = Console(stderr=True, theme=_CBFKIT_THEME)
+if HAS_RICH:
+    _CBFKIT_THEME = Theme(
+        {
+            "info": "cyan",
+            "warning": "yellow bold",
+            "error": "red bold",
+            "success": "green bold",
+            "jit": "magenta",
+        }
+    )
+    # The console auto-detects TTY. When stderr is not a terminal (piped or
+    # redirected) force_terminal=False ensures plain text. When it IS a TTY,
+    # rich renders colors and live updates.
+    console = Console(stderr=True, theme=_CBFKIT_THEME)
+else:
+    console = Console(stderr=True)
 
 
 # -- Progress bar factory -----------------------------------------------
@@ -64,21 +110,24 @@ def create_progress(
         must use it as a context manager or call ``start()``/``stop()``
         manually, and add a task via ``add_task()``.
     """
-    progress = Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(bar_width=40),
-        TaskProgressColumn(),
-        MofNCompleteColumn(),
-        TimeElapsedColumn(),
-        TimeRemainingColumn(),
-        console=console,
-        transient=transient,
-        # Throttle refresh to 10 Hz -- keeps overhead negligible even
-        # for 10k+ step simulations where on_step fires every iteration.
-        refresh_per_second=10,
-    )
-    return progress
+    if HAS_RICH:
+        progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(bar_width=40),
+            TaskProgressColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+            console=console,
+            transient=transient,
+            # Throttle refresh to 10 Hz -- keeps overhead negligible even
+            # for 10k+ step simulations where on_step fires every iteration.
+            refresh_per_second=10,
+        )
+        return progress
+    else:
+        return Progress()
 
 
 # -- Formatted message helpers ------------------------------------------


### PR DESCRIPTION
`rich` is now an optional dependency, part of the `vis` extra. This reduces the core installation size and potential conflicts.
When `rich` is missing, `cbfkit` falls back to a dummy `Console` and `Progress` implementation that uses standard `print` (stripping basic rich markup) and no-op progress bars.
Changes:
- Moved `rich` to `vis` extra in `pyproject.toml`.
- Added conditional imports and dummy classes in `src/cbfkit/simulation/ui.py`.
- Added conditional imports in `src/cbfkit/simulation/callbacks.py`.
- Improved dummy console to avoid stripping array brackets (e.g., `[1, 2]`).

---
*PR created automatically by Jules for task [6734191467578133813](https://jules.google.com/task/6734191467578133813) started by @bardhh*