### PR TITLE
🔍 Scout: JAX JIT compilation diagnostic

### DIFF
--- a/benchmarks/scout_jit_compile_counter.py
+++ b/benchmarks/scout_jit_compile_counter.py
@@ -1,0 +1,28 @@
+"""Scout Benchmark: JIT Compilation Counter"""
+import time
+import jax.numpy as jnp
+from cbfkit.simulation import simulator as sim
+from cbfkit.systems.unicycle.models.accel_unicycle import plant
+from cbfkit.integration import forward_euler
+from cbfkit.utils.jit_monitor import JitMonitor
+
+def run():
+    JitMonitor.reset()
+    dyn, x0, dt = plant(), jnp.zeros(4), 0.01
+    scenarios = [("Base", 100), ("Repeat", 100), ("Mod", 101)]
+
+    print(f"{'Run':<10} | {'N':<3} | {'Time':<6} | {'JIT':<3} | {'Status'}")
+    prev_jit = 0
+
+    for name, n in scenarios:
+        t0 = time.time()
+        sim.execute(x0, dt, n, dyn, forward_euler, use_jit=True, verbose=False)
+        elap = time.time() - t0
+        curr_jit = JitMonitor.get_counts().get("simulator_jit", 0)
+
+        stat = "Recompile" if curr_jit > prev_jit else ("Cached" if prev_jit > 0 else "Unknown")
+        print(f"{name:<10} | {n:<3} | {elap:.4f} | {curr_jit:<3} | {stat}")
+        prev_jit = curr_jit
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Add `benchmarks/scout_jit_compile_counter.py` to measure JAX JIT compilation overhead and detect redundant recompilations.

Command to run:
`PYTHONPATH=src python3 benchmarks/scout_jit_compile_counter.py`

What it measures:
- Execution time of `simulator.execute` with `use_jit=True`.
- JIT compilation count via `JitMonitor` (reveals cache hits/misses).

How to interpret:
- First run triggers JIT (slow, count increases).
- Second run with same args should hit cache (fast, count stable).
- Changed args (e.g. num_steps) trigger recompile (slow, count increases).

---
*PR created automatically by Jules for task [1212814837380144147](https://jules.google.com/task/1212814837380144147) started by @bardhh*