### PR TITLE
🧹 Curator: Make scipy an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "jax>=0.4.23",
     "jaxopt>=0.8.3,<0.9",
-    "scipy>=1.9,<2.0",
     "rich>=13.0,<15.0"
 ]
 
@@ -42,6 +41,9 @@ casadi = [
 vis = [
     "matplotlib>=3.8.2,<4.0",
 ]
+scipy = [
+    "scipy>=1.9,<2.0",
+]
 codegen = [
     "black>=23.12.1,<24.0",
     "jinja2>=3.0.0",
@@ -52,7 +54,7 @@ test = [
     "python-dotenv>=1.2.1",
 ]
 dev = [
-    "cbfkit[vis,codegen,test,casadi,cvxopt]",
+    "cbfkit[vis,codegen,test,casadi,cvxopt,scipy]",
     "black>=23.12.1,<24.0",
     "mypy>=1.8.0,<2.0",
     "jupyter>=1.0.0,<2.0",

--- a/src/cbfkit/integration/solve_ivp.py
+++ b/src/cbfkit/integration/solve_ivp.py
@@ -48,7 +48,13 @@ def solve_ivp(x: Array, vector_field: Callable[[Array], Array], dt: float) -> Ar
     -------
         new_state
     """
-    from scipy.integrate import solve_ivp as solve
+    try:
+        from scipy.integrate import solve_ivp as solve
+    except ImportError as e:
+        raise ImportError(
+            "To use 'solve_ivp', please install the 'scipy' extra: "
+            "pip install 'cbfkit[scipy]'"
+        ) from e
 
     # Wrap the vector field for scipy (which expects f(t, y) and uses numpy arrays)
     def fun(t, y):

--- a/src/cbfkit/utils/lqr.py
+++ b/src/cbfkit/utils/lqr.py
@@ -23,7 +23,13 @@ def compute_lqr_gain(A: Array, B: Array, Q: Array, R: Array) -> Array:
     -------
         Array: Gain matrix K
     """
-    from scipy.linalg import solve_continuous_are
+    try:
+        from scipy.linalg import solve_continuous_are
+    except ImportError as e:
+        raise ImportError(
+            "To use 'compute_lqr_gain', please install the 'scipy' extra: "
+            "pip install 'cbfkit[scipy]'"
+        ) from e
 
     # Convert JAX arrays to NumPy arrays for SciPy
     A_np = np.array(A)

--- a/uv.lock
+++ b/uv.lock
@@ -217,7 +217,6 @@ dependencies = [
     { name = "jax" },
     { name = "jaxopt" },
     { name = "rich" },
-    { name = "scipy" },
 ]
 
 [package.optional-dependencies]
@@ -245,6 +244,10 @@ dev = [
     { name = "pytest-cov" },
     { name = "python-dotenv" },
     { name = "ruff" },
+    { name = "scipy" },
+]
+scipy = [
+    { name = "scipy" },
 ]
 test = [
     { name = "pytest" },
@@ -260,7 +263,7 @@ requires-dist = [
     { name = "black", marker = "extra == 'codegen'", specifier = ">=23.12.1,<24.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.12.1,<24.0" },
     { name = "casadi", marker = "extra == 'casadi'", specifier = ">=3.6.4,<4.0" },
-    { name = "cbfkit", extras = ["casadi", "codegen", "cvxopt", "test", "vis"], marker = "extra == 'dev'" },
+    { name = "cbfkit", extras = ["casadi", "codegen", "cvxopt", "scipy", "test", "vis"], marker = "extra == 'dev'" },
     { name = "cvxopt", marker = "platform_machine != 'aarch64' and platform_machine != 'arm64' and extra == 'cvxopt'", specifier = ">=1.3.2,<2.0" },
     { name = "jax", specifier = ">=0.4.23" },
     { name = "jaxopt", specifier = ">=0.8.3,<0.9" },
@@ -274,9 +277,9 @@ requires-dist = [
     { name = "python-dotenv", marker = "extra == 'test'", specifier = ">=1.2.1" },
     { name = "rich", specifier = ">=13.0,<15.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.4" },
-    { name = "scipy", specifier = ">=1.9,<2.0" },
+    { name = "scipy", marker = "extra == 'scipy'", specifier = ">=1.9,<2.0" },
 ]
-provides-extras = ["cvxopt", "casadi", "vis", "codegen", "test", "dev"]
+provides-extras = ["cvxopt", "casadi", "vis", "scipy", "codegen", "test", "dev"]
 
 [[package]]
 name = "certifi"


### PR DESCRIPTION
🧹 Curator: Make scipy an optional dependency

- Moved `scipy` to `project.optional-dependencies` in `pyproject.toml`.
- Added `scipy` to `dev` extra.
- Updated `src/cbfkit/utils/lqr.py` and `src/cbfkit/integration/solve_ivp.py` to lazily import `scipy` inside functions and raise a descriptive `ImportError` if missing, instructing the user to install `cbfkit[scipy]`.
- Verified that `cbfkit` core imports without `scipy` (if simulated) and that accessing these functions raises the expected errors.
- Verified existing tests pass.


---
*PR created automatically by Jules for task [13003190383562150567](https://jules.google.com/task/13003190383562150567) started by @bardhh*