### PR TITLE
📝 Scribe: Make quickstart tutorial runnable without optional dependencies

### DIFF
--- a/tutorials/unicycle_reach_avoid.py
+++ b/tutorials/unicycle_reach_avoid.py
@@ -1,8 +1,14 @@
 import os
 import jax.numpy as jnp
 from jax import jit
-import matplotlib.pyplot as plt
-import matplotlib.patches as patches
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib.patches as patches
+
+    PLOT_AVAILABLE = True
+except ImportError:
+    PLOT_AVAILABLE = False
+    print("Matplotlib not found. Plotting disabled. Install 'cbfkit[vis]' to enable plotting.")
 
 from cbfkit.certificates import concatenate_certificates, rectify_relative_degree
 from cbfkit.certificates.conditions.barrier_conditions.zeroing_barriers import linear_class_k
@@ -124,26 +130,31 @@ x_sim, u_sim, z_sim, p_sim, controller_keys, controller_values, planner_keys, pl
 )
 
 # Plotting
-fig, ax = plt.subplots()
-circle1 = patches.Circle((0.9, 1.0), radius=0.5, edgecolor="r", facecolor="k")
-ax.add_patch(circle1)
-ax.plot(x_sim[:, 0], x_sim[:, 1])
-ax.set_aspect("equal")
-plt.title("Unicycle Reach-Avoid with CBF")
-plt.xlabel("X Position")
-plt.ylabel("Y Position")
-plt.savefig("trajectory_plot.png")
+if PLOT_AVAILABLE:
+    fig, ax = plt.subplots()
+    circle1 = patches.Circle((0.9, 1.0), radius=0.5, edgecolor="r", facecolor="k")
+    ax.add_patch(circle1)
+    ax.plot(x_sim[:, 0], x_sim[:, 1])
+    ax.set_aspect("equal")
+    plt.title("Unicycle Reach-Avoid with CBF")
+    plt.xlabel("X Position")
+    plt.ylabel("Y Position")
+    plt.savefig("trajectory_plot.png")
 
-if not os.getenv("CBFKIT_TEST_MODE"):
-    plt.show()
+    if not os.getenv("CBFKIT_TEST_MODE"):
+        plt.show()
 
-plt.figure()
-plt.plot(jnp.linspace(0.0, dt * len(u_sim[:, 0]), len(u_sim[:, 0])), u_sim[:, 0], label="Accel")
-plt.plot(jnp.linspace(0.0, dt * len(u_sim[:, 1]), len(u_sim[:, 1])), u_sim[:, 1], label="Omega")
-plt.legend()
-plt.title("Control Inputs")
-plt.xlabel("Time (s)")
-plt.ylabel("Control")
+    plt.figure()
+    plt.plot(
+        jnp.linspace(0.0, dt * len(u_sim[:, 0]), len(u_sim[:, 0])), u_sim[:, 0], label="Accel"
+    )
+    plt.plot(
+        jnp.linspace(0.0, dt * len(u_sim[:, 1]), len(u_sim[:, 1])), u_sim[:, 1], label="Omega"
+    )
+    plt.legend()
+    plt.title("Control Inputs")
+    plt.xlabel("Time (s)")
+    plt.ylabel("Control")
 
-if not os.getenv("CBFKIT_TEST_MODE"):
-    plt.show()
+    if not os.getenv("CBFKIT_TEST_MODE"):
+        plt.show()


### PR DESCRIPTION
Updated `tutorials/unicycle_reach_avoid.py` to handle cases where `matplotlib` is not installed. This allows the tutorial to serve as a runnable "quickstart" even with a minimal installation (`pip install .`), fulfilling the documentation's implication that it runs without additional dependencies. The simulation runs, and plotting is gracefully skipped with a warning if `cbfkit[vis]` is not present.

---
*PR created automatically by Jules for task [14931777789465579988](https://jules.google.com/task/14931777789465579988) started by @bardhh*