### PR TITLE
🔧 Forge: Fix risky uv configuration and improve project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
 cbfkit-bench = "cbfkit.cli.bench:main"
 [project.urls]
 Repository = "https://github.com/bardhh/cbfkit"
+Documentation = "https://github.com/bardhh/cbfkit#readme"
+Issues = "https://github.com/bardhh/cbfkit/issues"
 
 [project.optional-dependencies]
 cvxopt = [
@@ -88,6 +90,3 @@ ignore = ["D", "D104", "D401", "F401", "E402", "D205", "D209","E501"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
-
-[tool.uv.pip]
-system = true


### PR DESCRIPTION
`pyproject.toml` contained `[tool.uv.pip] system = true`, which forces `uv` to install packages system-wide by default. This is dangerous for local development and has been removed. Docker builds already use `--system` explicitly, so this change is safe.

Additionally, `Documentation` and `Issues` URLs were added to `[project.urls]` to improve the package's PyPI listing and user experience.

Verification:
- `pip install .` works.
- `python -m build` works.
- `cbfkit` imports correctly.

---
*PR created automatically by Jules for task [10077536053575753298](https://jules.google.com/task/10077536053575753298) started by @bardhh*