### PR TITLE
Sentinel: Enable integration error reporting for uncontrolled JIT simulations

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -502,6 +502,11 @@ def execute(
             u_nom_dummy = jnp.zeros((g_dummy.shape[1],))
             _, c_data = controller(0.0, x0, u_nom_dummy, prime_key3, c_data)  # type: ignore
 
+        # Sentinel: Ensure error_data is initialized to enable NaN reporting in JIT loop.
+        # If controller is None, the loop propagates this structure, allowing us to report errors.
+        if controller is None and c_data.error_data is None:
+            c_data = c_data._replace(error_data=jnp.array(-99, dtype=jnp.int32))
+
         if verbose:
             if progress_bar is not None:
                 print_jit_status(

--- a/tests/test_simulation/test_jit_error_reporting.py
+++ b/tests/test_simulation/test_jit_error_reporting.py
@@ -1,0 +1,50 @@
+
+import jax.numpy as jnp
+import pytest
+from cbfkit.simulation import simulator
+from cbfkit.simulation.simulator import SOLVER_STATUS_MAP
+
+def nan_dynamics(x):
+    # Returns NaNs immediately
+    return jnp.full_like(x, jnp.nan), jnp.zeros((x.shape[0], 1))
+
+def integrator(x, f, dt):
+    return x + dt * f(x)
+
+def test_jit_uncontrolled_nan_reporting():
+    """
+    Verifies that running an uncontrolled simulation (controller=None)
+    with JIT enabled correctly reports INTEGRATION_NAN_ERROR (-10)
+    when NaNs occur, instead of failing silently or with missing status.
+    """
+    x0 = jnp.array([1.0, 2.0])
+    dt = 0.01
+    num_steps = 10
+
+    # Run with JIT, no controller
+    results = simulator.execute(
+        x0=x0,
+        dt=dt,
+        num_steps=num_steps,
+        dynamics=nan_dynamics,
+        integrator=integrator,
+        use_jit=True,
+        verbose=False
+    )
+
+    # Check that error_data is present
+    assert "error_data" in results.controller_data, "error_data missing from results"
+
+    err_data = results.controller_data["error_data"]
+
+    # Check that we caught the specific error code (-10)
+    # The simulation should stop at step 0, filling the rest with -10 or previous value
+    # Since it fails immediately, we expect -10.
+    assert jnp.any(err_data == -10), f"Expected status -10, got {err_data}"
+
+    # Check that error flag is set
+    assert "error" in results.controller_data
+    assert jnp.any(results.controller_data["error"])
+
+if __name__ == "__main__":
+    test_jit_uncontrolled_nan_reporting()


### PR DESCRIPTION
Sentinel: Enable integration error reporting for uncontrolled JIT simulations

Previously, when running uncontrolled simulations (`controller=None`) using the JIT compiler (`use_jit=True`), the `ControllerData` structure's `error_data` field was initialized to `None` by default. This caused JAX's `lax.scan` loop to infer a `None` type for this field in the carry state, effectively closing the channel for reporting dynamic errors.

Consequently, if NaNs occurred during integration (e.g., due to unstable dynamics or singularity), the simulator would detect them and stop execution, but it could not write the `INTEGRATION_NAN_ERROR` (-10) status code. This resulted in a silent or confusing failure where the simulation stopped early with "NO_STATUS_AVAILABLE" (-99) or simply no error message.

This patch modifies `simulator.execute` to explicitly initialize `error_data` to a placeholder array (status -99) when no controller is present. This ensures that the JIT-compiled loop has a valid slot to write error codes into, making failure modes explicit and actionable.

Added `tests/test_simulation/test_jit_error_reporting.py` to verify the fix.

---
*PR created automatically by Jules for task [16499669262093287158](https://jules.google.com/task/16499669262093287158) started by @bardhh*