### PR TITLE
🧾 Piper: Introduce MppiParameters TypedDict for type-safe MPPI config

### DIFF
--- a/src/cbfkit/controllers/mppi/mppi_generator.py
+++ b/src/cbfkit/controllers/mppi/mppi_generator.py
@@ -47,6 +47,7 @@ from cbfkit.utils.user_types import (
     DynamicsCallable,
     Key,
     MppiGenerator,
+    MppiParameters,
     PlannerCallable,
     PlannerCallableReturns,
     PlannerData,
@@ -76,7 +77,7 @@ def mppi_generator() -> MppiGenerator:
         stage_cost: Optional[StageCostCallable] = None,
         terminal_cost: Optional[TerminalCostCallable] = None,
         trajectory_cost: Optional[TrajectoryCostCallable] = None,
-        mppi_args: Any = None,
+        mppi_args: Optional[MppiParameters] = None,
         **kwargs: Dict[str, Any],
     ) -> PlannerCallable:
         """Produces the function to deploy a MPPI control law.
@@ -95,6 +96,10 @@ def mppi_generator() -> MppiGenerator:
         """
         complete = False
         n_con = len(control_limits)
+
+        # Cast mppi_args to MppiParameters to avoid mypy errors, as the code assumes it is not None.
+        # This preserves the original runtime behavior (crashing if None is passed) while enforcing types.
+        mppi_args = cast(MppiParameters, mppi_args)
 
         mppi = setup_mppi(
             dyn_func=dynamics_func,

--- a/src/cbfkit/utils/user_types.py
+++ b/src/cbfkit/utils/user_types.py
@@ -473,6 +473,32 @@ GenerateComputeTerminalCostCallable = Callable[
 ]
 
 
+class MppiParameters(TypedDict, total=False):
+    """Parameters for MPPI controller configuration.
+
+    Attributes:
+        robot_state_dim (int): Dimensionality of the robot state.
+        robot_control_dim (int): Dimensionality of the robot control input.
+        prediction_horizon (int): Number of time steps in the prediction horizon.
+        num_samples (int): Number of trajectory samples.
+        time_step (float): Time step duration (seconds).
+        use_GPU (bool): Whether to use GPU for computations.
+        costs_lambda (float): Lambda parameter for cost weighting.
+        cost_perturbation (float): Coefficient for cost perturbation.
+        plot_samples (int): Number of samples to plot (optional).
+    """
+
+    robot_state_dim: int
+    robot_control_dim: int
+    prediction_horizon: int
+    num_samples: int
+    time_step: float
+    use_GPU: bool
+    costs_lambda: float
+    cost_perturbation: float
+    plot_samples: int
+
+
 class MppiGenerator(Protocol):
     """Protocol for MPPI generator."""
 
@@ -483,7 +509,7 @@ class MppiGenerator(Protocol):
         stage_cost: Optional[StageCostCallable] = None,
         terminal_cost: Optional[TerminalCostCallable] = None,
         trajectory_cost: Optional[TrajectoryCostCallable] = None,
-        mppi_args: Any = None,
+        mppi_args: Optional[MppiParameters] = None,
         **kwargs: Any,
     ) -> PlannerCallable:
         """Call method."""


### PR DESCRIPTION
🧾 Piper: Introduce MppiParameters TypedDict for type-safe MPPI config

**Summary:**
Replaced `Any` with `MppiParameters` TypedDict for MPPI controller arguments, enabling better type checking and documentation of required configuration keys.

**Changes:**
- Added `MppiParameters` TypedDict to `src/cbfkit/utils/user_types.py`.
- Updated `MppiGenerator` Protocol and implementation to reference `MppiParameters`.
- Used `typing.cast` to enforce type safety in implementation without modifying runtime behavior.

**Verification:**
- Validated with `mypy src/cbfkit/controllers/mppi/mppi_generator.py`.
- Verified that `mypy` correctly identifies missing keys (by temporarily introducing a typo).


---
*PR created automatically by Jules for task [8785062303117122445](https://jules.google.com/task/8785062303117122445) started by @bardhh*