### PR TITLE
feat: Validate dynamics output shapes in simulator.execute

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -442,6 +442,38 @@ def execute(
     if key is None:
         key = random.PRNGKey(0)  # type: ignore
 
+    # Atlas: Validate dynamics output shapes to catch common (N, 1) vs (N,) errors early
+    try:
+        # Ensure x0 is a JAX array for this check
+        x0_arr = jnp.array(x0)
+        f_check, g_check = dynamics(x0_arr)
+
+        if f_check.ndim != 1:
+            msg = (
+                f"Dynamics function returned `f` with shape {f_check.shape}. "
+                "Expected 1D array (shape (n,)).\n"
+            )
+            if f_check.ndim == 2 and f_check.shape[1] == 1:
+                msg += (
+                    "It appears `f` is a column vector (n, 1). "
+                    "Please squeeze it to (n,) (e.g., using jnp.squeeze or .flatten())."
+                )
+            raise ValueError(msg)
+
+        if g_check.ndim != 2:
+            raise ValueError(
+                f"Dynamics function returned `g` with shape {g_check.shape}. "
+                "Expected 2D array (shape (n, m))."
+            )
+
+    except Exception as e:
+        # If dynamics evaluation fails completely (e.g. wrong x0 dimension), re-raise wrapped error
+        if isinstance(e, ValueError):
+            raise e
+        raise ValueError(
+            f"Failed to evaluate dynamics function on initial state: {e}"
+        ) from e
+
     # Ensure data structures are NamedTuples
     if controller_data is None:
         controller_data = ControllerData()

--- a/tests/test_simulation/test_dynamics_shape.py
+++ b/tests/test_simulation/test_dynamics_shape.py
@@ -1,0 +1,51 @@
+import pytest
+import jax.numpy as jnp
+from cbfkit.simulation import simulator
+from cbfkit.integration import forward_euler
+
+def test_dynamics_shape_validation():
+    """Verifies that simulator.execute catches incorrect dynamics output shapes."""
+
+    def bad_dynamics(x):
+        # Returns column vector (2, 1) instead of (2,)
+        f = jnp.array([[0.0], [0.0]])
+        g = jnp.array([[1.0], [1.0]])
+        return f, g
+
+    x0 = jnp.array([0.0, 0.0])
+    dt = 0.1
+    num_steps = 2
+
+    # Expect ValueError with specific message about column vector
+    with pytest.raises(ValueError, match="It appears `f` is a column vector"):
+        simulator.execute(
+            x0=x0,
+            dt=dt,
+            num_steps=num_steps,
+            dynamics=bad_dynamics,
+            integrator=forward_euler,
+            use_jit=True
+        )
+
+def test_dynamics_g_shape_validation():
+    """Verifies that simulator.execute catches incorrect G output shapes."""
+
+    def bad_dynamics_g(x):
+        f = jnp.array([0.0, 0.0])
+        # Returns 1D array instead of 2D
+        g = jnp.array([1.0, 1.0])
+        return f, g
+
+    x0 = jnp.array([0.0, 0.0])
+    dt = 0.1
+    num_steps = 2
+
+    with pytest.raises(ValueError, match="Expected 2D array"):
+        simulator.execute(
+            x0=x0,
+            dt=dt,
+            num_steps=num_steps,
+            dynamics=bad_dynamics_g,
+            integrator=forward_euler,
+            use_jit=True
+        )


### PR DESCRIPTION
This PR adds an explicit validation step at the beginning of `simulator.execute` to evaluate the dynamics function on the initial state `x0`. 
It checks the shapes of the returned drift vector `f` and control matrix `g`.
Specifically, it catches the common mistake where `f` is returned as a column vector `(N, 1)` instead of a 1D array `(N,)`, which causes silent broadcasting errors or obscure JAX errors downstream.

Changes:
- Modified `src/cbfkit/simulation/simulator.py` to add validation logic.
- Added `tests/test_simulation/test_dynamics_shape.py` covering the validation cases.

---
*PR created automatically by Jules for task [5526207503573118675](https://jules.google.com/task/5526207503573118675) started by @bardhh*