### PR TITLE
fix(tutorials): resolve timeouts and QP errors in mppi_stochastic_cbf_reach_avoid

### DIFF
--- a/tutorials/mppi_stochastic_cbf_reach_avoid.py
+++ b/tutorials/mppi_stochastic_cbf_reach_avoid.py
@@ -108,6 +108,7 @@ controller = cbf_controller(
     dynamics_func=unicycle_dynamics,
     barriers=barrier_packages,
     sigma=sigma,
+    relaxable_cbf=True,
 )
 
 
@@ -158,7 +159,7 @@ def terminal_cost(state_and_time: Array, action: Array) -> Array:
 mppi_args = {
     "robot_state_dim": 4,
     "robot_control_dim": 2,
-    "prediction_horizon": 80,  # 150,
+    "prediction_horizon": 80 if not os.getenv("CBFKIT_TEST_MODE") else 20,  # 150,
     "num_samples": 1000 if not os.getenv("CBFKIT_TEST_MODE") else 100,  # Reduced from 20000 to prevent memory issues with JIT data logging
     "plot_samples": 30,
     "time_step": dt * 2.0,


### PR DESCRIPTION
This PR fixes failures in `tutorials/mppi_stochastic_cbf_reach_avoid.py`.

Changes:
- Enable `relaxable_cbf=True` in the `stochastic_cbf_clf_qp_controller` to resolve `MAX_ITER_UNSOLVED` (Status 5) errors caused by numerical sensitivity and infeasibility in the QP solver.
- Reduce MPPI `prediction_horizon` to 20 when `CBFKIT_TEST_MODE` is enabled to prevent timeouts during CI verification (reducing execution time from >2m to <45s).

Verified that the tutorial passes with these changes.

---
*PR created automatically by Jules for task [15178470584372168990](https://jules.google.com/task/15178470584372168990) started by @bardhh*