### PR TITLE
chore: normalize __init__.py files across examples and tutorials

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,1 +1,1 @@
-# This file makes the examples directory a Python package
+"""CBFKit example applications."""

--- a/examples/adaptive_cvar_cbf/__init__.py
+++ b/examples/adaptive_cvar_cbf/__init__.py
@@ -1,0 +1,1 @@
+"""Adaptive CVaR-CBF examples."""

--- a/examples/differential_drive/human_aware_navigation/__init__.py
+++ b/examples/differential_drive/human_aware_navigation/__init__.py
@@ -1,0 +1,1 @@
+"""Human-aware navigation scenarios for differential drive robot."""

--- a/examples/differential_drive/obstacle_avoidance/__init__.py
+++ b/examples/differential_drive/obstacle_avoidance/__init__.py
@@ -1,0 +1,1 @@
+"""Obstacle avoidance scenarios for differential drive robot."""

--- a/examples/fixed_wing/__init__.py
+++ b/examples/fixed_wing/__init__.py
@@ -1,0 +1,1 @@
+"""Fixed-wing aircraft examples."""

--- a/examples/fixed_wing/common/__init__.py
+++ b/examples/fixed_wing/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common utilities and configurations for fixed-wing examples."""

--- a/examples/fixed_wing/reach_drop_point/__init__.py
+++ b/examples/fixed_wing/reach_drop_point/__init__.py
@@ -1,0 +1,1 @@
+"""Reach drop point scenario for fixed-wing aircraft."""

--- a/examples/fixed_wing/reach_drop_point/visualizations/__init__.py
+++ b/examples/fixed_wing/reach_drop_point/visualizations/__init__.py
@@ -1,0 +1,1 @@
+"""Visualization utilities for fixed-wing reach drop point example."""

--- a/examples/pedestrian/__init__.py
+++ b/examples/pedestrian/__init__.py
@@ -1,0 +1,1 @@
+"""Pedestrian navigation examples."""

--- a/examples/pedestrian/navigate_among_pedestrians/__init__.py
+++ b/examples/pedestrian/navigate_among_pedestrians/__init__.py
@@ -1,0 +1,1 @@
+"""Navigate among pedestrians scenarios."""

--- a/examples/single_integrator/__init__.py
+++ b/examples/single_integrator/__init__.py
@@ -1,0 +1,1 @@
+"""Single integrator examples."""

--- a/examples/single_integrator/reach_goal/__init__.py
+++ b/examples/single_integrator/reach_goal/__init__.py
@@ -1,0 +1,1 @@
+"""Reach goal scenario for single integrator."""

--- a/examples/single_integrator/visualizations/__init__.py
+++ b/examples/single_integrator/visualizations/__init__.py
@@ -1,0 +1,1 @@
+"""Visualization utilities for single integrator examples."""

--- a/examples/unicycle/__init__.py
+++ b/examples/unicycle/__init__.py
@@ -1,1 +1,1 @@
-# This file makes the unicycle directory a Python package
+"""Unicycle robot examples."""

--- a/examples/unicycle/reach_goal/__init__.py
+++ b/examples/unicycle/reach_goal/__init__.py
@@ -1,0 +1,1 @@
+"""Reach goal scenario for unicycle robot."""

--- a/examples/van_der_pol/__init__.py
+++ b/examples/van_der_pol/__init__.py
@@ -1,0 +1,1 @@
+"""Van der Pol oscillator examples."""

--- a/examples/van_der_pol/regulation/__init__.py
+++ b/examples/van_der_pol/regulation/__init__.py
@@ -1,0 +1,1 @@
+"""Regulation scenario for Van der Pol oscillator."""

--- a/examples/van_der_pol/visualizations/__init__.py
+++ b/examples/van_der_pol/visualizations/__init__.py
@@ -1,0 +1,1 @@
+"""Visualization utilities for Van der Pol examples."""

--- a/tutorials/__init__.py
+++ b/tutorials/__init__.py
@@ -1,0 +1,1 @@
+"""CBFKit tutorials and learning resources."""


### PR DESCRIPTION
Add missing __init__.py files for fixed_wing/ and van_der_pol/ packages. Standardize all __init__.py to use one-line docstrings instead of the previous mix of empty files, comments, and inconsistent formats.