### PR TITLE
feat: unified QP solver interface with runtime selection

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -33,8 +33,9 @@ import jax.debug as jdebug
 from jax import Array, jit, lax, tree_util
 
 from cbfkit.certificates import concatenate_certificates
-from cbfkit.optimization.quadratic_program.qp_solver_jaxopt import (
-    solve_with_details as solve_qp,
+from cbfkit.optimization.quadratic_program.solver_registry import (
+    QpSolution,
+    get_solver,
 )
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
@@ -50,6 +51,7 @@ from cbfkit.utils.user_types import (
     DynamicsCallable,
     GenerateComputeCertificateConstraintCallable,
     Key,
+    QpSolverCallable,
     State,
 )
 
@@ -144,6 +146,7 @@ def cbf_clf_qp_generator(
         lyapunovs: Optional[CertificateInput] = EMPTY_CERTIFICATE_COLLECTION,
         p_mat: Optional[Union[Array, None]] = None,
         *,
+        solver: Optional[QpSolverCallable] = None,
         relaxable_clf: bool = True,
         relaxable_cbf: bool = False,
         tunable_class_k: bool = False,
@@ -164,6 +167,9 @@ def cbf_clf_qp_generator(
             lyapunovs (CertificateInput): collection of lyapunov functions,
                 gradients, hessians, dV/dt,  conditions. Can be a single collection, a list of them, or a legacy tuple.
             p_mat (Optional[Union[Array, None]] = None): objective function matrix (quadratic term)
+            solver (Optional[QpSolverCallable]): QP solver callable from
+                ``get_solver()``.  Defaults to ``get_solver("jaxopt")`` when
+                ``None``.  Must be JIT-compatible (currently only jaxopt).
             relaxable_clf (bool): whether to treat CLF as a soft constraint (default: True).
             relaxable_cbf (bool): whether to treat CBF as a soft constraint (default: False).
             tunable_class_k (bool): whether to tune the Class K function parameter (default: False).
@@ -177,6 +183,20 @@ def cbf_clf_qp_generator(
         -------
             ControllerCallable: function for computing control input based on CBF-CLF-QP
         """
+        # Resolve solver — default to jaxopt
+        solve_qp: QpSolverCallable
+        if solver is not None:
+            if not getattr(solver, "jit_compatible", False):
+                solver_name = getattr(solver, "solver_name", "unknown")
+                raise ValueError(
+                    f"Solver {solver_name!r} is not JIT-compatible. "
+                    f"The CBF-CLF-QP controller is JIT-compiled and requires a "
+                    f"JIT-compatible solver. Use get_solver('jaxopt', ...) instead."
+                )
+            solve_qp = solver
+        else:
+            solve_qp = get_solver("jaxopt")
+
         # Update kwargs to ensure downstream functions see the configuration
         kwargs.update(
             {

--- a/src/cbfkit/optimization/mpc/quadratic_cost_linear_dynamics.py
+++ b/src/cbfkit/optimization/mpc/quadratic_cost_linear_dynamics.py
@@ -1,9 +1,12 @@
-from typing import Callable, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 
 import jax.numpy as jnp
 from jax import Array, jit
 
-from cbfkit.optimization.quadratic_program.qp_solver_jaxopt import solve as solve_qp
+from cbfkit.optimization.quadratic_program.solver_registry import get_solver
+from cbfkit.utils.user_types.callables import QpSolverCallable
+
+_DEFAULT_SOLVER = get_solver("jaxopt")
 
 
 def generate_mpc_solver_quadratic_cost_linear_dynamics(
@@ -13,10 +16,12 @@ def generate_mpc_solver_quadratic_cost_linear_dynamics(
     R: Array,
     Qn: Array,
     N: int,
+    solver: Optional[QpSolverCallable] = None,
 ) -> Callable:
     n = Qn.shape[0]
     m = B.shape[1]
     mpc_to_qp = generate_mpc_to_qp(A, B, Q, R, Qn, N)
+    solve_qp = solver if solver is not None else get_solver("jaxopt")
 
     @jit
     def solve(concatenated_x_xr: Array) -> Tuple[Array, Array]:
@@ -31,7 +36,8 @@ def generate_mpc_solver_quadratic_cost_linear_dynamics(
         """
         # Convert Discrete-Time, LTI MPC problem into QP and solve
         h_mat, f_vec, g_mat, h_vec, a_mat, b_vec = mpc_to_qp(concatenated_x_xr)
-        sol, status = solve_qp(h_mat, f_vec, g_mat, h_vec, a_mat, b_vec)
+        qp_result = solve_qp(h_mat, f_vec, g_mat, h_vec, a_mat, b_vec)
+        sol = qp_result.primal
 
         # if not status:
         #     raise ValueError("Infeasible MPC!")
@@ -216,8 +222,9 @@ def quadratic_mpc_solver(
     m = B.shape[1]
     # Convert Discrete-Time, LTI MPC problem into QP and solve
     H, f, A, b, G, h = mpc_to_qp(x0, xr, A, B, Q, R, QN, N)
-    sol, status = solve_qp(H, f, A, b, G, h)
-    if not status:
+    qp_result = _DEFAULT_SOLVER(H, f, A, b, G, h)
+    sol = qp_result.primal
+    if qp_result.status != 1:
         print("MPC Infeasible.")
 
     # Extract optimal state and control trajectories

--- a/src/cbfkit/optimization/quadratic_program/__init__.py
+++ b/src/cbfkit/optimization/quadratic_program/__init__.py
@@ -1,3 +1,4 @@
 from .qp_solver_jaxopt import solve
+from .solver_registry import QpSolution, get_solver, list_solvers
 
-__all__ = ["solve"]
+__all__ = ["QpSolution", "get_solver", "list_solvers", "solve"]

--- a/src/cbfkit/optimization/quadratic_program/qp_solver_casadi.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_casadi.py
@@ -2,7 +2,7 @@
 
 import contextlib
 import os
-from typing import Tuple, Union
+from typing import Any, Tuple, Union
 
 import jax.numpy as jnp
 import numpy as np
@@ -93,6 +93,28 @@ def solve(
         success = solver.stats()["success"]
 
     return success * jnp.array(solution["x"]).reshape((n,)), success
+
+
+def solve_with_details(
+    h_mat: Array,
+    f_vec: Array,
+    g_mat: Union[Array, None] = None,
+    h_vec: Union[Array, None] = None,
+    a_mat: Union[Array, None] = None,
+    b_vec: Union[Array, None] = None,
+    init_params: Any = None,
+):
+    """Solve a QP using CasADi/qpOASES, returning a unified :class:`QpSolution`.
+
+    ``init_params`` is accepted for interface compatibility but ignored
+    (CasADi does not support warm-starting).
+    """
+    from cbfkit.optimization.quadratic_program.solver_registry import QpSolution
+
+    primal, success = solve(h_mat, f_vec, g_mat, h_vec, a_mat, b_vec)
+    if not success:
+        primal = jnp.zeros(len(f_vec))
+    return QpSolution(primal=primal, status=1 if success else 0, params=None)
 
 
 if __name__ == "__main__":

--- a/src/cbfkit/optimization/quadratic_program/qp_solver_cvxopt.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_cvxopt.py
@@ -76,3 +76,23 @@ def solve(
             success = bool(np.all(np.array(g_mat) @ np.array(sol["x"]) - np.array(h_vec) <= 0))
 
     return jnp.array(sol["x"]).reshape((len(sol["x"]),)), success
+
+
+def solve_with_details(
+    h_mat: Array,
+    f_vec: Array,
+    g_mat: Union[Array, None] = None,
+    h_vec: Union[Array, None] = None,
+    a_mat: Union[Array, None] = None,
+    b_vec: Union[Array, None] = None,
+    init_params: Any = None,
+):
+    """Solve a QP using CVXOPT, returning a unified :class:`QpSolution`.
+
+    ``init_params`` is accepted for interface compatibility but ignored
+    (CVXOPT does not support warm-starting).
+    """
+    from cbfkit.optimization.quadratic_program.solver_registry import QpSolution
+
+    primal, success = solve(h_mat, f_vec, g_mat, h_vec, a_mat, b_vec)
+    return QpSolution(primal=primal, status=1 if success else 0, params=None)

--- a/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_jaxopt.py
@@ -37,7 +37,13 @@ EC_QP = EqualityConstrainedQP()
 
 
 class QpSolution(NamedTuple):
-    """Return type for QP solvers."""
+    """Return type for QP solvers.
+
+    .. deprecated::
+        Prefer :class:`~cbfkit.optimization.quadratic_program.solver_registry.QpSolution`
+        from ``get_solver()``.  This NamedTuple is kept for backward compatibility
+        with code that unpacks ``(primal, status, params)``.
+    """
 
     primal: Array
     status: int

--- a/src/cbfkit/optimization/quadratic_program/solver_registry.py
+++ b/src/cbfkit/optimization/quadratic_program/solver_registry.py
@@ -1,0 +1,200 @@
+"""Unified QP solver interface with runtime selection.
+
+Provides a common ``QpSolution`` return type and factory functions that wrap
+each backend (jaxopt, cvxopt, casadi) behind a single callable signature.
+
+Usage::
+
+    from cbfkit.optimization.quadratic_program import get_solver
+
+    solver = get_solver("jaxopt", max_iter=5000, tol=1e-5)
+    sol = solver(H, f, G, h)
+    print(sol.primal, sol.status)
+
+    # Or with warm-starting (jaxopt only):
+    sol2 = solver(H, f, G, h, init_params=sol.params)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+
+import jax.numpy as jnp
+from jax import Array
+
+from cbfkit.utils.user_types.callables import QpSolverCallable
+
+
+class QpSolution:
+    """Return type for all QP solvers.
+
+    Attributes:
+        primal: Solution vector.
+        status: Integer status code (1 = solved).
+        params: Solver-specific state for warm-starting.  ``None`` for
+            backends that do not support warm-starting.
+    """
+
+    __slots__ = ("primal", "status", "params")
+
+    def __init__(self, primal: Array, status: int, params: Any = None):
+        self.primal = primal
+        self.status = status
+        self.params = params
+
+    # Support tuple unpacking: primal, status, params = solution
+    def __iter__(self):
+        return iter((self.primal, self.status, self.params))
+
+    def __getitem__(self, idx):
+        return (self.primal, self.status, self.params)[idx]
+
+    def __repr__(self):
+        return f"QpSolution(primal={self.primal}, status={self.status})"
+
+
+# ---------------------------------------------------------------------------
+# Factory functions — each returns a QpSolverCallable
+# ---------------------------------------------------------------------------
+
+
+def jaxopt_solver(
+    max_iter: int = 10000,
+    tol: float = 1e-4,
+) -> QpSolverCallable:
+    """Create a JIT-compatible QP solver backed by jaxopt OSQP.
+
+    Args:
+        max_iter: Maximum OSQP iterations.
+        tol: Convergence tolerance.
+
+    Returns:
+        A ``QpSolverCallable`` that returns :class:`QpSolution` with
+        warm-start ``params``.
+    """
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning, module="jaxopt")
+        from jaxopt import OSQP
+
+    from cbfkit.utils.jit_monitor import JitMonitor
+
+    qp = OSQP(maxiter=max_iter, tol=tol)
+
+    def solve_with_details(
+        h_mat: Array,
+        f_vec: Array,
+        g_mat: Union[Array, None] = None,
+        h_vec: Union[Array, None] = None,
+        a_mat: Union[Array, None] = None,
+        b_vec: Union[Array, None] = None,
+        init_params: Optional[Any] = None,
+    ) -> QpSolution:
+        JitMonitor.increment("qp_solver_jaxopt.solve_with_details")
+
+        if f_vec.ndim != 1:
+            raise ValueError(
+                f"Linear cost 'f_vec' must be a 1D array of shape (n_vars,), "
+                f"but got {f_vec.shape}."
+            )
+        if h_mat.ndim != 2:
+            raise ValueError(
+                f"Quadratic cost 'h_mat' must be a 2D array of shape (n_vars, n_vars), "
+                f"but got {h_mat.shape}."
+            )
+
+        params_obj = (h_mat, 0.5 * f_vec)
+        params_eq = None if (a_mat is None or b_vec is None) else (a_mat, b_vec)
+        params_ineq = None if (g_mat is None or h_vec is None) else (g_mat, h_vec)
+
+        real_init_params = init_params
+        if isinstance(init_params, tuple) and len(init_params) == 2:
+            real_init_params = init_params[0]
+
+        sol, state = qp.run(
+            init_params=real_init_params,
+            params_obj=params_obj,
+            params_eq=params_eq,
+            params_ineq=params_ineq,
+        )
+
+        status = state.status
+        status = jnp.where(
+            (status == 0) & (state.iter_num >= max_iter),
+            5,  # MAX_ITER_UNSOLVED
+            status,
+        )
+
+        return QpSolution(primal=sol.primal, status=status, params=(sol, state))
+
+    solve_with_details.jit_compatible = True
+    solve_with_details.solver_name = "jaxopt"
+    return solve_with_details
+
+
+def cvxopt_solver() -> QpSolverCallable:
+    """Create a QP solver backed by CVXOPT.
+
+    Not JIT-compatible.  Warm-starting is not supported (``init_params``
+    is ignored and ``params`` is always ``None``).
+    """
+    from cbfkit.optimization.quadratic_program.qp_solver_cvxopt import (
+        solve_with_details,
+    )
+
+    solve_with_details.jit_compatible = False
+    solve_with_details.solver_name = "cvxopt"
+    return solve_with_details
+
+
+def casadi_solver() -> QpSolverCallable:
+    """Create a QP solver backed by CasADi / qpOASES.
+
+    Not JIT-compatible.  Warm-starting is not supported (``init_params``
+    is ignored and ``params`` is always ``None``).
+    """
+    from cbfkit.optimization.quadratic_program.qp_solver_casadi import (
+        solve_with_details,
+    )
+
+    solve_with_details.jit_compatible = False
+    solve_with_details.solver_name = "casadi"
+    return solve_with_details
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_SOLVER_FACTORIES = {
+    "jaxopt": jaxopt_solver,
+    "cvxopt": cvxopt_solver,
+    "casadi": casadi_solver,
+}
+
+
+def get_solver(name: str = "jaxopt", **kwargs) -> QpSolverCallable:
+    """Look up a QP solver by name and return a configured callable.
+
+    Args:
+        name: One of ``"jaxopt"``, ``"cvxopt"``, ``"casadi"``.
+        **kwargs: Forwarded to the solver factory (e.g. ``max_iter``,
+            ``tol`` for jaxopt).
+
+    Returns:
+        A callable with signature
+        ``(H, f, G, h, A, b, init_params) -> QpSolution``.
+
+    Raises:
+        KeyError: If *name* is not a registered solver.
+    """
+    if name not in _SOLVER_FACTORIES:
+        available = ", ".join(sorted(_SOLVER_FACTORIES))
+        raise KeyError(f"Unknown QP solver {name!r}. Available: {available}")
+    return _SOLVER_FACTORIES[name](**kwargs)
+
+
+def list_solvers() -> list[str]:
+    """Return the names of all registered QP solvers."""
+    return sorted(_SOLVER_FACTORIES)

--- a/src/cbfkit/utils/user_types/callables.py
+++ b/src/cbfkit/utils/user_types/callables.py
@@ -1,6 +1,18 @@
 """Callable type definitions and configuration types for CBFKit."""
 
-from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, TypeAlias, TypedDict, Union, TYPE_CHECKING
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    Tuple,
+    TypeAlias,
+    TypedDict,
+    Union,
+    TYPE_CHECKING,
+)
 
 from jax import Array
 
@@ -80,9 +92,14 @@ IntegratorCallable = Callable[[State, VectorFieldCallable, float], State]
 
 
 # QP Solver Callables
+#
+# The unified solver signature accepts an optional ``init_params`` for
+# warm-starting and returns a ``QpSolution`` (which supports tuple
+# unpacking as ``(primal, status, params)``).  Backends that do not
+# support warm-starting accept and ignore the argument.
 QpSolverCallable = Callable[
-    [Array, Array, Union[Array, None], Union[Array, None], Union[Array, None], Union[Array, None]],
-    Tuple[Array, Dict[str, Any]],
+    ...,
+    Any,  # QpSolution — typed as Any to avoid circular import
 ]
 
 

--- a/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_qp_solver_safety.py
@@ -1,10 +1,33 @@
-
 import unittest
-from unittest.mock import patch
-import jax.numpy as jnp
+from collections import namedtuple
+
 import jax
+import jax.numpy as jnp
+
 from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+from cbfkit.optimization.quadratic_program.solver_registry import QpSolution
 from cbfkit.utils.user_types import ControllerData, EMPTY_CERTIFICATE_COLLECTION
+
+
+MockState = namedtuple("MockState", ["iter_num"])
+
+
+def _mock_max_iter_solver(
+    h_mat, f_vec, g_mat=None, h_vec=None, a_mat=None, b_vec=None, init_params=None
+):
+    """Mock solver that always returns MAX_ITER_REACHED (status 2)."""
+    n_vars = f_vec.shape[0]
+    mock_state = MockState(iter_num=jnp.array(100))
+    return QpSolution(
+        primal=jnp.zeros(n_vars),
+        status=jnp.array(2, dtype=jnp.int32),
+        params=(None, mock_state),
+    )
+
+
+_mock_max_iter_solver.jit_compatible = True
+_mock_max_iter_solver.solver_name = "mock"
+
 
 class TestQPSolverSafety(unittest.TestCase):
     def test_max_iter_safety(self):
@@ -13,74 +36,46 @@ class TestQPSolverSafety(unittest.TestCase):
         The controller treats status 2 as failure (unsafe to use unconverged result),
         returning NaNs.
         """
-
-        # 1. Setup simple controller
         control_limits = jnp.array([10.0, 10.0])
 
         def dynamics(x):
             return jnp.zeros((2,)), jnp.eye(2)
 
-        # We need to construct the controller inside the test or use the pre-generated one.
-        # vanilla_cbf_clf_qp_controller is a generator function.
-        # It imports solve_qp from cbf_clf_qp_generator module.
+        # Pass the mock solver via the solver= parameter
+        controller = vanilla_cbf_clf_qp_controller(
+            control_limits=control_limits,
+            dynamics_func=dynamics,
+            barriers=EMPTY_CERTIFICATE_COLLECTION,
+            lyapunovs=EMPTY_CERTIFICATE_COLLECTION,
+            solver=_mock_max_iter_solver,
+        )
 
-        # 2. Define the mock solver
-        from collections import namedtuple
-        MockState = namedtuple("MockState", ["iter_num"])
+        t = 0.0
+        x = jnp.array([0.0, 0.0])
+        u_nom = jnp.array([1.0, 1.0])
+        key = jax.random.PRNGKey(0)
+        data = ControllerData(
+            error=False,
+            error_data=0,
+            complete=False,
+            sol=jnp.array([]),
+            u=jnp.zeros(2),
+            u_nom=jnp.zeros(2),
+            sub_data={},
+        )
 
-        def mock_solve(p_mat, q_vec, g_mat, h_vec, init_params=None):
-            # Return dummy solution (zeros), status 2 (MAX_ITER), and None params
-            # Solution size must match q_vec (which is n_controls + slacks)
-            n_vars = q_vec.shape[0]
-            # status=2 means MAX_ITER_REACHED
-            # Scout: Controller expects (sol, state) in params to extract iter_num
-            mock_state = MockState(iter_num=jnp.array(100))
-            return jnp.zeros((n_vars,)), jnp.array(2, dtype=jnp.int32), (None, mock_state)
+        u, new_data = controller(t, x, u_nom, key, data)
 
-        # 3. Patch solve_qp in the module where it is used
-        with patch('cbfkit.controllers.cbf_clf.cbf_clf_qp_generator.solve_qp', side_effect=mock_solve):
+        # Controller treats status 2 as failure — u should be NaNs
+        self.assertTrue(
+            jnp.isnan(u).any(),
+            f"Controller returned valid output {u} for MAX_ITER status (should be NaNs)!",
+        )
+        self.assertTrue(new_data.error, "Controller failed to report error for status 2!")
+        self.assertEqual(
+            new_data.error_data, 2, f"Controller reported wrong status: {new_data.error_data}"
+        )
 
-            # Generate the controller *while patched* so it captures the mock?
-            # cbf_clf_qp_generator returns a function `generate_cbf_clf_controller`.
-            # That function returns `controller`.
-            # `controller` uses `solve_qp` from global scope.
-            # So patching the global in the module should work even if generator was imported earlier.
 
-            controller = vanilla_cbf_clf_qp_controller(
-                control_limits=control_limits,
-                dynamics_func=dynamics,
-                barriers=EMPTY_CERTIFICATE_COLLECTION,
-                lyapunovs=EMPTY_CERTIFICATE_COLLECTION
-            )
-
-            # 4. Run the controller
-            t = 0.0
-            x = jnp.array([0.0, 0.0])
-            u_nom = jnp.array([1.0, 1.0])
-            key = jax.random.PRNGKey(0)
-            data = ControllerData(
-                error=False,
-                error_data=0,
-                complete=False,
-                sol=jnp.array([]),
-                u=jnp.zeros(2),
-                u_nom=jnp.zeros(2),
-                sub_data={}
-            )
-
-            # JIT compilation happens here
-            u, new_data = controller(t, x, u_nom, key, data)
-
-            # 5. Assertions
-            # The controller treats status 2 as failure.
-            # u should be NaNs
-            self.assertTrue(jnp.isnan(u).any(), f"Controller returned valid output {u} for MAX_ITER status (should be NaNs)!")
-
-            # Error flag should be True (failure)
-            self.assertTrue(new_data.error, "Controller failed to report error for status 2!")
-
-            # Error data should capture the status code 2
-            self.assertEqual(new_data.error_data, 2, f"Controller reported wrong status: {new_data.error_data}")
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_optimization/test_solver_failure.py
+++ b/tests/test_optimization/test_solver_failure.py
@@ -1,13 +1,10 @@
-
-import pytest
 import jax.numpy as jnp
-from jax import random, jit
-from jaxopt import OSQP
+from jax import random
 
-# Import the module where solve_qp is used
-from cbfkit.controllers.cbf_clf import cbf_clf_qp_generator
 from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+from cbfkit.optimization.quadratic_program.solver_registry import get_solver
 from cbfkit.utils.user_types import ControllerData
+
 
 def test_max_iter_failure_returns_nan():
     """Test that MAX_ITER_REACHED (or other non-SOLVED status) results in NaN output.
@@ -17,78 +14,52 @@ def test_max_iter_failure_returns_nan():
     intermediate results.
     """
 
-    # 1. Setup a problem that requires iterations (feasible but non-trivial)
-    # Dynamics: x_dot = u.
-    # CLF: V = x^2. dot(V) <= -V. => 2xu <= -x^2.
-    # x=1. 2u <= -1 => u <= -0.5.
-    # u_nom = 10.0 (far from -0.5).
-    # This requires moving u significantly.
-
     def dynamics(x):
         return jnp.array([0.0]), jnp.array([[1.0]])
 
-    def V(t, x): return x[0]**2
-    def dVdx(t, x): return jnp.array([2*x[0]])
-    def d2Vdx2(t, x): return jnp.array([[2.0]])
-    def partial_t(t, x): return 0.0
-    def condition(val): return -1.0 * val  # dot(V) <= -V
+    def V(t, x):
+        return x[0] ** 2
+
+    def dVdx(t, x):
+        return jnp.array([2 * x[0]])
+
+    def d2Vdx2(t, x):
+        return jnp.array([[2.0]])
+
+    def partial_t(t, x):
+        return 0.0
+
+    def condition(val):
+        return -1.0 * val  # dot(V) <= -V
 
     lyapunovs = ([V], [dVdx], [d2Vdx2], [partial_t], [condition])
 
-    # 2. Define a patched solve_qp function that uses a crippled OSQP solver
-    # We define it here to ensure it's a fresh function object, forcing JAX to trace it.
-    @jit
-    def patched_solve_qp(h_mat, f_vec, g_mat=None, h_vec=None, a_mat=None, b_vec=None, init_params=None):
-        # Create a customized solver locally with maxiter=0 to force failure
-        qp = OSQP(maxiter=0, tol=1e-9)
+    # Use a crippled solver (maxiter=0) to force failure
+    crippled_solver = get_solver("jaxopt", max_iter=0, tol=1e-9)
 
-        params_obj = (h_mat, 0.5 * f_vec)
-        params_eq = None if (a_mat is None or b_vec is None) else (a_mat, b_vec)
-        params_ineq = None if (g_mat is None or h_vec is None) else (g_mat, h_vec)
+    controller = vanilla_cbf_clf_qp_controller(
+        control_limits=jnp.array([10.0]),
+        dynamics_func=dynamics,
+        lyapunovs=lyapunovs,
+        relaxable_clf=False,
+        solver=crippled_solver,
+    )
 
-        sol, state = qp.run(
-            init_params=init_params,
-            params_obj=params_obj,
-            params_eq=params_eq,
-            params_ineq=params_ineq,
-        )
-        return sol.primal, state.status, (sol, state)
+    x = jnp.array([1.0])
+    t = 0.0
+    key = random.PRNGKey(0)
+    data = ControllerData()
+    u_nom = jnp.array([10.0])
 
-    # 3. Patch the module's solve_qp
-    original_solve_qp = cbf_clf_qp_generator.solve_qp
-    cbf_clf_qp_generator.solve_qp = patched_solve_qp
+    u, data = controller(t, x, u_nom, key, data)
 
-    try:
-        # 4. Create controller with strict constraints (no relaxation)
-        # The generator will use our patched_solve_qp
-        controller = vanilla_cbf_clf_qp_controller(
-            control_limits=jnp.array([10.0]),
-            dynamics_func=dynamics,
-            lyapunovs=lyapunovs,
-            nominal_input=None,
-            relaxable_clf=False  # Crucial to force strict constraint solving
-        )
+    # Expect failure because maxiter=0 is insufficient
+    assert data.error, "Controller should report error on solver failure"
+    assert data.error_data != 1, f"Solver status should not be SOLVED (1), got {data.error_data}"
 
-        # 5. Run controller
-        x = jnp.array([1.0])
-        t = 0.0
-        key = random.PRNGKey(0)
-        data = ControllerData()
-        u_nom = jnp.array([10.0])
+    # Expect NaN return (Safety Invariant)
+    assert jnp.all(jnp.isnan(u)), f"Controller should return NaN on solver failure, got {u}"
 
-        u, data = controller(t, x, u_nom, key, data)
-
-        # 6. Assertions
-        # Expect failure because maxiter=0 is insufficient
-        assert data.error, "Controller should report error on solver failure"
-        assert data.error_data != 1, f"Solver status should not be SOLVED (1), got {data.error_data}"
-
-        # Expect NaN return (Safety Invariant)
-        assert jnp.all(jnp.isnan(u)), f"Controller should return NaN on solver failure, got {u}"
-
-    finally:
-        # Restore original solve_qp
-        cbf_clf_qp_generator.solve_qp = original_solve_qp
 
 if __name__ == "__main__":
     test_max_iter_failure_returns_nan()

--- a/tests/test_optimization/test_solver_registry.py
+++ b/tests/test_optimization/test_solver_registry.py
@@ -1,0 +1,170 @@
+"""Tests for the unified QP solver registry."""
+
+import pytest
+import jax.numpy as jnp
+
+from cbfkit.optimization.quadratic_program.solver_registry import (
+    QpSolution,
+    get_solver,
+    list_solvers,
+    jaxopt_solver,
+)
+
+
+# -- Shared test problem ------------------------------------------------
+
+
+def _feasible_problem():
+    """min ‖x‖²  s.t.  x >= -1  (solution: x = [0, 0])."""
+    H = 2.0 * jnp.eye(2)
+    f = jnp.zeros(2)
+    G = -jnp.eye(2)
+    h = jnp.ones(2)
+    return H, f, G, h
+
+
+def _feasible_problem_with_cost():
+    """min 0.5 x'Hx + 0.5 f'x  s.t.  x <= 3  (solution: x = [1, 2]).
+
+    The registry solver applies 0.5*f internally, so we pass f = -4*target
+    to get the intended minimizer.
+    """
+    H = 2.0 * jnp.eye(2)
+    f = -4.0 * jnp.array([1.0, 2.0])
+    G = jnp.eye(2)
+    h = 3.0 * jnp.ones(2)
+    return H, f, G, h
+
+
+# -- Registry tests ------------------------------------------------------
+
+
+class TestRegistry:
+    def test_list_solvers(self):
+        names = list_solvers()
+        assert "jaxopt" in names
+        assert "cvxopt" in names
+        assert "casadi" in names
+
+    def test_get_unknown_solver_raises(self):
+        with pytest.raises(KeyError, match="Unknown QP solver"):
+            get_solver("nonexistent")
+
+    def test_get_jaxopt_default(self):
+        solver = get_solver()
+        assert getattr(solver, "solver_name", None) == "jaxopt"
+        assert getattr(solver, "jit_compatible", False) is True
+
+    def test_get_jaxopt_custom_params(self):
+        solver = get_solver("jaxopt", max_iter=500, tol=1e-3)
+        assert getattr(solver, "solver_name", None) == "jaxopt"
+
+
+# -- QpSolution tests ----------------------------------------------------
+
+
+class TestQpSolution:
+    def test_tuple_unpacking(self):
+        sol = QpSolution(primal=jnp.array([1.0]), status=1, params=None)
+        primal, status, params = sol
+        assert float(primal[0]) == 1.0
+        assert status == 1
+        assert params is None
+
+    def test_indexing(self):
+        sol = QpSolution(primal=jnp.array([1.0]), status=1, params="state")
+        assert sol[0] is sol.primal
+        assert sol[1] == 1
+        assert sol[2] == "state"
+
+    def test_repr(self):
+        sol = QpSolution(primal=jnp.array([1.0]), status=1)
+        assert "QpSolution" in repr(sol)
+
+
+# -- Jaxopt solver tests --------------------------------------------------
+
+
+class TestJaxoptSolver:
+    def test_feasible(self):
+        solver = get_solver("jaxopt")
+        H, f, G, h = _feasible_problem()
+        sol = solver(H, f, G, h)
+        assert sol.status == 1
+        assert jnp.allclose(sol.primal, jnp.zeros(2), atol=1e-3)
+
+    def test_feasible_with_cost(self):
+        solver = get_solver("jaxopt")
+        H, f, G, h = _feasible_problem_with_cost()
+        sol = solver(H, f, G, h)
+        assert sol.status == 1
+        assert jnp.allclose(sol.primal, jnp.array([1.0, 2.0]), atol=1e-3)
+
+    def test_warm_start(self):
+        solver = get_solver("jaxopt")
+        H, f, G, h = _feasible_problem_with_cost()
+        sol1 = solver(H, f, G, h)
+        assert sol1.params is not None
+
+        sol2 = solver(H, f, G, h, init_params=sol1.params)
+        assert sol2.status == 1
+        assert jnp.allclose(sol1.primal, sol2.primal, atol=1e-3)
+
+    def test_custom_max_iter(self):
+        solver = jaxopt_solver(max_iter=100, tol=1e-4)
+        H, f, G, h = _feasible_problem()
+        sol = solver(H, f, G, h)
+        # Should still solve this simple problem
+        assert sol.status == 1
+
+    def test_jit_compatible_flag(self):
+        solver = get_solver("jaxopt")
+        assert solver.jit_compatible is True
+
+    def test_input_validation(self):
+        solver = get_solver("jaxopt")
+        with pytest.raises(ValueError, match="1D array"):
+            solver(jnp.eye(2), jnp.zeros((2, 1)))  # f_vec must be 1D
+
+    def test_equality_constraints(self):
+        solver = get_solver("jaxopt")
+        H = 2.0 * jnp.eye(2)
+        f = jnp.zeros(2)
+        # x1 + x2 = 1
+        A = jnp.array([[1.0, 1.0]])
+        b = jnp.array([1.0])
+        sol = solver(H, f, a_mat=A, b_vec=b)
+        assert sol.status == 1
+        assert jnp.allclose(sol.primal[0] + sol.primal[1], 1.0, atol=1e-3)
+
+
+# -- Backward compatibility -----------------------------------------------
+
+
+class TestBackwardCompatibility:
+    """Ensure existing direct imports still work."""
+
+    def test_legacy_solve_import(self):
+        from cbfkit.optimization.quadratic_program import solve
+
+        H, f, G, h = _feasible_problem()
+        x, success = solve(H, f, G, h)
+        assert success
+        assert jnp.allclose(x, jnp.zeros(2), atol=1e-3)
+
+    def test_legacy_solve_with_details_import(self):
+        from cbfkit.optimization.quadratic_program.qp_solver_jaxopt import (
+            solve_with_details,
+        )
+
+        H, f, G, h = _feasible_problem()
+        sol = solve_with_details(H, f, G, h)
+        # Legacy QpSolution is a NamedTuple — supports unpacking
+        primal, status, params = sol
+        assert status == 1
+
+    def test_qp_solution_from_init(self):
+        from cbfkit.optimization.quadratic_program import QpSolution as PubQpSolution
+
+        sol = PubQpSolution(primal=jnp.array([1.0]), status=1)
+        assert sol.status == 1


### PR DESCRIPTION
## Summary

- Adds a solver registry (`get_solver("jaxopt", max_iter=5000)`) that wraps jaxopt, cvxopt, and casadi behind a common `QpSolution` return type
- Threads a `solver=` parameter through `cbf_clf_qp_generator` and MPC solver for runtime solver selection
- Adds `solve_with_details()` to cvxopt and casadi backends for unified interface
- Validates JIT compatibility when non-JIT solvers are passed to the CBF-CLF-QP generator
- Updates tests to use solver injection instead of fragile module-level patching

## Usage

```python
from cbfkit.optimization.quadratic_program import get_solver

# Configure solver parameters at runtime
solver = get_solver("jaxopt", max_iter=5000, tol=1e-5)

# Pass to controller generator
controller = vanilla_cbf_clf_qp_controller(
    control_limits=limits,
    dynamics_func=dynamics,
    barriers=barriers,
    solver=solver,  # NEW
)
```

## Test plan

- [x] 17 new tests in `test_solver_registry.py` (registry, QpSolution, jaxopt solver, backward compat)
- [x] Full non-slow test suite passes (358 passed, 0 failed)
- [x] Existing direct imports (`from ...qp_solver_jaxopt import solve`) unchanged
- [x] Solver injection replaces module patching in `test_qp_solver_safety.py` and `test_solver_failure.py`