### PR TITLE
feat: neural CBF module for learning barrier functions from data

### DIFF
--- a/examples/neural_cbf/neural_cbf_obstacle_avoidance.py
+++ b/examples/neural_cbf/neural_cbf_obstacle_avoidance.py
@@ -1,0 +1,199 @@
+"""Neural CBF obstacle avoidance — single integrator.
+
+Demonstrates learning a barrier function from data and using it for
+safe control.  A 2D single integrator must reach a goal while avoiding
+a circular obstacle.  Instead of hand-crafting h(x) = ||x-c||^2 - r^2,
+we *learn* h(x) from samples of the safe and unsafe regions.
+
+Requirements::
+
+    pip install cbfkit[neural]   # adds flax + optax
+
+Run::
+
+    python examples/neural_cbf/neural_cbf_obstacle_avoidance.py
+"""
+
+import os
+import sys
+
+root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+if root_path not in sys.path:
+    sys.path.insert(0, root_path)
+
+os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
+
+import jax
+import jax.numpy as jnp
+from jax import random
+
+import cbfkit.simulation.simulator as sim
+from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+from cbfkit.integration import forward_euler as integrator
+from cbfkit.modeling.neural_cbf import train_neural_cbf
+from cbfkit.sensors import perfect as sensor
+from cbfkit.estimators import naive as estimator
+
+# ── Problem setup ──────────────────────────────────────────────────────
+
+STATE_DIM = 2
+OBSTACLE_CENTER = jnp.array([3.0, 3.0])
+OBSTACLE_RADIUS = 1.0
+GOAL = jnp.array([6.0, 6.0])
+DT = 0.05
+NUM_STEPS = 200 if not os.getenv("CBFKIT_TEST_MODE") else 20
+TRAIN_EPOCHS = 1000 if not os.getenv("CBFKIT_TEST_MODE") else 50
+
+
+def dynamics(x):
+    """Single integrator: xdot = u."""
+    return jnp.zeros(STATE_DIM), jnp.eye(STATE_DIM)
+
+
+def nominal_controller(t, x, *args, **kwargs):
+    """Proportional drive toward the goal."""
+    u = 2.0 * (GOAL - x)
+    return u, {}
+
+
+# ── Step 1: Generate training data ────────────────────────────────────
+
+
+def generate_samples(key, n_safe=500, n_unsafe=200):
+    """Sample points inside (unsafe) and outside (safe) the obstacle."""
+    k1, k2 = random.split(key)
+
+    # Safe: ring around obstacle [r+0.3, r+4.0]
+    angles = random.uniform(k1, (n_safe,), minval=0, maxval=2 * jnp.pi)
+    radii = random.uniform(
+        k1, (n_safe,), minval=OBSTACLE_RADIUS + 0.3, maxval=OBSTACLE_RADIUS + 4.0
+    )
+    safe = OBSTACLE_CENTER + jnp.stack([radii * jnp.cos(angles), radii * jnp.sin(angles)], axis=1)
+
+    # Unsafe: inside obstacle [0, r*0.9]
+    angles = random.uniform(k2, (n_unsafe,), minval=0, maxval=2 * jnp.pi)
+    radii = random.uniform(k2, (n_unsafe,), minval=0.0, maxval=OBSTACLE_RADIUS * 0.9)
+    unsafe = OBSTACLE_CENTER + jnp.stack([radii * jnp.cos(angles), radii * jnp.sin(angles)], axis=1)
+
+    return safe, unsafe
+
+
+# ── Step 2: Train the neural CBF ──────────────────────────────────────
+
+print("Generating training samples...")
+safe_samples, unsafe_samples = generate_samples(random.PRNGKey(42))
+print(f"  Safe: {safe_samples.shape[0]} points, Unsafe: {unsafe_samples.shape[0]} points")
+
+print("\nTraining neural CBF...")
+barriers = train_neural_cbf(
+    dynamics_func=dynamics,
+    safe_samples=safe_samples,
+    unsafe_samples=unsafe_samples,
+    state_dim=STATE_DIM,
+    alpha=1.0,
+    hidden_layers=[64, 64],
+    activation="tanh",
+    num_epochs=TRAIN_EPOCHS,
+    learning_rate=1e-3,
+    margin=0.1,
+    key=random.PRNGKey(0),
+    verbose=True,
+)
+print("Training complete. CertificateCollection ready.")
+
+# ── Step 3: Verify the learned barrier ────────────────────────────────
+
+h_func = barriers.functions[0]
+
+# Check: safe point should have h > 0
+safe_point = jnp.array([0.0, 0.0])
+h_safe = h_func(0.0, safe_point)
+print(f"\nh(safe_point={safe_point}) = {float(h_safe):.4f}  (should be > 0)")
+
+# Check: unsafe point (obstacle center) should have h < 0
+h_unsafe = h_func(0.0, OBSTACLE_CENTER)
+print(f"h(obstacle_center={OBSTACLE_CENTER}) = {float(h_unsafe):.4f}  (should be < 0)")
+
+# ── Step 4: Build controller and simulate ─────────────────────────────
+
+print("\nBuilding CBF-CLF-QP controller with learned barrier...")
+controller = vanilla_cbf_clf_qp_controller(
+    control_limits=jnp.array([5.0, 5.0]),
+    dynamics_func=dynamics,
+    barriers=barriers,
+)
+
+x0 = jnp.array([0.0, 0.0])
+
+print(f"Simulating: x0={x0}, goal={GOAL}, obstacle=({OBSTACLE_CENTER}, r={OBSTACLE_RADIUS})")
+print(f"  dt={DT}, steps={NUM_STEPS}")
+
+results = sim.execute(
+    x0=x0,
+    dt=DT,
+    num_steps=NUM_STEPS,
+    dynamics=dynamics,
+    integrator=integrator,
+    nominal_controller=nominal_controller,
+    controller=controller,
+    sensor=sensor,
+    estimator=estimator,
+)
+
+states = results["states"]
+
+# ── Step 5: Check results ─────────────────────────────────────────────
+
+final_state = states[-1]
+final_dist_goal = float(jnp.linalg.norm(final_state - GOAL))
+min_dist_obstacle = float(jnp.min(jnp.linalg.norm(states - OBSTACLE_CENTER, axis=1)))
+
+print(f"\nResults:")
+print(f"  Final state: [{float(final_state[0]):.2f}, {float(final_state[1]):.2f}]")
+print(f"  Distance to goal: {final_dist_goal:.2f}")
+print(f"  Min distance to obstacle center: {min_dist_obstacle:.2f} (radius={OBSTACLE_RADIUS})")
+
+if min_dist_obstacle > OBSTACLE_RADIUS:
+    print("  SAFE: Robot avoided the obstacle!")
+else:
+    print("  VIOLATION: Robot entered the obstacle region.")
+
+if final_dist_goal < 1.0:
+    print("  REACHED: Robot is near the goal.")
+else:
+    print("  NOT REACHED: Robot did not reach the goal (may need more steps).")
+
+# Optional: plot if matplotlib is available
+try:
+    if not os.getenv("CBFKIT_TEST_MODE"):
+        import matplotlib.pyplot as plt
+
+        fig, ax = plt.subplots(1, 1, figsize=(6, 6))
+        ax.plot(states[:, 0], states[:, 1], "b-", linewidth=1.5, label="Trajectory")
+        ax.plot(x0[0], x0[1], "go", markersize=10, label="Start")
+        ax.plot(GOAL[0], GOAL[1], "r*", markersize=15, label="Goal")
+
+        theta = jnp.linspace(0, 2 * jnp.pi, 100)
+        ax.fill(
+            OBSTACLE_CENTER[0] + OBSTACLE_RADIUS * jnp.cos(theta),
+            OBSTACLE_CENTER[1] + OBSTACLE_RADIUS * jnp.sin(theta),
+            alpha=0.3,
+            color="red",
+            label="Obstacle",
+        )
+
+        ax.set_xlabel("x")
+        ax.set_ylabel("y")
+        ax.set_title("Neural CBF Obstacle Avoidance")
+        ax.legend()
+        ax.set_aspect("equal")
+        ax.grid(True, alpha=0.3)
+        plt.tight_layout()
+        plt.savefig(
+            os.path.join(os.path.dirname(__file__), "neural_cbf_trajectory.png"),
+            dpi=150,
+        )
+        print("\nPlot saved to examples/neural_cbf/neural_cbf_trajectory.png")
+        plt.show()
+except ImportError:
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ manim = [
 optuna = [
     "optuna>=3.0",
 ]
+neural = [
+    "flax>=0.8",
+    "optax>=0.2",
+]
 dev = [
     "pytest>=8.0.2",
     "pytest-cov",

--- a/src/cbfkit/modeling/neural_cbf/__init__.py
+++ b/src/cbfkit/modeling/neural_cbf/__init__.py
@@ -1,0 +1,19 @@
+"""Neural Control Barrier Functions for CBFKit.
+
+Learn barrier functions from data using JAX neural networks, producing
+``CertificateCollection`` objects that integrate directly with the
+CBF-CLF-QP controller pipeline.
+
+Requires the ``neural`` extra: ``pip install cbfkit[neural]``
+"""
+
+from .model import CBFNetwork, create_neural_cbf, make_cbf_callable
+from .training import cbf_loss, train_neural_cbf
+
+__all__ = [
+    "CBFNetwork",
+    "cbf_loss",
+    "create_neural_cbf",
+    "make_cbf_callable",
+    "train_neural_cbf",
+]

--- a/src/cbfkit/modeling/neural_cbf/model.py
+++ b/src/cbfkit/modeling/neural_cbf/model.py
@@ -1,0 +1,105 @@
+"""Neural Control Barrier Function model.
+
+Provides a Flax-based MLP that maps state to a scalar barrier value,
+and a factory function that produces a frozen callable compatible with
+the CBFKit certificate pipeline.
+
+Usage::
+
+    from cbfkit.modeling.neural_cbf import create_neural_cbf
+
+    params, h_func = create_neural_cbf(
+        state_dim=2,
+        hidden_layers=[64, 64],
+        key=jax.random.PRNGKey(0),
+    )
+    # h_func(x) -> scalar, compatible with generate_certificate
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence, Tuple
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+try:
+    import flax.linen as nn
+except ImportError:
+    raise ImportError(
+        "Flax is required for neural CBFs. " "Install it with: pip install cbfkit[neural]"
+    )
+
+
+class CBFNetwork(nn.Module):
+    """MLP that maps state to a scalar barrier value.
+
+    The final layer has no activation, producing an unconstrained scalar.
+    Hidden layers use ``tanh`` by default (smooth, so ``jax.grad`` and
+    ``jax.hessian`` produce well-behaved derivatives).
+    """
+
+    hidden_dims: Sequence[int] = (64, 64)
+    activation: str = "tanh"
+
+    @nn.compact
+    def __call__(self, x: Array) -> Array:
+        act_fn = _get_activation(self.activation)
+        for dim in self.hidden_dims:
+            x = nn.Dense(dim)(x)
+            x = act_fn(x)
+        x = nn.Dense(1)(x)
+        return x.squeeze(-1)  # scalar output
+
+
+def _get_activation(name: str):
+    activations = {
+        "tanh": nn.tanh,
+        "softplus": nn.softplus,
+        "sigmoid": nn.sigmoid,
+        "swish": nn.swish,
+    }
+    if name not in activations:
+        available = ", ".join(sorted(activations))
+        raise ValueError(f"Unknown activation {name!r}. Available: {available}")
+    return activations[name]
+
+
+def create_neural_cbf(
+    state_dim: int,
+    hidden_layers: Sequence[int] = (64, 64),
+    activation: str = "tanh",
+    key: Optional[Array] = None,
+) -> Tuple[dict, Callable[[Array], Array]]:
+    """Create a neural CBF model and return frozen parameters + callable.
+
+    Args:
+        state_dim: Dimension of the state vector.
+        hidden_layers: Hidden layer sizes for the MLP.
+        activation: Activation function name (tanh, softplus, sigmoid, swish).
+        key: JAX PRNG key for parameter initialization.
+
+    Returns:
+        Tuple of ``(params, h_func)`` where ``h_func(x) -> scalar``
+        is a pure JAX function compatible with
+        ``generate_certificate(h_func, conditions, input_style="state")``.
+    """
+    if key is None:
+        key = jax.random.PRNGKey(0)
+
+    model = CBFNetwork(hidden_dims=tuple(hidden_layers), activation=activation)
+    params = model.init(key, jnp.zeros(state_dim))
+    return params, make_cbf_callable(model, params)
+
+
+def make_cbf_callable(model: CBFNetwork, params: dict) -> Callable[[Array], Array]:
+    """Bind trained parameters to a model, returning ``h(x) -> scalar``.
+
+    Use this after training to create a fresh callable from updated params.
+    """
+
+    def h_func(x: Array) -> Array:
+        return model.apply(params, x)
+
+    return h_func

--- a/src/cbfkit/modeling/neural_cbf/training.py
+++ b/src/cbfkit/modeling/neural_cbf/training.py
@@ -1,0 +1,198 @@
+"""Training utilities for neural Control Barrier Functions.
+
+Provides loss functions and a training loop that produces a
+``CertificateCollection`` ready for use with the CBF-CLF-QP controller.
+
+Usage::
+
+    from cbfkit.modeling.neural_cbf import train_neural_cbf
+
+    cert = train_neural_cbf(
+        dynamics_func=dynamics,
+        safe_samples=safe_pts,     # (N, state_dim) points in safe set
+        unsafe_samples=unsafe_pts, # (M, state_dim) points in unsafe set
+        state_dim=2,
+        alpha=1.0,
+    )
+    # cert is a CertificateCollection, drop-in for the QP generator
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence, Tuple
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+try:
+    import optax
+except ImportError:
+    raise ImportError(
+        "Optax is required for neural CBF training. " "Install it with: pip install cbfkit[neural]"
+    )
+
+from cbfkit.certificates.conditions.barrier_conditions.zeroing_barriers import (
+    linear_class_k,
+)
+from cbfkit.certificates.packager import generate_certificate
+from cbfkit.utils.user_types import CertificateCollection, DynamicsCallable
+
+from .model import CBFNetwork, make_cbf_callable
+
+
+def cbf_loss(
+    params: dict,
+    model: CBFNetwork,
+    safe_samples: Array,
+    unsafe_samples: Array,
+    dynamics_func: DynamicsCallable,
+    alpha: float = 1.0,
+    margin: float = 0.1,
+) -> Tuple[Array, dict]:
+    """Compute the CBF training loss.
+
+    The loss has four terms:
+
+    - **safe**: ``h(x) > margin`` for x in safe set (ReLU penalty)
+    - **unsafe**: ``h(x) < -margin`` for x in unsafe set (ReLU penalty)
+    - **descent**: ``nabla h . f(x) + alpha * h(x) >= 0`` for x in safe set
+      (CBF invariance condition, using only the drift term f)
+    - **norm**: Light L2 regularization on params
+
+    Args:
+        params: Flax model parameters.
+        model: CBFNetwork instance.
+        safe_samples: Points in the safe set, shape ``(N, state_dim)``.
+        unsafe_samples: Points in the unsafe set, shape ``(M, state_dim)``.
+        dynamics_func: System dynamics ``(x) -> (f, g)``.
+        alpha: Class-K function gain for the CBF condition.
+        margin: Desired separation from zero-level set.
+
+    Returns:
+        Tuple of ``(total_loss, loss_dict)`` where ``loss_dict`` has per-term values.
+    """
+
+    def h(x):
+        return model.apply(params, x)
+
+    # --- Safe set: h(x) > margin ---
+    h_safe = jax.vmap(h)(safe_samples)
+    loss_safe = jnp.mean(jax.nn.relu(margin - h_safe))
+
+    # --- Unsafe set: h(x) < -margin ---
+    h_unsafe = jax.vmap(h)(unsafe_samples)
+    loss_unsafe = jnp.mean(jax.nn.relu(h_unsafe + margin))
+
+    # --- CBF descent condition: dh/dx . f(x) + alpha * h(x) >= 0 ---
+    def descent_violation(x):
+        hx, gh = jax.value_and_grad(h)(x)
+        f, _g = dynamics_func(x)
+        lie_f = jnp.dot(gh, f)
+        return jax.nn.relu(-(lie_f + alpha * hx))
+
+    loss_descent = jnp.mean(jax.vmap(descent_violation)(safe_samples))
+
+    # --- L2 regularization ---
+    leaves = jax.tree_util.tree_leaves(params)
+    loss_reg = 1e-4 * sum(jnp.sum(p**2) for p in leaves)
+
+    total = loss_safe + loss_unsafe + loss_descent + loss_reg
+
+    return total, {
+        "safe": loss_safe,
+        "unsafe": loss_unsafe,
+        "descent": loss_descent,
+        "reg": loss_reg,
+        "total": total,
+    }
+
+
+def train_neural_cbf(
+    dynamics_func: DynamicsCallable,
+    safe_samples: Array,
+    unsafe_samples: Array,
+    state_dim: int,
+    alpha: float = 1.0,
+    hidden_layers: Sequence[int] = (64, 64),
+    activation: str = "tanh",
+    learning_rate: float = 1e-3,
+    num_epochs: int = 500,
+    margin: float = 0.1,
+    key: Optional[Array] = None,
+    verbose: bool = False,
+    certificate_conditions: Optional[Callable] = None,
+) -> CertificateCollection:
+    """Train a neural CBF and return a ready-to-use CertificateCollection.
+
+    Args:
+        dynamics_func: System dynamics ``(x) -> (f, g)``.
+        safe_samples: Points in the safe set, shape ``(N, state_dim)``.
+        unsafe_samples: Points in the unsafe set, shape ``(M, state_dim)``.
+        state_dim: Dimension of the state vector.
+        alpha: Class-K function gain.
+        hidden_layers: MLP hidden layer sizes.
+        activation: Activation function name.
+        learning_rate: Adam learning rate.
+        num_epochs: Number of training epochs.
+        margin: Desired separation from zero-level set.
+        key: JAX PRNG key for initialization.
+        verbose: Print loss every 100 epochs.
+        certificate_conditions: Class-K function for the certificate.
+            Defaults to ``linear_class_k(alpha)`` (linear zeroing CBF).
+            See also ``cubic_class_k`` in
+            ``cbfkit.certificates.conditions.barrier_conditions.zeroing_barriers``.
+
+    Returns:
+        A ``CertificateCollection`` with auto-diffed jacobian, hessian,
+        and partial, ready for use with the CBF-CLF-QP generator.
+    """
+    if key is None:
+        key = jax.random.PRNGKey(0)
+
+    safe_samples = jnp.asarray(safe_samples)
+    unsafe_samples = jnp.asarray(unsafe_samples)
+
+    # Initialize model and optimizer
+    model = CBFNetwork(hidden_dims=tuple(hidden_layers), activation=activation)
+    params = model.init(key, jnp.zeros(state_dim))
+    optimizer = optax.adam(learning_rate)
+    opt_state = optimizer.init(params)
+
+    # Training loop — samples passed as explicit args to avoid JIT retracing
+    # if called again with different-shaped data.
+    @jax.jit
+    def train_step(params, opt_state, safe, unsafe):
+        (loss, info), grads = jax.value_and_grad(cbf_loss, has_aux=True)(
+            params, model, safe, unsafe, dynamics_func, alpha, margin
+        )
+        updates, opt_state_new = optimizer.update(grads, opt_state, params)
+        params_new = optax.apply_updates(params, updates)
+        return params_new, opt_state_new, info
+
+    for epoch in range(num_epochs):
+        params, opt_state, info = train_step(params, opt_state, safe_samples, unsafe_samples)
+        if verbose and (epoch % 100 == 0 or epoch == num_epochs - 1):
+            print(
+                f"Epoch {epoch:4d} | "
+                f"total={float(info['total']):.4f} "
+                f"safe={float(info['safe']):.4f} "
+                f"unsafe={float(info['unsafe']):.4f} "
+                f"descent={float(info['descent']):.4f}"
+            )
+
+    # Build the frozen callable
+    h_func = make_cbf_callable(model, params)
+
+    # Default condition: linear class-K
+    if certificate_conditions is None:
+        certificate_conditions = linear_class_k(alpha)
+
+    # Use the existing pipeline to auto-diff and package
+    cert = generate_certificate(
+        certificate=h_func,
+        certificate_conditions=certificate_conditions,
+        input_style="state",
+    )
+
+    return cert

--- a/tests/test_modeling/test_neural_cbf.py
+++ b/tests/test_modeling/test_neural_cbf.py
@@ -1,0 +1,246 @@
+"""Tests for the neural CBF module."""
+
+import pytest
+import jax
+import jax.numpy as jnp
+from jax import random
+
+from cbfkit.modeling.neural_cbf.model import CBFNetwork, create_neural_cbf, make_cbf_callable
+from cbfkit.modeling.neural_cbf.training import cbf_loss, train_neural_cbf
+from cbfkit.utils.user_types import CertificateCollection
+
+
+# -- Simple 2D system: single integrator (xdot = u) -------------------------
+
+
+def _si_dynamics(x):
+    """Single integrator: f(x) = 0, g(x) = I."""
+    return jnp.zeros(2), jnp.eye(2)
+
+
+def _generate_samples(key, center, radius, n_safe=200, n_unsafe=100):
+    """Generate safe/unsafe samples around a circular obstacle.
+
+    Safe set: outside the obstacle (||x - center|| > radius)
+    Unsafe set: inside the obstacle (||x - center|| < radius)
+    """
+    k1, k2 = random.split(key)
+
+    # Safe: sample in a ring [radius+0.2, radius+2.0] around obstacle
+    angles_safe = random.uniform(k1, (n_safe,), minval=0, maxval=2 * jnp.pi)
+    radii_safe = random.uniform(k1, (n_safe,), minval=radius + 0.3, maxval=radius + 2.0)
+    safe = center + jnp.stack(
+        [radii_safe * jnp.cos(angles_safe), radii_safe * jnp.sin(angles_safe)], axis=1
+    )
+
+    # Unsafe: sample inside the obstacle
+    angles_unsafe = random.uniform(k2, (n_unsafe,), minval=0, maxval=2 * jnp.pi)
+    radii_unsafe = random.uniform(k2, (n_unsafe,), minval=0.0, maxval=radius * 0.8)
+    unsafe = center + jnp.stack(
+        [radii_unsafe * jnp.cos(angles_unsafe), radii_unsafe * jnp.sin(angles_unsafe)], axis=1
+    )
+
+    return safe, unsafe
+
+
+# -- Model tests --------------------------------------------------------------
+
+
+class TestCBFNetwork:
+    def test_forward_pass(self):
+        model = CBFNetwork(hidden_dims=(32, 32))
+        params = model.init(random.PRNGKey(0), jnp.zeros(2))
+        out = model.apply(params, jnp.array([1.0, 2.0]))
+        assert out.shape == ()  # scalar
+
+    def test_differentiable(self):
+        model = CBFNetwork(hidden_dims=(16,))
+        params = model.init(random.PRNGKey(0), jnp.zeros(2))
+
+        def h(x):
+            return model.apply(params, x)
+
+        x = jnp.array([1.0, 0.5])
+        grad = jax.grad(h)(x)
+        assert grad.shape == (2,)
+        assert not jnp.any(jnp.isnan(grad))
+
+    def test_hessian(self):
+        model = CBFNetwork(hidden_dims=(16,), activation="tanh")
+        params = model.init(random.PRNGKey(0), jnp.zeros(2))
+
+        def h(x):
+            return model.apply(params, x)
+
+        x = jnp.array([1.0, 0.5])
+        hess = jax.hessian(h)(x)
+        assert hess.shape == (2, 2)
+        assert not jnp.any(jnp.isnan(hess))
+
+
+class TestCreateNeuralCBF:
+    def test_returns_params_and_callable(self):
+        params, h_func = create_neural_cbf(state_dim=2, hidden_layers=[32])
+        assert isinstance(params, dict)
+        out = h_func(jnp.zeros(2))
+        assert out.shape == ()
+
+    def test_custom_activation(self):
+        params, h_func = create_neural_cbf(
+            state_dim=3, hidden_layers=[16, 16], activation="softplus"
+        )
+        out = h_func(jnp.ones(3))
+        assert out.shape == ()
+
+    def test_unknown_activation_raises(self):
+        with pytest.raises(ValueError, match="Unknown activation"):
+            create_neural_cbf(state_dim=2, activation="gelu")
+
+
+class TestMakeCBFCallable:
+    def test_binds_params(self):
+        model = CBFNetwork(hidden_dims=(16,))
+        params = model.init(random.PRNGKey(0), jnp.zeros(2))
+        h_func = make_cbf_callable(model, params)
+        out = h_func(jnp.array([1.0, 2.0]))
+        assert out.shape == ()
+
+
+# -- Training tests ------------------------------------------------------------
+
+
+class TestCBFLoss:
+    def test_loss_computes(self):
+        key = random.PRNGKey(42)
+        center = jnp.array([3.0, 3.0])
+        safe, unsafe = _generate_samples(key, center, radius=1.0, n_safe=50, n_unsafe=30)
+
+        model = CBFNetwork(hidden_dims=(32,))
+        params = model.init(random.PRNGKey(0), jnp.zeros(2))
+
+        loss, info = cbf_loss(params, model, safe, unsafe, _si_dynamics)
+        assert jnp.isfinite(loss)
+        assert all(k in info for k in ("safe", "unsafe", "descent", "reg", "total"))
+
+    def test_loss_is_differentiable(self):
+        key = random.PRNGKey(42)
+        center = jnp.array([3.0, 3.0])
+        safe, unsafe = _generate_samples(key, center, radius=1.0, n_safe=50, n_unsafe=30)
+
+        model = CBFNetwork(hidden_dims=(16,))
+        params = model.init(random.PRNGKey(0), jnp.zeros(2))
+
+        grads = jax.grad(lambda p: cbf_loss(p, model, safe, unsafe, _si_dynamics)[0])(params)
+        leaves = jax.tree_util.tree_leaves(grads)
+        assert all(jnp.isfinite(g).all() for g in leaves)
+
+
+class TestTrainNeuralCBF:
+    def test_returns_certificate_collection(self):
+        key = random.PRNGKey(42)
+        center = jnp.array([3.0, 3.0])
+        safe, unsafe = _generate_samples(key, center, radius=1.0)
+
+        cert = train_neural_cbf(
+            dynamics_func=_si_dynamics,
+            safe_samples=safe,
+            unsafe_samples=unsafe,
+            state_dim=2,
+            alpha=1.0,
+            hidden_layers=[32, 32],
+            num_epochs=50,
+            key=random.PRNGKey(0),
+        )
+
+        assert isinstance(cert, CertificateCollection)
+        assert len(cert.functions) == 1
+        assert len(cert.jacobians) == 1
+        assert len(cert.hessians) == 1
+        assert len(cert.partials) == 1
+        assert len(cert.conditions) == 1
+
+    def test_certificate_callables_work(self):
+        key = random.PRNGKey(42)
+        center = jnp.array([3.0, 3.0])
+        safe, unsafe = _generate_samples(key, center, radius=1.0)
+
+        cert = train_neural_cbf(
+            dynamics_func=_si_dynamics,
+            safe_samples=safe,
+            unsafe_samples=unsafe,
+            state_dim=2,
+            num_epochs=50,
+            key=random.PRNGKey(0),
+        )
+
+        t = 0.0
+        x = jnp.array([5.0, 5.0])  # safe point, far from obstacle
+
+        h_val = cert.functions[0](t, x)
+        j_val = cert.jacobians[0](t, x)
+        hess_val = cert.hessians[0](t, x)
+        p_val = cert.partials[0](t, x)
+        cond_val = cert.conditions[0](h_val)
+
+        assert h_val.shape == ()
+        assert j_val.shape == (2,)
+        assert hess_val.shape == (2, 2)
+        assert p_val.shape == ()
+        assert cond_val.shape == ()
+        assert jnp.isfinite(h_val)
+
+    def test_integration_with_qp_controller(self):
+        """End-to-end: train neural CBF, build controller, run one step."""
+        key = random.PRNGKey(42)
+        center = jnp.array([3.0, 3.0])
+        safe, unsafe = _generate_samples(key, center, radius=1.0)
+
+        cert = train_neural_cbf(
+            dynamics_func=_si_dynamics,
+            safe_samples=safe,
+            unsafe_samples=unsafe,
+            state_dim=2,
+            num_epochs=100,
+            key=random.PRNGKey(0),
+        )
+
+        from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+        from cbfkit.utils.user_types import ControllerData
+
+        controller = vanilla_cbf_clf_qp_controller(
+            control_limits=jnp.array([5.0, 5.0]),
+            dynamics_func=_si_dynamics,
+            barriers=cert,
+        )
+
+        x = jnp.array([5.0, 5.0])
+        u_nom = jnp.array([1.0, 1.0])
+        data = ControllerData()
+
+        u, new_data = controller(0.0, x, u_nom, random.PRNGKey(0), data)
+
+        # Should produce a finite control output (safe point, should succeed)
+        assert u.shape == (2,)
+        assert jnp.isfinite(u).all(), f"Controller returned {u}"
+
+    def test_custom_conditions(self):
+        key = random.PRNGKey(42)
+        center = jnp.array([3.0, 3.0])
+        safe, unsafe = _generate_samples(key, center, radius=1.0, n_safe=50, n_unsafe=30)
+
+        cubic_k = lambda h: 2.0 * h**3
+
+        cert = train_neural_cbf(
+            dynamics_func=_si_dynamics,
+            safe_samples=safe,
+            unsafe_samples=unsafe,
+            state_dim=2,
+            num_epochs=20,
+            certificate_conditions=cubic_k,
+            key=random.PRNGKey(0),
+        )
+
+        h_val = cert.functions[0](0.0, jnp.array([5.0, 5.0]))
+        cond_val = cert.conditions[0](h_val)
+        expected = 2.0 * h_val**3
+        assert jnp.allclose(cond_val, expected, atol=1e-6)


### PR DESCRIPTION
## Summary

- Adds a neural CBF module (`cbfkit.modeling.neural_cbf`) that learns barrier functions from safe/unsafe samples using Flax MLPs
- Trained barriers produce a `CertificateCollection` that drops directly into the existing CBF-CLF-QP controller pipeline
- Gradients, hessians, and partials are auto-computed via `generate_certificate` — no manual derivative code needed
- Adds `flax` and `optax` as optional dependency (`pip install cbfkit[neural]`)

## Usage

```python
from cbfkit.modeling.neural_cbf import train_neural_cbf

cert = train_neural_cbf(
    dynamics_func=dynamics,
    safe_samples=safe_pts,
    unsafe_samples=unsafe_pts,
    state_dim=2,
    alpha=1.0,
    num_epochs=1000,
)

# Drop-in replacement for analytical barriers
controller = vanilla_cbf_clf_qp_controller(
    control_limits=limits,
    dynamics_func=dynamics,
    barriers=cert,
)
```

See `examples/neural_cbf/neural_cbf_obstacle_avoidance.py` for a complete walkthrough.

## Test plan

- [x] 13 new tests: model forward pass, differentiability (grad + hessian), loss computation, training output type, certificate callable shapes, end-to-end QP controller integration, custom class-K conditions
- [x] Full non-slow test suite passes (354 passed, 0 failed)
- [x] Example runs successfully: robot avoids obstacle and reaches goal