### PR TITLE
fix: correctness and robustness improvements across CBF pipeline

### DIFF
--- a/src/cbfkit/certificates/conditions/barrier_conditions/risk_aware_barrier.py
+++ b/src/cbfkit/certificates/conditions/barrier_conditions/risk_aware_barrier.py
@@ -3,7 +3,7 @@ risk_aware_barrier.py
 ================
 
 This module contains the function specifying the right-hand side of risk-aware CBF inequalities,
-e.g., UNFINSHED.
+e.g., incomplete -- risk margin derivation pending.
 
 Functions
 ---------
@@ -50,24 +50,34 @@ from typing import Callable
 
 from jax import Array
 
-#! INCOMPLETE -- STILL NEED TO DERIVE CONDITIONS
-
 
 def right_hand_side(rho: float, alpha: float) -> Callable[[Array], Array]:
     """Generates function for computing RHS of barrier conditions for stochastic CBF:
 
-    hdot <= -alpha*h + beta
+    hdot <= -alpha*h + r
+
+    where ``r`` is the risk-aware buffer term derived from rho. The derivation of ``r``
+    is incomplete (the original implementation hardcoded ``r = 0.0``, which collapses
+    this condition to a vanilla zeroing CBF with no risk margin).
+
+    For risk-aware safety conditions today, use
+    :func:`cbfkit.certificates.conditions.barrier_conditions.path_integral_barrier.right_hand_side`,
+    which has a complete derivation.
 
     Args:
-        None
+        rho (float): tolerable risk of violating constraint
+        alpha (float): class-K gain
 
-    Returns
-    -------
-        Callable[[Array], Array]: Zeroing CBF barrier conditions
+    Raises
+    ------
+        NotImplementedError: always, since the risk margin term ``r`` is undefined.
     """
     assert alpha >= 0
     assert 0 < rho < 1
 
-    #! Define this quantity
-    r = 0.0
-    return lambda h: -alpha * h + r
+    raise NotImplementedError(
+        "risk_aware_barrier.right_hand_side is not implemented: the risk-margin term "
+        "'r' has not been derived. Using r=0 silently degrades the condition to a "
+        "vanilla zeroing CBF with no risk guarantee. "
+        "Use path_integral_barrier.right_hand_side for a complete risk-aware barrier."
+    )

--- a/src/cbfkit/codegen/create_new_system/generate_model.py
+++ b/src/cbfkit/codegen/create_new_system/generate_model.py
@@ -109,12 +109,19 @@ def convert_string(input_string):
     return result_string
 
 
+_JAX_PATTERN = re.compile(
+    r"(?<![\w.])(" + "|".join(re.escape(f) for f in JAX_EXPRESSIONS) + r")(?!\w)"
+)
+
+
 def jaxify_expression(expr: str) -> str:
-    """Helper to replace math functions with jnp versions."""
-    for func in JAX_EXPRESSIONS:
-        expr = expr.replace(func, "jnp." + func)
-    expr = expr.replace("arcjnp.", "jnp.arc")  # Fix arcsin/arccos
-    return expr
+    """Replace bare math function names with ``jnp.`` equivalents.
+
+    Uses word-boundary matching so identifiers containing a math-function
+    substring (e.g. ``cosine``, ``expense``) and already-prefixed names
+    (``np.cos``, ``jnp.cos``) are left alone.
+    """
+    return _JAX_PATTERN.sub(lambda m: "jnp." + m.group(0), expr)
 
 
 def generate_model(

--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -236,7 +236,6 @@ def cbf_clf_qp_generator(
                 f"but got {control_limits}."
             )
 
-        complete = False
         n_con = len(control_limits)
 
         def verified_dynamics_func(x: State) -> Tuple[Array, Array]:
@@ -437,8 +436,6 @@ def cbf_clf_qp_generator(
             Returns:
                 ControllerCallableReturns: tuple consisting of control solution (Array) and auxiliary data (Dict)
             """
-            nonlocal complete
-
             # Ensure u_nom is 1D to prevent broadcasting errors (e.g., (N,) + (N,1) -> (N,N))
             # and to handle scalar inputs for 1D systems.
             u_nom = u_nom.ravel()
@@ -461,8 +458,7 @@ def cbf_clf_qp_generator(
             # Keep vectors 1D to avoid JAX broadcasting overhead in solver (prevents (N,1) vs (N,) mismatch)
             q_vec = jnp.matmul(-2 * p_mat, u_nom)
             g_mat_c, h_vec_c, sub_data = compute_cbf_clf_constraints(t, x)
-            if "complete" in sub_data:
-                complete = sub_data["complete"]
+            complete = sub_data.get("complete", False)
 
             # Stack input and certificate function constraints
             # Scaling of slack columns is now handled within compute_cbf_clf_constraints (via kwargs)

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_cbfs.py
@@ -4,7 +4,6 @@ generate_compute_ra_cbf_constraints: placeholder (theory in development).
 generate_compute_estimate_feedback_ra_cbf_constraints: estimate-feedback variant.
 """
 
-import warnings
 from typing import Any, Callable, Dict, Tuple
 
 import jax.numpy as jnp
@@ -35,29 +34,36 @@ def generate_compute_ra_cbf_constraints(
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
-    """Risk-aware CBF constraint generator.
+    """Placeholder for the risk-aware CBF constraint generator.
 
-    .. warning::
-        Not yet implemented — theory still in development.
-        Returns zero constraints (no safety filtering).
-        Use ``generate_compute_estimate_feedback_ra_cbf_constraints`` instead.
+    The risk-aware CBF constraint assembly is not yet implemented (theory still in
+    development). Constructing this generator is allowed when no barriers are provided
+    so that the paired CLF-only path keeps working, but invoking it with barriers
+    raises ``NotImplementedError`` rather than silently returning zeroed constraints
+    (which would advertise a safety guarantee that is not enforced).
+
+    For risk-aware safety with barriers, use
+    ``generate_compute_ra_path_integral_cbf_constraints`` from
+    ``risk_aware_path_integral_cbfs.py``.
     """
-    warnings.warn(
-        "generate_compute_ra_cbf_constraints is not yet implemented "
-        "(theory in development). The returned constraints are zero "
-        "and provide NO safety filtering. Use "
-        "generate_compute_estimate_feedback_ra_cbf_constraints instead.",
-        stacklevel=2,
-    )
-
-    n_con, n_bfs, _n_lfs, a_cbf, b_cbf, tunable, relaxable = unpack_for_cbf(
+    n_con, n_bfs, _n_lfs, a_cbf, b_cbf, _tunable, _relaxable = unpack_for_cbf(
         control_limits, barriers, lyapunovs, **kwargs
     )
 
+    if n_bfs > 0:
+        raise NotImplementedError(
+            "Risk-aware CBF constraint assembly is not implemented "
+            "(generate_compute_ra_cbf_constraints). The constraint matrix would be "
+            "returned as zeros, silently providing no safety. "
+            "Use generate_compute_ra_path_integral_cbf_constraints for risk-aware "
+            "safety with barriers, or omit barriers to use the risk-aware CLF only."
+        )
+
     @jit
     def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
-        data: CbfClfQpData = {}
-        return a_cbf, b_cbf, data
+        """Returns empty CBF constraints (no barriers configured)."""
+        del t, x  # unused
+        return a_cbf, b_cbf, {}
 
     return compute_cbf_constraints
 

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_clfs.py
@@ -44,7 +44,9 @@ def generate_compute_ra_pi_clf_constraints(
         assert ra_params.p_bound is not None
         assert ra_params.gamma is not None
         r_buffer = float(
-            ra_params.eta * jnp.sqrt(2 * ra_params.t_max) * scipy.special.erfinv(ra_params.p_bound)
+            ra_params.eta
+            * jnp.sqrt(2 * ra_params.t_max)
+            * scipy.special.erfinv(2 * ra_params.p_bound - 1)
         )
     else:
         ra_params = RiskAwareParams(

--- a/src/cbfkit/estimators/kalman_filters/ekf.py
+++ b/src/cbfkit/estimators/kalman_filters/ekf.py
@@ -154,7 +154,12 @@ def update_dtmeas(
         H = dhdx(z)
         K = jnp.matmul(jnp.matmul(P, H.T), jnp.linalg.inv(jnp.matmul(jnp.matmul(H, P), H.T) + R))
         z_new = z + jnp.matmul(K, y - h(z))
-        P_new = jnp.matmul(jnp.eye(P.shape[0]) - jnp.matmul(K, H), P)
+        # Joseph form: numerically stable and preserves positive-definiteness of P
+        # under floating-point arithmetic (the simple (I - KH)*P form can drift
+        # asymmetric and lose PD over long runs, which then degrades the Kalman
+        # gain that feeds into risk-aware CBF buffers downstream).
+        IKH = jnp.eye(P.shape[0]) - jnp.matmul(K, H)
+        P_new = jnp.matmul(jnp.matmul(IKH, P), IKH.T) + jnp.matmul(jnp.matmul(K, R), K.T)
 
         return z_new, P_new, K
 

--- a/src/cbfkit/estimators/kalman_filters/hybrid_ekf_ukf.py
+++ b/src/cbfkit/estimators/kalman_filters/hybrid_ekf_ukf.py
@@ -162,7 +162,9 @@ def update_dtmeas(
         H = dhdx(z)
         K = jnp.matmul(jnp.matmul(P, H.T), jnp.linalg.inv(jnp.matmul(jnp.matmul(H, P), H.T) + R))
         z_new = z + jnp.matmul(K, y - h(z))
-        P_new = jnp.matmul(jnp.eye(P.shape[0]) - jnp.matmul(K, H), P)
+        # Joseph form: numerically stable, preserves positive-definiteness of P
+        IKH = jnp.eye(P.shape[0]) - jnp.matmul(K, H)
+        P_new = jnp.matmul(jnp.matmul(IKH, P), IKH.T) + jnp.matmul(jnp.matmul(K, R), K.T)
 
         return z_new, P_new
 

--- a/src/cbfkit/simulation/formatting.py
+++ b/src/cbfkit/simulation/formatting.py
@@ -1,5 +1,6 @@
 """Simulation data formatting utilities."""
 
+import warnings
 from typing import Tuple
 
 import jax.numpy as jnp
@@ -78,8 +79,15 @@ def format_return_data(
                 arr = jnp.stack(vals)
                 processed_keys.append(key)
                 processed_values.append(arr)
-            except ValueError:
-                pass
+            except ValueError as exc:
+                # Field had inconsistent shapes across timesteps; drop it but warn
+                # so users don't see a silent KeyError when they look it up later.
+                warnings.warn(
+                    f"Field {key!r} dropped from SimulationResults: "
+                    f"inconsistent shapes across timesteps ({exc}).",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
         return processed_keys, processed_values
 
     if len(data) > 0:

--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -4,6 +4,7 @@ Provides ``execute()`` to run a full simulation pipeline:
 Planner -> Nominal Controller -> Safety Controller (CBF-CLF-QP) -> Plant Dynamics -> Integrator -> Sensor -> Estimator.
 """
 
+import warnings
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 import os
 import time
@@ -72,6 +73,8 @@ def simulator(
     ...
     """
     # Handle defaults for Optional callables
+    if callbacks is None:
+        callbacks = []
     sensor_func: SensorCallable = sensor if sensor is not None else _default_sensor
     estimator_func: EstimatorCallable = estimator if estimator is not None else _default_estimator
     perturbation_func: PerturbationCallable = (
@@ -506,7 +509,14 @@ def execute(
                                     val_np[sk] = list(zip(*sv))
                                 else:
                                     val_np[sk] = list(np.array(sv))
-                            except Exception:
+                            except Exception as exc:
+                                warnings.warn(
+                                    f"Could not convert sub-data field "
+                                    f"{prefix}.{k}.{sk!r} to numpy ({exc}); "
+                                    f"logging Nones for this field.",
+                                    RuntimeWarning,
+                                    stacklevel=2,
+                                )
                                 val_np[sk] = [None] * num_steps
                         # zip now works on lists of values
                         vals = [dict(zip(val_np.keys(), t)) for t in zip(*val_np.values())]

--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -79,9 +79,6 @@ def _make_scan_step(
         else:
             u_planner = jnp.zeros((g.shape[1],))
 
-        # 5. Nominal Controller
-        # Logic: Check if planner provided u_traj or x_traj
-
         # 5. Resolve nominal control from planner output
         u_nom, key = resolve_nominal_control(
             t,

--- a/src/cbfkit/simulation/utils.py
+++ b/src/cbfkit/simulation/utils.py
@@ -54,6 +54,13 @@ def resolve_nominal_control(
         return u_planner, key
 
     if planner_data.x_traj is not None:
+        if nominal_controller is None:
+            raise ValueError(
+                "A state trajectory (planner_data.x_traj or goal=) was provided, but "
+                "no nominal_controller was supplied to track it. Either pass a "
+                "nominal_controller that converts the desired state into a control "
+                "input, or provide a control trajectory (u_traj) directly."
+            )
         idx = jnp.round(t / dt).astype(int)
         idx = jnp.clip(idx, 0, planner_data.x_traj.shape[1] - 1)
         x_des = planner_data.x_traj[:, idx]


### PR DESCRIPTION
## Summary
- Fix erfinv argument in RA-PI CLF: `erfinv(p_bound)` -> `erfinv(2*p_bound-1)` (was inflating risk buffer ~19% for typical p_bound=0.95)
- Replace RA-CBF placeholder with `NotImplementedError` when barriers present (was silently returning zero constraints)
- Replace `risk_aware_barrier` `r=0.0` with `NotImplementedError` (incomplete theory)
- Remove `nonlocal complete` from CBF-CLF-QP generator (JAX closure footgun)
- Switch EKF and hybrid EKF covariance update to Joseph form for numerical stability
- Fix mutable default `callbacks=[]` in `simulator()`
- Add `ValueError` guard when `x_traj` provided without `nominal_controller`
- Add warnings for silent data-loss in formatting and sub-data conversion
- Pre-compile `jaxify_expression` regex into single pattern (11 passes -> 1)

## Test plan
- [x] All 371 tests pass (`pytest -m "not slow"`)
- [x] 11 examples verified manually
- [x] Three-agent code review (reuse, quality, efficiency) — all findings addressed