### PR TITLE
feat: auto-select JIT simulation path by default (5-11x speedup)

### DIFF
--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -232,7 +232,7 @@ def execute(
     planner_data: Optional[Union[PlannerData, Dict[str, Any]]] = None,
     initial_covariance: Optional[Covariance] = None,
     stl_trajectory_cost: Optional[StlTrajectoryCostCallable] = None,
-    use_jit: bool = False,
+    use_jit: Union[bool, str] = "auto",
     jit_progress: bool = False,
     jit_progress_interval: int = 50,
 ) -> SimulationResults:
@@ -269,8 +269,10 @@ def execute(
         initial_covariance (Optional[Covariance], optional): Initial estimator covariance.
         Defaults to None.
         stl_trajectory_cost (Optional[Any], optional): STL cost object. Defaults to None.
-        use_jit (bool, optional): If True, uses `jax.jit` for faster execution.
-            JIT compilation requires that all callables are JIT-compatible. Defaults to False.
+        use_jit (Union[bool, str], optional): Controls JIT compilation.
+            ``"auto"`` (default): use JIT unless features that require the eager path
+            are detected (``stl_trajectory_cost``). ``True``: force JIT. ``False``:
+            force eager Python loop.
         jit_progress (bool, optional): Show a host-side progress bar during JIT execution.
             Disabled by default to avoid overhead; requires `verbose=True` to display.
         jit_progress_interval (int, optional): Number of steps between progress updates when
@@ -385,6 +387,16 @@ def execute(
 
     if jit_progress and jit_progress_interval <= 0:
         raise ValueError("jit_progress_interval must be positive when jit_progress is enabled.")
+
+    # Resolve use_jit="auto"
+    if use_jit == "auto":
+        # STL trajectory cost requires the eager path (dynamic trajectory slicing)
+        jit_blocked = stl_trajectory_cost is not None
+        use_jit = not jit_blocked
+        if verbose and use_jit:
+            print_jit_status("Auto-selected JIT execution path.")
+        elif verbose and jit_blocked:
+            print_jit_status("Auto-selected eager path (stl_trajectory_cost requires it).")
 
     if use_jit:
         # JIT Execution Path

--- a/tests/test_simulation/test_simulator_goal_api.py
+++ b/tests/test_simulation/test_simulator_goal_api.py
@@ -1,8 +1,8 @@
-
 import jax.numpy as jnp
 import pytest
 from cbfkit.simulation import simulator
 from cbfkit.utils.user_types import PlannerData
+
 
 def test_goal_sets_xtraj():
     """Test that passing 'goal' correctly populates planner_data.x_traj."""
@@ -40,7 +40,7 @@ def test_goal_sets_xtraj():
         assert jnp.allclose(ref.flatten(), goal_arr)
         return jnp.zeros(1), {}
 
-    # 1. Test with goal only
+    # 1. Test with goal only (eager path: mock controller uses Python assert)
     simulator.execute(
         x0=jnp.zeros(2),
         dt=0.1,
@@ -48,8 +48,10 @@ def test_goal_sets_xtraj():
         dynamics=dynamics,
         integrator=integrator,
         nominal_controller=nominal_controller,
-        goal=goal_arr
+        goal=goal_arr,
+        use_jit=False,
     )
+
 
 def test_goal_with_empty_planner_data():
     """Test goal works when planner_data is provided but empty."""
@@ -73,7 +75,8 @@ def test_goal_with_empty_planner_data():
         integrator=integrator,
         nominal_controller=nominal_controller,
         goal=goal_arr,
-        planner_data=PlannerData() # Empty
+        planner_data=PlannerData(),  # Empty
+        use_jit=False,
     )
 
     # Also test with dict
@@ -85,16 +88,21 @@ def test_goal_with_empty_planner_data():
         integrator=integrator,
         nominal_controller=nominal_controller,
         goal=goal_arr,
-        planner_data={} # Empty dict
+        planner_data={},  # Empty dict
+        use_jit=False,
     )
+
 
 def test_goal_conflict_raises_error():
     """Test that providing both goal and x_traj raises ValueError."""
     goal_arr = jnp.array([1.0])
     traj = jnp.array([[2.0]])
 
-    def dynamics(x): return jnp.zeros_like(x), jnp.zeros((x.shape[0], 1))
-    def integrator(x, f, dt): return x
+    def dynamics(x):
+        return jnp.zeros_like(x), jnp.zeros((x.shape[0], 1))
+
+    def integrator(x, f, dt):
+        return x
 
     # Case 1: PlannerData object
     with pytest.raises(ValueError, match="Cannot specify both 'goal' and 'planner_data.x_traj'"):
@@ -105,7 +113,7 @@ def test_goal_conflict_raises_error():
             dynamics=dynamics,
             integrator=integrator,
             goal=goal_arr,
-            planner_data=PlannerData(x_traj=traj)
+            planner_data=PlannerData(x_traj=traj),
         )
 
     # Case 2: Dict
@@ -117,5 +125,5 @@ def test_goal_conflict_raises_error():
             dynamics=dynamics,
             integrator=integrator,
             goal=goal_arr,
-            planner_data={"x_traj": traj}
+            planner_data={"x_traj": traj},
         )


### PR DESCRIPTION
## Summary
Change `use_jit` default from `False` to `"auto"`. In auto mode, `execute()` uses the JIT path (`lax.scan`) unless `stl_trajectory_cost` is provided.

This eliminates per-step Python-to-XLA dispatch overhead (~125us/step) for the common case.

## Benchmark: Unicycle + 5 Obstacles
```
Steps | Eager        | JIT (auto)   | Speedup
------|--------------|--------------|--------
  200 |    230ms     |    134ms     |   1.7x
  500 |    498ms     |    140ms     |   3.5x
 1000 |    872ms     |    141ms     |   6.2x
 2000 |   1775ms     |    158ms     |  11.2x
```

Backward compatible: `use_jit=True` and `use_jit=False` still work as before.

## Test plan
- [x] 317 tests pass (no regressions)
- [x] Tests using non-JIT-safe mocks explicitly set `use_jit=False`
- [x] Examples auto-select JIT and run correctly