### PR TITLE
fix: unblock CBF-CLF-QP convergence in si_ekf and mppi_cbf tutorials

### DIFF
--- a/examples/single_integrator/common/config.py
+++ b/examples/single_integrator/common/config.py
@@ -45,7 +45,10 @@ class EKFEstimationConfig(BaseConfig):
     VISUALIZE = True
     actuation_limits = 1e6 * jnp.array([1.0, 1.0])
     R = 0.25 * jnp.eye(len(BaseConfig.desired_state))
-    pg = 0.95
+    # pg=0.95 makes path-integral RA-CLF r_buffer ~4.6, driving the CLF
+    # constraint near-infeasible and OSQP grinds past MAX_ITER. 0.50 matches
+    # UKF and lets the QP converge.
+    pg = 0.50
     gamma_v = 1.0 - 0.5 * BaseConfig.goal_radius**2
     n_trials = 1 if os.getenv("CBFKIT_TEST_MODE") else 10
     pkl_file = f"examples/single_integrator/reach_goal/results/ekf_estimation_n{n_trials}_pg{int(pg * 100)}.pkl"

--- a/tutorials/mppi_cbf_reach_avoid.py
+++ b/tutorials/mppi_cbf_reach_avoid.py
@@ -142,13 +142,17 @@ mppi_local_planner = mppi_planner.vanilla_mppi(
 # alternatively, instantiate a fixed waypoint planner
 target_setpoint = single_waypoint_planner.vanilla_waypoint(target_state=goal)
 
-# Instantiate CBF-CLF-QP control law
+# Instantiate CBF-CLF-QP control law.
+# relaxable_cbf=True so OSQP can return a feasible u when the MPPI plan grazes
+# the obstacle boundary; without it the hard CBF + aggressive CLF deadlocks the
+# solver into MAX_ITER and the trajectory NaNs out partway through.
 cbf_clf_controller = cbf_clf_controllers.vanilla_cbf_clf_qp_controller(
     control_limits=ACTUATION_LIMITS,
     dynamics_func=dynamics,
     barriers=barriers,
     lyapunovs=lyapunov,
     relaxable_clf=True,
+    relaxable_cbf=True,
 )
 
 # Run the simulation


### PR DESCRIPTION
## Summary
Two scripts ran to exit 0 but the underlying CBF-CLF-QP hit OSQP's `MAX_ITER` (10000), so the simulator stopped early and the trajectory NaN'd out. Distinct root causes:

- **`examples/single_integrator/reach_goal/ekf.py`** — `EKFEstimationConfig.pg = 0.95` inflated the path-integral RA-CLF buffer `r_buffer = eta * sqrt(2*t_max) * erfinv(2*pg - 1)` to ~4.6. The FxTS Lyapunov condition then demanded very aggressive descent and OSQP couldn't reconcile within the iter cap. Dropping to `pg = 0.50` (matches `UKFEstimationConfig`) lets the QP converge.
- **`tutorials/mppi_cbf_reach_avoid.py`** — `vanilla_cbf_clf_qp_controller` used the default `relaxable_cbf=False`. When the MPPI plan grazes the obstacle, the hard CBF blocks the CLF descent direction and the QP becomes infeasible. Setting `relaxable_cbf=True` lets the solver return a feasible u with a small CBF slack penalty.

## Verification (with `CBFKIT_TEST_MODE=1`)

| Script | Before | After |
|---|---|---|
| `examples/single_integrator/reach_goal/ekf.py` | QP MAX_ITER at step 11, Success Rate 0.00 | GOAL REACHED, 0 QP failures |
| `tutorials/mppi_cbf_reach_avoid.py` | QP MAX_ITER at step 75, NaN trajectory | GOAL REACHED, 0 QP failures |
| `examples/single_integrator/reach_goal/perfect_sensing.py` | OK | Still OK (sanity, no regression) |
| `examples/single_integrator/reach_goal/ukf.py` | OK | Still OK (sanity, no regression) |

## Test plan
- [x] Both fixed scripts run end-to-end and log "GOAL REACHED!" with zero `CBF-CLF-QP Failed` warnings
- [x] Sibling `single_integrator` examples (perfect_sensing, ukf) still pass — `EKFEstimationConfig` was the only class touched
- [x] CI green

## Out of scope
A third tutorial — `tutorials/multi_robot_coordination_codegen.py` — exhibits the same surface symptom but its root cause is genuine infeasibility from a symmetric 10-robot star deadlock at the center crossing (10 robots on a circle, each heading to the antipodal point). Even `relaxable_cbf=True` doesn't help. That one needs scenario-level redesign and is intentionally not touched here.