### PR TITLE
perf(simulation): early-stop latch, single-execution Monte Carlo, memory fixes, RNG scheme

### DIFF
--- a/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
+++ b/src/cbfkit/controllers/cbf_clf/cbf_clf_qp_generator.py
@@ -26,7 +26,7 @@ Examples
 >>> )
 """
 
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import jax.numpy as jnp
 import jax.debug as jdebug
@@ -34,12 +34,10 @@ from jax import Array, jit, lax, tree_util
 
 from cbfkit.certificates import concatenate_certificates
 from cbfkit.optimization.quadratic_program.solver_registry import (
-    QpSolution,
     get_solver,
 )
 from cbfkit.utils.user_types import (
     EMPTY_CERTIFICATE_COLLECTION,
-    CbfClfQpConfig,
     CbfClfQpData,
     CbfClfQpGenerator,
     CertificateCollection,
@@ -154,6 +152,7 @@ def cbf_clf_qp_generator(
         slack_bound_clf: float = 1e9,
         slack_penalty_cbf: float = 2e3,
         slack_penalty_clf: float = 2e3,
+        report_failures: bool = False,
         **kwargs: Any,
     ) -> ControllerCallable:
         """Produces the function to deploy a CBF-CLF-QP control law.
@@ -177,6 +176,12 @@ def cbf_clf_qp_generator(
             slack_bound_clf (float): Maximum slack for CLF constraints (default: 1e9).
             slack_penalty_cbf (float): Penalty weight for CBF slack variables (default: 2e3).
             slack_penalty_clf (float): Penalty weight for CLF slack variables (default: 2e3).
+            report_failures (bool): whether to emit human-readable diagnostics when the QP
+                fails (default: False). The reporter is built from ``jax.debug`` host
+                callbacks, which cannot be optimized out of the compiled graph, so enabling
+                it costs roughly 60us per step on the success path as well. Turn it on when
+                debugging solver failures, not in benchmarks or production loops. The solver
+                status is recorded in ``sub_data["solver_status"]`` either way.
             **kwargs (CbfClfQpConfig): keyword arguments.
 
         Returns
@@ -468,7 +473,6 @@ def cbf_clf_qp_generator(
             # Avoid normalizing noise vectors. If norm < tol, do NOT scale up.
             # Input constraints (box limits) are already normalized (row norm = 1).
             impossible_constraints = jnp.array(False)
-            autodiff_safety_override = jnp.array(False)
             if auto_p_mat:
                 # Compute norms with overflow/underflow-safe scaling.
                 row_max = jnp.max(jnp.abs(g_mat_c), axis=1)
@@ -493,11 +497,13 @@ def cbf_clf_qp_generator(
                 infeasible_zero_rows = lax.stop_gradient(zero_rows & (h_vec_c < -1e-12))
                 impossible_constraints = jnp.any(infeasible_zero_rows)
                 feasible_zero_rows = lax.stop_gradient(zero_rows & (~infeasible_zero_rows))
-                autodiff_safety_override = lax.stop_gradient(jnp.any(feasible_zero_rows))
                 h_vec_c = jnp.where(feasible_zero_rows, 1.0, h_vec_c)
 
                 # Add an inactive regularization row for feasible degenerate constraints
-                # so reverse-mode differentiation avoids singular sensitivities.
+                # so reverse-mode differentiation avoids singular sensitivities. Rewriting
+                # the row is the whole remedy: a degenerate row carries no information, so
+                # replacing it with an inactive one leaves the QP's feasible set unchanged
+                # and its solution is still the control that must be applied.
                 reg_rows = jnp.zeros_like(g_mat_c)
                 reg_rows = reg_rows.at[:, 0].set(1e-6)
                 g_mat_c = jnp.where(feasible_zero_rows[:, None], reg_rows, g_mat_c)
@@ -526,10 +532,6 @@ def cbf_clf_qp_generator(
 
             if "solver_params" in controller_sub_data:
                 solver_params = controller_sub_data["solver_params"]
-
-            safe_nominal_u = jnp.clip(
-                u_nom[:n_con], -control_limits[:n_con], control_limits[:n_con]
-            )
 
             def _solve_with(p_local: Array, q_local: Array, g_local: Array, h_local: Array):
                 sol_local, status_local, new_params_local = solve_qp(
@@ -573,20 +575,22 @@ def cbf_clf_qp_generator(
             new_params = tree_util.tree_map(lax.stop_gradient, new_params)
             iter_num = lax.stop_gradient(iter_num)
 
+            # The applied control is the QP solution whenever the solve succeeded, and NaN
+            # otherwise. Substituting the nominal control for a solved QP would hand the
+            # plant an unfiltered input while still reporting success -- an unsafe control
+            # that no downstream check can see. Infeasibility is surfaced through `error`.
             success = status == 1
-            solved_u = lax.cond(
+            u = lax.cond(
                 success,
                 lambda _fake: sol[:n_con],
                 lambda _fake: jnp.full_like(u_nom[:n_con], jnp.nan),
                 0,
             )
-            u = lax.cond(
-                autodiff_safety_override,
-                lambda _fake: lax.stop_gradient(safe_nominal_u),
-                lambda _fake: solved_u,
-                0,
-            )
 
+            # The reporter below is built from jax.debug host callbacks. Those cannot be
+            # elided by XLA, so they are paid on every step -- including successful ones --
+            # even though they only print on failure. Tracing it out entirely when
+            # report_failures is False keeps the compiled graph callback-free.
             def _print_failure(status, iter_num, sub_data):
                 # Map status codes to human-readable strings
                 def print_status_msg(msg):
@@ -646,19 +650,20 @@ def cbf_clf_qp_generator(
                 if "lfs" in sub_data:
                     jdebug.print("   -> Lyapunov Values (V): {V}", V=sub_data["lfs"])
 
-            # Only print failure if we weren't already in error state
-            prev_error = data.error if data.error is not None else jnp.array(False)
-            should_print = jnp.logical_not(success) & jnp.logical_not(prev_error)
+            if report_failures:
+                # Only print failure if we weren't already in error state
+                prev_error = data.error if data.error is not None else jnp.array(False)
+                should_print = jnp.logical_not(success) & jnp.logical_not(prev_error)
 
-            # Debug hook: Print failure details if solver failed AND it's a new failure
-            lax.cond(
-                should_print,
-                _print_failure,
-                lambda *_: None,
-                status,
-                iter_num,
-                sub_data,
-            )
+                # Debug hook: Print failure details if solver failed AND it's a new failure
+                lax.cond(
+                    should_print,
+                    _print_failure,
+                    lambda *_: None,
+                    status,
+                    iter_num,
+                    sub_data,
+                )
 
             error = lax.cond(success, lambda _fake: False, lambda _fake: True, 0)
 

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/_constraint_core.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/_constraint_core.py
@@ -80,7 +80,7 @@ def build_cbf_constraint_generator(
     """
     certs = certificate_package if certificate_package is not None else barriers
     compute_barrier_values = generate_compute_certificate_values(certs, compute_hessians)
-    n_con, n_bfs, _n_lfs, a_cbf, b_cbf, tunable, relaxable = unpack_for_cbf(
+    n_con, n_bfs, _n_lfs, a_cbf_template, b_cbf_template, tunable, relaxable = unpack_for_cbf(
         control_limits, barriers, lyapunovs, **kwargs
     )
     scale_cbf = kwargs.get("scale_cbf", 1.0)
@@ -92,13 +92,18 @@ def build_cbf_constraint_generator(
         f: Optional[Array] = None,
         g: Optional[Array] = None,
     ) -> Tuple[Array, Array, CbfClfQpData]:
-        nonlocal a_cbf, b_cbf
         data: CbfClfQpData = {}
 
         dyn_f = f
         dyn_g = g
         if dyn_f is None or dyn_g is None:
             dyn_f, dyn_g = dyn_func(x)
+
+        # Bind the zero templates to locals. Rebinding the enclosing names instead
+        # would store this trace's tracers in the closure, so the next trace (new
+        # dtype/shape, or disable_jit) would read a leaked tracer.
+        a_cbf = a_cbf_template
+        b_cbf = b_cbf_template
 
         if n_bfs > 0:
             bf_x, bj_x, bh_x, dbf_t, bc_x = compute_barrier_values(t, x)
@@ -151,7 +156,7 @@ def build_clf_constraint_generator(
         **kwargs: Forwarded to ``unpack_for_clf``.
     """
     compute_lyapunov_values = generate_compute_certificate_values(lyapunovs, compute_hessians)
-    n_con, _n_bfs, n_lfs, a_clf, b_clf, relaxable = unpack_for_clf(
+    n_con, _n_bfs, n_lfs, a_clf_template, b_clf_template, relaxable = unpack_for_clf(
         control_limits, lyapunovs, barriers, **kwargs
     )
     scale_clf = kwargs.get("scale_clf", 1.0)
@@ -164,13 +169,17 @@ def build_clf_constraint_generator(
         f: Optional[Array] = None,
         g: Optional[Array] = None,
     ) -> Tuple[Array, Array, CbfClfQpData]:
-        nonlocal a_clf, b_clf
         data: CbfClfQpData = {}
 
         dyn_f = f
         dyn_g = g
         if dyn_f is None or dyn_g is None:
             dyn_f, dyn_g = dyn_func(x)
+
+        # See the note in build_cbf_constraint_generator: the enclosing templates
+        # must stay concrete, so this trace works on locals.
+        a_clf = a_clf_template
+        b_clf = b_clf_template
 
         if n_lfs > 0:
             lf_x, lj_x, lh_x, dlf_t, lc_x = compute_lyapunov_values(t, x)

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/activated_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/activated_cbfs.py
@@ -24,7 +24,19 @@ def generate_compute_activated_cbf_constraints(
     lyapunovs: CertificateCollection = EMPTY_CERTIFICATE_COLLECTION,
     **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
-    """Generates zeroing CBF constraints with activation weight scaling."""
+    """Generates zeroing CBF constraints with activation weight scaling.
+
+    Each barrier row (its control columns, its slack column, and its right-hand side) is
+    multiplied by that barrier's activation weight. Scaling an inequality by a positive
+    constant leaves its feasible set untouched, so the weight is an on/off switch rather
+    than a soft knob: a barrier with any weight above zero is enforced exactly as it would
+    be unweighted, and only a weight of exactly zero -- which ``compute_activation_weights``
+    produces for every obstacle outside the k-closest set -- removes it from the QP.
+
+    Zeroing the whole row is what deactivation means here, so the resulting all-zero row is
+    intentional. ``cbf_clf_qp_generator`` recognizes such rows and substitutes an inactive
+    regularization row; it must not treat them as a reason to discard the QP solution.
+    """
     obstacle_positions = kwargs.get("obstacle_positions")
     k_closest = kwargs.get("k_closest", 3)
     activation_radius = kwargs.get("activation_radius", 2.0)
@@ -47,6 +59,9 @@ def generate_compute_activated_cbf_constraints(
             radius=activation_radius,
             smoothness=activation_smoothness,
         )
+        # Scale the slack column along with the rest of the row: leaving it unscaled would
+        # divide through to an effective slack of delta/w, amplifying the relaxation of a
+        # barely-activated barrier by 1/w.
         a_cbf = a_cbf * weights[:, None]
         b_cbf = b_cbf * weights
         data["activation_weights"] = weights

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_cbfs.py
@@ -4,7 +4,7 @@ generate_compute_ra_cbf_constraints: placeholder (theory in development).
 generate_compute_estimate_feedback_ra_cbf_constraints: estimate-feedback variant.
 """
 
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Tuple
 
 import jax.numpy as jnp
 from jax import Array, jit, lax, scipy
@@ -78,7 +78,7 @@ def generate_compute_estimate_feedback_ra_cbf_constraints(
     **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     compute_lyapunov_values = generate_compute_certificate_values(lyapunovs)
-    n_con, n_bfs, _n_lfs, a_clf, b_clf, tunable, relaxable = unpack_for_cbf(
+    n_con, n_bfs, _n_lfs, a_clf_template, b_clf_template, tunable, relaxable = unpack_for_cbf(
         control_limits, barriers, lyapunovs, **kwargs
     )
 
@@ -103,11 +103,16 @@ def generate_compute_estimate_feedback_ra_cbf_constraints(
     @jit
     def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
-        nonlocal a_clf, b_clf
         data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         # Get K matrix from kwargs (passed from estimator state)
         k_mat = kwargs.get("kalman_gain", jnp.zeros((x.shape[0], x.shape[0])))
+
+        # Bind the zero templates to locals. Rebinding the enclosing names instead
+        # would store this trace's tracers in the closure, so the next trace (new
+        # dtype/shape, or disable_jit) would read a leaked tracer.
+        a_clf = a_clf_template
+        b_clf = b_clf_template
 
         if n_bfs > 0:
             lf_x, lj_x, lh_x, dlf_t, lc_x = compute_lyapunov_values(t, x)

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_clfs.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Tuple
 
 import jax.numpy as jnp
 from jax import Array, jit, lax, scipy
@@ -31,7 +31,7 @@ def generate_compute_ra_clf_constraints(
     **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     compute_lyapunov_values = generate_compute_certificate_values(lyapunovs)
-    n_con, _n_bfs, n_lfs, a_clf, b_clf, relaxable = unpack_for_clf(
+    n_con, _n_bfs, n_lfs, a_clf_template, b_clf_template, relaxable = unpack_for_clf(
         control_limits, lyapunovs, barriers, **kwargs
     )
     scale_clf = kwargs.get("scale_clf", 1.0)
@@ -54,11 +54,16 @@ def generate_compute_ra_clf_constraints(
     @jit
     def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
-        nonlocal a_clf, b_clf
         data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         assert ra_params.sigma is not None
         sigma = ra_params.sigma(x)
+
+        # Bind the zero templates to locals. Rebinding the enclosing names instead
+        # would store this trace's tracers in the closure, so the next trace (new
+        # dtype/shape, or disable_jit) would read a leaked tracer.
+        a_clf = a_clf_template
+        b_clf = b_clf_template
 
         if n_lfs > 0:
             lf_x, lj_x, lh_x, dlf_t, lc_x = compute_lyapunov_values(t, x)
@@ -93,7 +98,7 @@ def generate_compute_estimate_feedback_ra_clf_constraints(
     **kwargs: Any,
 ) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     compute_lyapunov_values = generate_compute_certificate_values(lyapunovs)
-    n_con, _n_bfs, n_lfs, a_clf, b_clf, relaxable = unpack_for_clf(
+    n_con, _n_bfs, n_lfs, a_clf_template, b_clf_template, relaxable = unpack_for_clf(
         control_limits, lyapunovs, barriers, **kwargs
     )
     scale_clf = kwargs.get("scale_clf", 1.0)
@@ -119,11 +124,15 @@ def generate_compute_estimate_feedback_ra_clf_constraints(
     @jit
     def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
-        nonlocal a_clf, b_clf
         data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         # Get K matrix from kwargs (passed from estimator state)
         k_mat = kwargs.get("kalman_gain", jnp.zeros((x.shape[0], x.shape[0])))
+
+        # See the note in generate_compute_ra_clf_constraints: the enclosing
+        # templates must stay concrete, so this trace works on locals.
+        a_clf = a_clf_template
+        b_clf = b_clf_template
 
         if n_lfs > 0:
             lf_x, lj_x, lh_x, dlf_t, lc_x = compute_lyapunov_values(t, x)

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_cbfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_cbfs.py
@@ -5,15 +5,17 @@ risk_aware_path_integral_cbfs.py
 .. deprecated::
     **NON-FUNCTIONAL STUB — the path integral never accumulates.**
 
-    Line 52 unconditionally overwrites ``ra_params.integrator_states`` with zeros::
+    The generator body unconditionally overwrites ``ra_params.integrator_states``
+    with zeros, discarding any caller-supplied value::
 
         ra_params.integrator_states = jnp.zeros((n_bfs,))
 
-    The ``lax.cond`` on line 62 that was meant to reset-on-t==0 only runs once at
-    construction time (the attribute is then shadowed by the assignment above), so
-    ``integrator_states`` is permanently 0.  The root cause is architectural: this
-    function receives only ``(t, x)`` and cannot accumulate mutable state across calls
-    inside a JIT/scan loop without a proper carry mechanism.
+    No term anywhere in the package ever increments it, so the reset-on-``t == 0``
+    ``lax.cond`` reduces to ``w <- (t == 0 ? 0 : w)`` over a value that is already
+    zero: ``integrator_states`` is identically 0 at every timestep.  The root cause
+    is architectural: this function receives only ``(t, x)`` and cannot accumulate
+    mutable state across calls inside a JIT/scan loop without a proper carry
+    mechanism.
 
     **Use** ``accumulating_risk_aware_cbf_controller`` from
     ``cbfkit.controllers.cbf_clf.accumulating_risk_aware_cbf`` instead.  It carries
@@ -23,7 +25,7 @@ risk_aware_path_integral_cbfs.py
     unchanged so that existing tests continue to pass.
 """
 
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Tuple
 
 import jax.numpy as jnp
 from jax import Array, jit, lax
@@ -56,7 +58,7 @@ def generate_compute_ra_pi_cbf_constraints(
 ) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     conditions = barriers[-1]
     compute_barrier_values = generate_compute_certificate_values(barriers)
-    n_con, n_bfs, _n_lfs, a_cbf, b_cbf, tunable, relaxable = unpack_for_cbf(
+    n_con, n_bfs, _n_lfs, a_cbf_template, b_cbf_template, tunable, relaxable = unpack_for_cbf(
         control_limits, barriers, lyapunovs, **kwargs
     )
 
@@ -71,23 +73,35 @@ def generate_compute_ra_pi_cbf_constraints(
         )
 
     ra_params.integrator_states = jnp.zeros((n_bfs,))
+    integrator_states_template = ra_params.integrator_states
 
     @jit
     def compute_cbf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
-        nonlocal a_cbf, b_cbf, ra_params
         data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         assert ra_params.sigma is not None
         sigma = ra_params.sigma(x)
-        ra_params.integrator_states = lax.cond(
-            t == 0, lambda _: jnp.zeros((n_bfs,)), lambda _: ra_params.integrator_states, 0
+
+        # Bind the zero templates to locals. Rebinding the enclosing names instead
+        # would store this trace's tracers in the closure, so the next trace (new
+        # dtype/shape, or disable_jit) would read a leaked tracer.
+        a_cbf = a_cbf_template
+        b_cbf = b_cbf_template
+
+        # Per the module docstring this integrator never accumulates: no term
+        # anywhere increments it, so both branches yield the construction-time
+        # zeros and the reset is a no-op. It is kept (reading the concrete
+        # template, never the mutated attribute) so the reset-at-t==0 intent
+        # survives for whoever threads a real carry through ControllerData.
+        integrator_states = lax.cond(
+            t == 0, lambda _: jnp.zeros((n_bfs,)), lambda _: integrator_states_template, 0
         )
 
         if n_bfs > 0:
             bf_x, bj_x, bh_x, dbf_t, _ = compute_barrier_values(t, x)
             # Ensure array types for addition
-            w_vals = ra_params.integrator_states
+            w_vals = integrator_states
             bc_x = jnp.stack([bc(w_vals[ii]) for ii, bc in enumerate(conditions)])
             traces = batched_hessian_trace(sigma, bh_x)
 

--- a/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_clfs.py
+++ b/src/cbfkit/controllers/cbf_clf/generate_constraints/risk_aware_path_integral_clfs.py
@@ -1,4 +1,27 @@
-from typing import Any, Callable, Dict, Tuple
+"""
+risk_aware_path_integral_clfs.py
+=================================
+
+.. deprecated::
+    **NON-FUNCTIONAL STUB — the path integral never accumulates.**
+
+    This is the CLF counterpart of ``risk_aware_path_integral_cbfs.py`` and shares
+    its defect.  The generator body unconditionally overwrites
+    ``ra_params.integrator_states`` with zeros, and no term anywhere in the package
+    ever increments it, so ``w_vals`` collapses to the constant
+    ``gamma + r_buffer`` at every timestep instead of tracking an accumulated
+    integral.  The root cause is architectural: this function receives only
+    ``(t, x)`` and cannot accumulate mutable state across calls inside a JIT/scan
+    loop without a proper carry mechanism.
+
+    See ``cbfkit.controllers.cbf_clf.accumulating_risk_aware_cbf`` for the pattern
+    that carries the integral correctly in ``ControllerData.sub_data``.
+
+    This module is kept for backward compatibility only.  Its runtime behaviour is
+    unchanged so that existing tests continue to pass.
+"""
+
+from typing import Any, Callable, Tuple
 
 import jax.numpy as jnp
 from jax import Array, jit, lax, scipy
@@ -31,7 +54,7 @@ def generate_compute_ra_pi_clf_constraints(
 ) -> Callable[[Time, State], Tuple[Array, Array, CbfClfQpData]]:
     conditions = lyapunovs[-1]
     compute_lyapunov_values = generate_compute_certificate_values(lyapunovs)
-    n_con, _n_bfs, n_lfs, a_clf, b_clf, relaxable = unpack_for_clf(
+    n_con, _n_bfs, n_lfs, a_clf_template, b_clf_template, relaxable = unpack_for_clf(
         control_limits, lyapunovs, barriers, **kwargs
     )
     scale_clf = kwargs.get("scale_clf", 1.0)
@@ -57,24 +80,36 @@ def generate_compute_ra_pi_clf_constraints(
         r_buffer = 0.0
 
     ra_params.integrator_states = jnp.zeros((n_lfs,))
+    integrator_states_template = ra_params.integrator_states
 
     @jit
     def compute_clf_constraints(t: Time, x: State) -> Tuple[Array, Array, CbfClfQpData]:
         """Computes CBF and CLF constraints."""
-        nonlocal a_clf, b_clf, ra_params
         data: CbfClfQpData = {}
         dyn_f, dyn_g = dyn_func(x)
         assert ra_params.sigma is not None
         sigma = ra_params.sigma(x)
-        ra_params.integrator_states = lax.cond(
-            t == 0, lambda _: jnp.zeros((n_lfs,)), lambda _: ra_params.integrator_states, 0
+
+        # Bind the zero templates to locals. Rebinding the enclosing names instead
+        # would store this trace's tracers in the closure, so the next trace (new
+        # dtype/shape, or disable_jit) would read a leaked tracer.
+        a_clf = a_clf_template
+        b_clf = b_clf_template
+
+        # Per the module docstring this integrator never accumulates: no term
+        # anywhere increments it, so both branches yield the construction-time
+        # zeros and the reset is a no-op. It is kept (reading the concrete
+        # template, never the mutated attribute) so the reset-at-t==0 intent
+        # survives for whoever threads a real carry through ControllerData.
+        integrator_states = lax.cond(
+            t == 0, lambda _: jnp.zeros((n_lfs,)), lambda _: integrator_states_template, 0
         )
 
         if n_lfs > 0:
             lf_x, lj_x, lh_x, dlf_t, _ = compute_lyapunov_values(t, x)
             assert ra_params.gamma is not None
             # Ensure array types for addition
-            w_vals = ra_params.integrator_states + ra_params.gamma + r_buffer
+            w_vals = integrator_states + ra_params.gamma + r_buffer
             lc_x = jnp.stack([lc(w_vals[ii]) for ii, lc in enumerate(conditions)])
             traces = batched_hessian_trace(sigma, lh_x)
 

--- a/src/cbfkit/estimators/kalman_filters/ukf.py
+++ b/src/cbfkit/estimators/kalman_filters/ukf.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Tuple, Union, cast
+from typing import Callable, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -21,7 +21,7 @@ def ct_ukf_dtmeas(
         step_ukf (Callable): function handle to compute the next UKF observer state
     """
     predict = predict_ct_dtmeas(Q, dynamics, dt)
-    update = update_dtmeas(R, h)
+    update = update_dtmeas(R, h, Q.shape[0])
 
     def step_ukf(
         t: Time,
@@ -111,21 +111,23 @@ def predict_ct_dtmeas(
 
 
 def update_dtmeas(
-    R: Array, h: Callable[[Array], Array]
+    R: Array, h: Callable[[Array], Array], n_states: int
 ) -> Callable[[Array, Array, Array], Tuple[Array, Array]]:
-    """Function defining the update step for (any) EKF with discrete-time measurements.
+    """Function defining the update step for the UKF with discrete-time measurements.
 
     Arguments:
         R (Array): measurement noise covariance matrix
         h (Callable): measurement model
-        dhdx (Callable): linearized measurement model
+        n_states (int): dimension of the observer state
 
 
     Returns
     -------
-        update (Callable): function handle to compute the updated EKF state and covariance matrix
+        update (Callable): function handle to compute the updated UKF state and covariance matrix
     """
-    sigma_points = generate_sigma_points(R.shape[0], scheme=1)
+    # Sigma points are drawn over the state, so the unscented transform is
+    # parameterized by the state dimension, not the measurement dimension.
+    sigma_points = generate_sigma_points(n_states, scheme=1)
 
     def update(z: Array, y: Array, P: Array) -> Tuple[Array, Array]:
         """Update step for (any)) EKF with discrete-time measurements.
@@ -223,8 +225,13 @@ def generate_sigma_points(
         Returns
         -------
         """
-        # Cholesky decomposition of covariance matrix
-        A = jnp.linalg.cholesky(P)
+        # Cholesky decomposition of covariance matrix. LAPACK's factorization
+        # returns NaN for a zero pivot, but an all-zero P is a legitimate
+        # "no prior uncertainty" seed (the simulator's default initial
+        # covariance): its factor is exactly zero, so the sigma points collapse
+        # to the mean and the predict step restores spread via Q. Genuinely
+        # degenerate or NaN covariances still fail loudly.
+        A = jnp.where(jnp.all(P == 0.0), jnp.zeros_like(P), jnp.linalg.cholesky(P))
 
         # Initialize sigma points and weights
         sigma_points = jnp.zeros((2 * L + 1, len(z)))

--- a/src/cbfkit/optimization/quadratic_program/qp_solver_cvxopt.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_cvxopt.py
@@ -104,8 +104,12 @@ def solve_with_details(
 
     ``init_params`` is accepted for interface compatibility but ignored
     (CVXOPT does not support warm-starting).
+
+    Note: the registry convention is ``min x'Hx + f'x`` while CVXOPT's native
+    form is ``min 1/2 x'Px + q'x``; the ``P = 2H`` conversion happens here so
+    all ``get_solver()`` backends agree (see ``solver_registry`` docstring).
     """
     from cbfkit.optimization.quadratic_program.solver_registry import QpSolution
 
-    primal, success = solve(h_mat, f_vec, g_mat, h_vec, a_mat, b_vec)
+    primal, success = solve(2.0 * h_mat, f_vec, g_mat, h_vec, a_mat, b_vec)
     return QpSolution(primal=primal, status=1 if success else 0, params=None)

--- a/src/cbfkit/optimization/quadratic_program/qp_solver_fast.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_fast.py
@@ -13,6 +13,7 @@ from typing import Optional, Tuple
 from jax import Array
 
 from cbfkit.optimization.quadratic_program.qp_solver_pdipm import (
+    DEFAULT_MAX_ITER,
     PdipmState,
     solve_qp_pdipm,
 )
@@ -24,13 +25,17 @@ def solve_qp_fast(
     G: Array,
     h: Array,
     warm_start: Optional[Array] = None,
-    max_iter: int = 25,
+    max_iter: Optional[int] = None,
     tol: float = 1e-6,
 ) -> Tuple[Array, int, Array]:
     """Backward-compatible alias for solve_qp_pdipm.
 
     Returns ``(x, status, dual)``. For full state including primal slacks
     (needed for richer warm-starting), call ``solve_qp_pdipm`` directly.
+
+    ``max_iter=None`` defers to ``qp_solver_pdipm.DEFAULT_MAX_ITER`` rather
+    than pinning its own copy of the budget, so tuning the solver default is
+    not silently masked here.
 
     Note: the legacy interface accepted an Array as ``warm_start`` (the dual
     only). To preserve that signature, we wrap it in a minimal ``PdipmState``
@@ -55,7 +60,7 @@ def solve_qp_fast(
         G,
         h,
         warm_start=warm,
-        max_iter=max_iter,
+        max_iter=DEFAULT_MAX_ITER if max_iter is None else max_iter,
         tol=tol,
     )
     return x, status, state.dual

--- a/src/cbfkit/optimization/quadratic_program/qp_solver_pdipm.py
+++ b/src/cbfkit/optimization/quadratic_program/qp_solver_pdipm.py
@@ -46,25 +46,45 @@ def _step_to_boundary(s: Array, ds: Array) -> Array:
 _EPS_PD = 1e-10  # PD regularization on H before Cholesky
 
 
-def _solve_newton_reduced(P: Array, G: Array, s: Array, lam: Array, rhs: Array) -> Array:
-    """Solve (P + G^T diag(lam/s) G + eps*I) dx = rhs via Cholesky.
+def _factor_newton_reduced(P: Array, G: Array, s: Array, lam: Array) -> Array:
+    """Cholesky factor of (P + G^T diag(lam/s) G + eps*I).
 
     The eps*I term guards against rounding-induced non-PD near the optimum.
+
+    The predictor and corrector of a Mehrotra iteration share this matrix and
+    differ only in their right-hand side, so it is factored once per iteration
+    and reused via ``_solve_with_factor``.
     """
     n = P.shape[0]
     D = lam / s
     H = P + G.T @ (D[:, None] * G) + _EPS_PD * jnp.eye(n)
-    L = jnp.linalg.cholesky(H)
-    # dx = H^-1 rhs via two triangular solves
+    return jnp.linalg.cholesky(H)
+
+
+def _solve_with_factor(L: Array, rhs: Array) -> Array:
+    """Solve H dx = rhs given the Cholesky factor L of H, via two triangular solves."""
     y = jax.scipy.linalg.solve_triangular(L, rhs, lower=True)
-    dx = jax.scipy.linalg.solve_triangular(L.T, y, lower=False)
-    return dx
+    return jax.scipy.linalg.solve_triangular(L.T, y, lower=False)
 
 
 _STEP_SAFETY = 0.995  # fraction of step-to-boundary; keeps strict interior
 
+# Default iteration budget. Because the fori_loop always runs to completion,
+# this is the per-solve cost, so it is chosen as the smallest value that is
+# still exact rather than a loose upper bound.
+#
+# Calibrated on two 250-QP suites (n=5, m=24), comparing against max_iter=60:
+#   - benign QPs (well-conditioned P, slack interior): converged by iteration 8.
+#   - hard QPs (cond(P) ~ 1e6 from slack penalty weighting, optimum on the
+#     barrier boundary with many near-active constraints) needed far more:
+#       max_iter=10 -> 123/250 QPs off by >1e-8;  max_iter=12 -> 30/250;
+#       max_iter=14 -> 1/250;   max_iter=16 -> 0/250, all status==1.
+# 16 is the first budget that is exact on both suites. Benign problems are
+# unaffected in accuracy since they freeze on convergence.
+DEFAULT_MAX_ITER = 16
 
-def _pdipm_iteration(
+
+def _residuals(
     P: Array,
     q: Array,
     G: Array,
@@ -72,16 +92,33 @@ def _pdipm_iteration(
     x: Array,
     s: Array,
     lam: Array,
+) -> Tuple[Array, Array]:
+    """Dual and primal residuals (r_d, r_p).
+
+    Computed once per iteration and shared by the freeze-on-converge test and
+    the Newton step, which would otherwise each rebuild them.
+    """
+    r_d = P @ x + G.T @ lam + q
+    r_p = G @ x + s - h
+    return r_d, r_p
+
+
+def _pdipm_iteration(
+    P: Array,
+    G: Array,
+    x: Array,
+    s: Array,
+    lam: Array,
+    r_d: Array,
+    r_p: Array,
 ) -> Tuple[Array, Array, Array]:
-    """One Mehrotra predictor-corrector PDIPM step.
+    """One Mehrotra predictor-corrector PDIPM step, given precomputed residuals.
 
     Returns updated (x, s, lam) all strictly positive in s, lam.
     """
     m = G.shape[0]
 
-    # --- Residuals (predictor: r_c with mu = 0) ---
-    r_d = P @ x + G.T @ lam + q
-    r_p = G @ x + s - h
+    # Predictor complementarity residual (r_c with mu = 0).
     r_c_aff = s * lam
 
     # --- Predictor (affine) step ---
@@ -90,7 +127,9 @@ def _pdipm_iteration(
     #                            = -(r_d + G^T ((lam*r_p - s*lam) / s))
     # which simplifies via r_c_aff = s*lam to -(r_d + G^T ((lam*r_p - r_c_aff)/s)).
     rhs_aff = -(r_d + G.T @ ((lam * r_p - r_c_aff) / s))
-    dx_aff = _solve_newton_reduced(P, G, s, lam, rhs_aff)
+    # Predictor and corrector share this factorization; see _factor_newton_reduced.
+    L = _factor_newton_reduced(P, G, s, lam)
+    dx_aff = _solve_with_factor(L, rhs_aff)
     ds_aff = -r_p - G @ dx_aff
     dlam_aff = -(r_c_aff + lam * ds_aff) / s
 
@@ -110,7 +149,7 @@ def _pdipm_iteration(
     # --- Corrector ---
     r_c = s * lam + ds_aff * dlam_aff - sigma * mu
     rhs = -(r_d + G.T @ ((lam * r_p - r_c) / s))
-    dx = _solve_newton_reduced(P, G, s, lam, rhs)
+    dx = _solve_with_factor(L, rhs)
     ds = -r_p - G @ dx
     dlam = -(r_c + lam * ds) / s
 
@@ -125,21 +164,11 @@ def _pdipm_iteration(
     return x_new, s_new, lam_new
 
 
-def _combined_residual(
-    P: Array,
-    q: Array,
-    G: Array,
-    h: Array,
-    x: Array,
-    s: Array,
-    lam: Array,
-) -> Array:
+def _combined_residual(r_d: Array, r_p: Array, s: Array, lam: Array) -> Array:
     """Scalar residual used both for in-loop freeze-on-converge and for the
     post-loop status check: ||r_d||_inf + ||r_p||_inf + mu.
     """
-    r_d = P @ x + G.T @ lam + q
-    r_p = G @ x + s - h
-    mu = jnp.sum(s * lam) / G.shape[0]
+    mu = jnp.sum(s * lam) / s.shape[0]
     return jnp.max(jnp.abs(r_d)) + jnp.max(jnp.abs(r_p)) + mu
 
 
@@ -150,7 +179,7 @@ def solve_qp_pdipm(
     G: Array,
     h: Array,
     warm_start: Optional[PdipmState] = None,
-    max_iter: int = 25,
+    max_iter: int = DEFAULT_MAX_ITER,
     tol: float = 1e-6,
 ) -> Tuple[Array, Array, PdipmState]:
     """Mehrotra predictor-corrector PDIPM for min 0.5 x^T P x + q^T x s.t. G x <= h.
@@ -161,7 +190,14 @@ def solve_qp_pdipm(
     fixed for the remaining iterations rather than stepping further. This
     prevents a degenerate (s ≈ 0, lam ≈ 0) post-convergence state from
     propagating NaN through ``lam/s`` divisions in subsequent iterations.
-    The total flop count is still ``max_iter`` Newton solves per call.
+    The total flop count is still ``max_iter`` Newton solves per call, which
+    is why ``max_iter`` defaults to the tight ``DEFAULT_MAX_ITER`` rather than
+    a loose upper bound; raise it for QPs harder than the CBF-QP shapes it was
+    calibrated on (see that constant for the measurements).
+
+    ``fori_loop`` is deliberate and load-bearing: ``lax.while_loop`` has no
+    reverse-mode differentiation rule, and downstream differentiable-CBF-QP
+    work takes ``jax.grad`` through this solver.
 
     Returns:
         (x, status, state) where status is:
@@ -193,8 +229,10 @@ def solve_qp_pdipm(
     # --- Outer loop (fixed iterations, freeze-on-converge) ---
     def body(_, carry):
         x_, s_, lam_ = carry
-        already_converged = _combined_residual(P, q, G, h, x_, s_, lam_) < tol
-        x_new, s_new, lam_new = _pdipm_iteration(P, q, G, h, x_, s_, lam_)
+        # One residual evaluation feeds both the convergence test and the step.
+        r_d, r_p = _residuals(P, q, G, h, x_, s_, lam_)
+        already_converged = _combined_residual(r_d, r_p, s_, lam_) < tol
+        x_new, s_new, lam_new = _pdipm_iteration(P, G, x_, s_, lam_, r_d, r_p)
         # If already converged, keep current (good) state rather than stepping.
         # Both branches of jnp.where are traced; the step is cheap relative to
         # the cost of NaN propagation if we let lam/s explode after convergence.
@@ -206,7 +244,8 @@ def solve_qp_pdipm(
     x_final, s_final, lam_final = lax.fori_loop(0, max_iter, body, (x0, s0, lam0))
 
     # --- Status: solved if final residual norm below tol ---
-    res_norm = _combined_residual(P, q, G, h, x_final, s_final, lam_final)
+    r_d_final, r_p_final = _residuals(P, q, G, h, x_final, s_final, lam_final)
+    res_norm = _combined_residual(r_d_final, r_p_final, s_final, lam_final)
     status = jnp.where(res_norm < tol, jnp.int32(1), jnp.int32(2))
 
     state = PdipmState(x=x_final, s=s_final, dual=lam_final, iter_num=max_iter)

--- a/src/cbfkit/optimization/quadratic_program/solver_registry.py
+++ b/src/cbfkit/optimization/quadratic_program/solver_registry.py
@@ -3,6 +3,19 @@
 Provides a common ``QpSolution`` return type and factory functions that wrap
 each backend (jaxopt, cvxopt, casadi) behind a single callable signature.
 
+**Objective convention.** Every solver returned by :func:`get_solver` solves
+
+.. math::
+
+    \\min_x \\; x^T H x + f^T x \\quad \\text{s.t.} \\quad G x \\le h \\;(, A x = b)
+
+This matches the CBF-CLF-QP generator, which passes ``f = -2 H u_nom`` so the
+unconstrained minimizer is ``u_nom``.  Backends whose native form is
+``min 1/2 x^T P x + q^T x`` (OSQP, CVXOPT, PDIPM) are adapted at this boundary
+(``P = 2 H`` or equivalently ``q = f/2``); the raw modules
+(``qp_solver_pdipm.solve_qp_pdipm``, ``qp_solver_cvxopt.solve``) keep their
+native halved convention.
+
 Usage::
 
     from cbfkit.optimization.quadratic_program import get_solver
@@ -168,7 +181,7 @@ def casadi_solver() -> QpSolverCallable:
 # ---------------------------------------------------------------------------
 
 
-def fast_solver(max_iter: int = 25, tol: float = 1e-6) -> QpSolverCallable:
+def fast_solver(max_iter: Optional[int] = None, tol: float = 1e-6) -> QpSolverCallable:
     """Fast PDIPM solver for small CBF-CLF problems.
 
     Mehrotra predictor-corrector primal-dual interior-point method. Designed
@@ -181,14 +194,23 @@ def fast_solver(max_iter: int = 25, tol: float = 1e-6) -> QpSolverCallable:
     (see ``benchmarks/qp_solver_comparison.py``). JIT-compatible and
     warm-startable across consecutive control steps.
 
+    Inequality constraints only: passing ``a_mat``/``b_vec`` raises
+    ``NotImplementedError`` rather than dropping them.
+
     Args:
-        max_iter: Maximum PDIPM iterations (default 25; ~10-15 typically suffice).
+        max_iter: Maximum PDIPM iterations. ``None`` (default) defers to
+            ``qp_solver_pdipm.DEFAULT_MAX_ITER`` so the solver's calibrated
+            budget is not silently pinned here.
         tol: Combined primal/dual/complementarity residual tolerance.
     """
     from cbfkit.optimization.quadratic_program.qp_solver_pdipm import (
+        DEFAULT_MAX_ITER,
         PdipmState,
         solve_qp_pdipm,
     )
+
+    if max_iter is None:
+        max_iter = DEFAULT_MAX_ITER
 
     def solve_with_details(
         h_mat: Array,
@@ -199,8 +221,19 @@ def fast_solver(max_iter: int = 25, tol: float = 1e-6) -> QpSolverCallable:
         b_vec: Optional[Array] = None,
         init_params: Any = None,
     ) -> QpSolution:
+        if a_mat is not None or b_vec is not None:
+            raise NotImplementedError(
+                "The 'fast' (PDIPM) backend solves inequality-constrained QPs only "
+                "(min x'Hx + f'x s.t. Gx <= h), but was given equality constraints "
+                "via a_mat/b_vec. Silently dropping them would return a solution "
+                "that violates Ax = b — e.g. an MPC trajectory ignoring its own "
+                "dynamics. Use get_solver('jaxopt') or get_solver('casadi'), which "
+                "support equality constraints."
+            )
+
         if g_mat is None or h_vec is None:
-            x = jnp.linalg.solve(h_mat, -f_vec)
+            # Registry convention min x'Hx + f'x  =>  2H x* = -f.
+            x = jnp.linalg.solve(2.0 * h_mat, -f_vec)
             return QpSolution(primal=x, status=1, params=None)
 
         # Extract warm-start state from previous QpSolution.params
@@ -213,8 +246,11 @@ def fast_solver(max_iter: int = 25, tol: float = 1e-6) -> QpSolverCallable:
             elif isinstance(init_params, PdipmState):
                 warm = init_params
 
+        # Convention adapter: solve_qp_pdipm natively solves
+        # min 1/2 x'Px + q'x; the registry convention is min x'Hx + f'x,
+        # so pass P = 2H (the jaxopt wrapper adapts via q = f/2 instead).
         sol, status, state = solve_qp_pdipm(
-            h_mat,
+            2.0 * h_mat,
             f_vec,
             g_mat,
             h_vec,

--- a/src/cbfkit/sensors/__init__.py
+++ b/src/cbfkit/sensors/__init__.py
@@ -1,3 +1,3 @@
-from .full_state import perfect, unbiased_gaussian_noise
+from .full_state import perfect, unbiased_gaussian_noise, unbiased_gaussian_noise_factory
 
-__all__ = ["perfect", "unbiased_gaussian_noise"]
+__all__ = ["perfect", "unbiased_gaussian_noise", "unbiased_gaussian_noise_factory"]

--- a/src/cbfkit/sensors/full_state.py
+++ b/src/cbfkit/sensors/full_state.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 import jax.numpy as jnp
 from jax import Array, lax, random
 
-from cbfkit.utils.user_types import Key, Time
+from cbfkit.utils.user_types import Key, SensorCallable, Time
 
 
 def perfect(
@@ -76,3 +76,63 @@ def unbiased_gaussian_noise(
     sampled_random_vector = sampled_random_vector.reshape(x.shape)
 
     return x + sampled_random_vector
+
+
+def unbiased_gaussian_noise_factory(sigma: Array) -> SensorCallable:
+    """Builds an `unbiased_gaussian_noise`-equivalent sensor with the Cholesky factor
+    of `sigma` precomputed at construction time.
+
+    `unbiased_gaussian_noise` re-derives the Cholesky factor of `sigma` (and re-evaluates
+    the noise/no-noise branch via `lax.cond`) on every call, even though `sigma` is fixed
+    for the lifetime of a simulation run. This factory takes `sigma` once, resolves both
+    at build time, and returns a per-step callable whose hot path is just a matrix-vector
+    product -- matching the factory pattern used for controllers/planners elsewhere in
+    this codebase.
+
+    Args:
+        sigma (Array): measurement model covariance matrix, fixed for the lifetime of
+            the returned sensor.
+
+    Returns
+    -------
+        sensor (SensorCallable): callable with signature `(t, x, *, sigma=None, key=None,
+            **kwargs) -> Array`. The `sigma` keyword is accepted only for interface
+            compatibility with `SensorCallable`/the simulator's call convention -- it is
+            ignored, and the covariance captured at construction time is always used.
+    """
+    dim = sigma.shape[0]
+    has_noise = bool(jnp.trace(jnp.abs(sigma)) > 0)
+    chol = jnp.linalg.cholesky(sigma) if has_noise else jnp.zeros(sigma.shape)
+
+    def sensor(
+        t: Time,
+        x: Array,
+        *,
+        sigma: Optional[Array] = None,
+        key: Optional[Key] = None,
+        **kwargs: Any,
+    ) -> Array:
+        """Senses the state subject to additive, unbiased Gaussian noise with the
+        covariance fixed at factory-build time.
+
+        Args:
+            t (float): time (sec), unused
+            x (Array): state vector (ground truth)
+            sigma: unused -- accepted for `SensorCallable` compatibility only; the
+                covariance baked in by `unbiased_gaussian_noise_factory` is always used.
+            key (Key): PRNG key
+
+        Returns
+        -------
+            y (Array): measurement of full state vector
+        """
+        del t, sigma
+        if key is None:
+            key = random.PRNGKey(0)  # type: ignore[assignment]
+
+        z = random.normal(key, shape=(dim,))
+        sampled_random_vector = jnp.dot(chol, z).reshape(x.shape)
+
+        return x + sampled_random_vector
+
+    return sensor

--- a/src/cbfkit/simulation/backend.py
+++ b/src/cbfkit/simulation/backend.py
@@ -1,10 +1,10 @@
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import jax.numpy as jnp
 from jax import Array, random
 
 from cbfkit.simulation.integration_utils import integrate_with_cached_dynamics
-from cbfkit.simulation.utils import SimulationStepData, resolve_nominal_control
+from cbfkit.simulation.utils import resolve_nominal_control
 from cbfkit.utils.user_types import (
     Control,
     ControllerCallable,
@@ -71,12 +71,16 @@ def stepper(
             planner_data = PlannerData()
 
         nonlocal key
-        key, _ = random.split(key)  # type: ignore
+        # One split per step, handing a dedicated subkey to each consumer. The
+        # JIT backend (simulator_jit._advance) derives its subkeys the same way
+        # in the same order, and test_rng_consistency pins the two streams
+        # together -- change one scheme and you must change the other.
+        key, sensor_key, planner_key, nom_key, ctrl_key, pert_key = random.split(key, 6)  # type: ignore
 
         if z is None:
             z = x
 
-        y = sensor(t, x, sigma=sigma, key=key)
+        y = sensor(t, x, sigma=sigma, key=sensor_key)
         # Handle both 2-tuple (z, c) and 3-tuple (z, c, K) returns from estimator
         est_result = estimator(t, y, z, u, c)
         if len(est_result) == 3:
@@ -98,7 +102,6 @@ def stepper(
             planner_data = planner_data._replace(prev_robustness=None)
 
         if planner is not None:
-            key, planner_key = random.split(key)  # type: ignore
             u_planner, planner_data = planner(t, z, None, planner_key, planner_data)
             if planner_data.error:
                 return (
@@ -113,11 +116,11 @@ def stepper(
             u_planner = jnp.zeros(g.shape[1])
             planner_data = planner_data._replace(u_traj=None)
 
-        u, key = resolve_nominal_control(
+        u = resolve_nominal_control(
             t,
             z,
             dt,
-            key,
+            nom_key,
             g,
             nominal_controller,
             planner_data,
@@ -125,7 +128,6 @@ def stepper(
             has_planner=(planner is not None),
         )
 
-        key, ctrl_key = random.split(key)  # type: ignore
         if controller is not None:
             u, controller_data = controller(t, z, u, ctrl_key, controller_data)
             if controller_data.error:
@@ -150,9 +152,7 @@ def stepper(
             controller_data = ControllerData()
 
         p = perturbation(x, u, f, g)
-        key, subkey = random.split(key)  # type: ignore
-
-        p_val = p(subkey)
+        p_val = p(pert_key)
         x = integrate_with_cached_dynamics(
             x=x,
             u=u,

--- a/src/cbfkit/simulation/monte_carlo_gpu.py
+++ b/src/cbfkit/simulation/monte_carlo_gpu.py
@@ -14,10 +14,17 @@ import jax.numpy as jnp
 from jax import lax, random
 
 from cbfkit.simulation.simulator_jit import _make_scan_step
+
+# Re-exported for external consumers (benchmarks/scenario_builders.py imports
+# these from here); "unused" only from this module's own perspective.
+from cbfkit.simulation.status import (  # noqa: F401
+    _default_estimator,
+    _default_perturbation,
+    _default_sensor,
+)
 from cbfkit.utils.user_types import (
     ControllerCallable,
     ControllerData,
-    Covariance,
     DynamicsCallable,
     EstimatorCallable,
     IntegratorCallable,
@@ -60,13 +67,6 @@ class MonteCarloGPUResults(NamedTuple):
     n_trials: int
 
 
-from cbfkit.simulation.status import (
-    _default_sensor,
-    _default_estimator,
-    _default_perturbation,
-)
-
-
 def conduct_monte_carlo_gpu(
     setup: MonteCarloSetup,
     n_trials: int,
@@ -93,7 +93,10 @@ def conduct_monte_carlo_gpu(
     sampler_keys = random.split(random.fold_in(master_key, 1), n_trials)
     initial_states = jax.vmap(setup.initial_state_sampler)(sampler_keys)
 
-    # Build the vmap-safe scan step (no debug callbacks)
+    # Build the vmap-safe scan step (no debug callbacks). The estimate and
+    # covariance are dropped from the emitted outputs: this function keeps only
+    # states, controls and the two data pytrees, and stacking the covariance
+    # costs (n_trials, num_steps, n, n) of device memory for nothing.
     scan_step = _make_scan_step(
         dynamics=setup.dynamics,
         integrator=setup.integrator,
@@ -109,6 +112,7 @@ def conduct_monte_carlo_gpu(
         enable_debug=False,
         progress_callback=None,
         progress_interval=1,
+        emit_estimates=False,
     )
 
     # Probe dimensions from dynamics
@@ -133,27 +137,27 @@ def conduct_monte_carlo_gpu(
             c0,
             setup.controller_data,
             setup.planner_data,
+            jnp.asarray(False),  # stopped
         )
 
         _final_carry, trajectory = lax.scan(scan_step, carry_init, jnp.arange(setup.num_steps))
         return trajectory
 
-    # JIT-compile the vmapped function
-    batched_fn = jax.jit(jax.vmap(single_trajectory, in_axes=(0, 0)))
+    # Compile ahead of time so the batch is *executed* exactly once: calling the
+    # jitted function to warm it up would run all n_trials trajectories, and the
+    # timed call would then run them a second time (doubling both wall time and
+    # peak memory, while reporting only half the cost).
+    compiled_fn = (
+        jax.jit(jax.vmap(single_trajectory, in_axes=(0, 0))).lower(keys, initial_states).compile()
+    )
 
-    # Warmup: compile without timing
-    _ = batched_fn(keys, initial_states)
-    # Block until compilation + execution finishes
-    jax.block_until_ready(_)
-
-    # Timed run
     start = time.perf_counter()
-    trajectory = batched_fn(keys, initial_states)
+    trajectory = compiled_fn(keys, initial_states)
     # Force synchronization for accurate timing
     jax.block_until_ready(trajectory)
     wall_time = time.perf_counter() - start
 
-    xs, us, zs, cs, c_datas, p_datas = trajectory
+    xs, us, c_datas, p_datas = trajectory
 
     return MonteCarloGPUResults(
         states=xs,
@@ -200,7 +204,7 @@ def conduct_monte_carlo_gpu_multiseed(
 
     initial_states = jax.vmap(setup.initial_state_sampler)(all_sampler_keys)
 
-    # Build the vmap-safe scan step
+    # Build the vmap-safe scan step (estimate/covariance not emitted; see above)
     scan_step = _make_scan_step(
         dynamics=setup.dynamics,
         integrator=setup.integrator,
@@ -216,6 +220,7 @@ def conduct_monte_carlo_gpu_multiseed(
         enable_debug=False,
         progress_callback=None,
         progress_interval=1,
+        emit_estimates=False,
     )
 
     # Probe dimensions
@@ -237,25 +242,29 @@ def conduct_monte_carlo_gpu_multiseed(
             c0,
             setup.controller_data,
             setup.planner_data,
+            jnp.asarray(False),  # stopped
         )
         _final_carry, trajectory = lax.scan(scan_step, carry_init, jnp.arange(setup.num_steps))
         return trajectory
 
-    batched_fn = jax.jit(jax.vmap(single_trajectory, in_axes=(0, 0)))
+    # Compile without executing, then execute once (see conduct_monte_carlo_gpu).
+    compiled_fn = (
+        jax.jit(jax.vmap(single_trajectory, in_axes=(0, 0)))
+        .lower(all_keys, initial_states)
+        .compile()
+    )
 
-    # Warmup (single JIT compilation for all seeds)
-    _ = batched_fn(all_keys, initial_states)
-    jax.block_until_ready(_)
-
-    # Timed run
     start = time.perf_counter()
-    trajectory = batched_fn(all_keys, initial_states)
+    trajectory = compiled_fn(all_keys, initial_states)
     jax.block_until_ready(trajectory)
     wall_time = time.perf_counter() - start
 
-    xs, us, zs, cs, c_datas, p_datas = trajectory
+    xs, us, c_datas, p_datas = trajectory
 
-    # Split results back into per-seed MonteCarloGPUResults
+    # Split results back into per-seed MonteCarloGPUResults.
+    # All seeds run inside one batched kernel, so there is no independently
+    # measurable per-seed time: this is that single execution's wall time
+    # amortised over the seeds, and the per-seed values sum to the real total.
     per_seed_time = wall_time / n_seeds
     results = []
     for i in range(n_seeds):

--- a/src/cbfkit/simulation/simulator.py
+++ b/src/cbfkit/simulation/simulator.py
@@ -9,9 +9,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 import os
 import time
 
-import jax
 import jax.numpy as jnp
-import jax.tree_util
 import numpy as np
 from jax import Array, random
 
@@ -38,7 +36,7 @@ from .callbacks import LoggingCallback, ProgressCallback, SimulationCallback
 from .formatting import format_return_data
 from .simulator_jit import INTEGRATION_NAN_ERROR, simulator_jit
 from .status import (
-    SOLVER_STATUS_MAP,
+    SOLVER_STATUS_MAP,  # noqa: F401  (re-exported; external code imports it from here)
     _check_simulation_status,
     _default_estimator,
     _default_perturbation,
@@ -47,6 +45,44 @@ from .status import (
 )
 from .ui import create_progress, print_jit_status
 from .utils import SimulationStepData
+
+
+class _JitProgressHook:
+    """Host-side progress callback whose identity is stable across ``execute()`` calls.
+
+    ``simulator_jit`` takes ``progress_callback`` as a static argument, so a
+    fresh closure per call would miss the JIT cache and recompile the whole
+    simulation every run. A single instance is reused instead and re-bound to
+    the live progress bar before each run; the compiled computation captures
+    this object once and calls through to whichever bar is currently bound.
+    """
+
+    __slots__ = ("_bar", "_task_id", "_last_step")
+
+    def __init__(self) -> None:
+        self._bar: Any = None
+        self._task_id: Any = None
+        self._last_step: int = -1
+
+    def bind(self, bar: Any, task_id: Any) -> None:
+        self._bar = bar
+        self._task_id = task_id
+        self._last_step = -1
+
+    def unbind(self) -> None:
+        self._bar = None
+        self._task_id = None
+
+    def __call__(self, step_idx: int) -> None:
+        if self._bar is None or self._task_id is None:
+            return
+        step_delta = step_idx - self._last_step
+        if step_delta > 0:
+            self._bar.update(self._task_id, advance=step_delta)
+            self._last_step = step_idx
+
+
+_JIT_PROGRESS_HOOK = _JitProgressHook()
 
 
 def simulator(
@@ -64,6 +100,7 @@ def simulator(
     key: Array,
     callbacks: Optional[List[SimulationCallback]] = None,
     stl_trajectory_cost: Optional[StlTrajectoryCostCallable] = None,
+    log_planner_samples: bool = False,
 ) -> Callable[
     [Array, Optional[ControllerData], Optional[PlannerData]],
     Iterator[SimulationStepData],
@@ -160,9 +197,19 @@ def simulator(
                 xs_buf = xs_buf.at[:, s + 1].set(x)
                 planner_data = planner_data._replace(xs=xs_buf[:, : s + 2])
 
-            # Strip sampled_x_traj before logging to avoid accumulating
-            # massive MPPI sample arrays (num_samples * state_dim * horizon per step)
-            planner_data_for_log = planner_data._replace(sampled_x_traj=None)
+            # Strip the fields that must not accumulate before logging:
+            # sampled_x_traj holds a full MPPI sample batch (num_samples *
+            # state_dim * horizon) per step, and xs is a growing slice of the
+            # trajectory buffer, so retaining one per step costs O(N^2) memory.
+            # Both are still carried on planner_data for the next step; xs is
+            # also dropped by format_return_data for having inconsistent shapes.
+            # log_planner_samples opts the sample batch back in for callers that
+            # animate the rollout cloud; xs is dropped either way.
+            planner_data_for_log = (
+                planner_data._replace(xs=None)
+                if log_planner_samples
+                else planner_data._replace(sampled_x_traj=None, xs=None)
+            )
 
             # Use the list for step data to avoid JAX array overhead for logging
             step_data = SimulationStepData(
@@ -235,12 +282,25 @@ def execute(
     use_jit: Union[bool, str] = "auto",
     jit_progress: bool = False,
     jit_progress_interval: int = 50,
+    log_planner_samples: bool = False,
 ) -> SimulationResults:
     """Executes a complete simulation of the dynamical system.
 
     This function runs the simulation for `num_steps` starting from `x0`.
     It can execute either in a standard Python loop or using JAX JIT compilation
     for performance.
+
+    Build once, call many
+    ---------------------
+    On the JIT path the component callables (``dynamics``, ``integrator``,
+    ``planner``, ``nominal_controller``, ``controller``, ``sensor``,
+    ``estimator``, ``perturbation``) are static arguments, so their *identity*
+    keys the JIT cache along with ``num_steps`` and ``jit_progress_interval``.
+    Build each component once and reuse those objects across calls: rebuilding
+    them per call -- for example calling a generator factory inside a sweep loop
+    -- produces a fresh object every time and recompiles the whole simulation on
+    every run. Array arguments (``x0``, ``sigma``, ``key``, initial data) may
+    vary freely without recompiling.
 
     Args:
         x0 (State): Initial state vector.
@@ -277,6 +337,11 @@ def execute(
             Disabled by default to avoid overhead; requires `verbose=True` to display.
         jit_progress_interval (int, optional): Number of steps between progress updates when
             `jit_progress` is enabled. Defaults to 50.
+        log_planner_samples (bool, optional): Retain ``PlannerData.sampled_x_traj`` in the
+            returned planner values. Off by default because one MPPI sample batch per step
+            (``n_samples * state_dim * horizon``) dwarfs the trajectory -- roughly 320 MB for
+            1000 samples over a 200-step run. Enable it to animate the MPPI rollout cloud;
+            the two ``examples/unicycle/reach_goal`` MPPI scripts do exactly that.
 
     Returns
     -------
@@ -419,15 +484,9 @@ def execute(
             progress_bar = create_progress(total=num_steps, description="JIT Simulation")
             progress_bar.start()
             progress_task_id = progress_bar.add_task("JIT Simulation", total=num_steps)
-            last_step_reported = -1
-
-            def progress_hook(step_idx: int) -> None:
-                nonlocal last_step_reported
-                if progress_bar is not None and progress_task_id is not None:
-                    step_delta = step_idx - last_step_reported
-                    if step_delta > 0:
-                        progress_bar.update(progress_task_id, advance=step_delta)
-                        last_step_reported = step_idx
+            # Reuse the shared hook so repeated runs hit the same JIT cache entry.
+            progress_hook = _JIT_PROGRESS_HOOK
+            progress_hook.bind(progress_bar, progress_task_id)
 
         if verbose:
             print_jit_status("Warming up JIT...")
@@ -436,8 +495,12 @@ def execute(
 
         if planner is not None:
             _, p_data = planner(0.0, x0, None, prime_key1, p_data)  # type: ignore
-            # Strip sampled_x_traj from p_data to avoid carrying it in JIT loop
-            p_data = p_data._replace(sampled_x_traj=None)
+            # Strip sampled_x_traj from p_data to avoid carrying it in JIT loop.
+            # When the caller opted in, the priming call above is what gives the
+            # initial carry a correctly shaped sample batch instead of None --
+            # the scan carry cannot start as None and later hold an array.
+            if not log_planner_samples:
+                p_data = p_data._replace(sampled_x_traj=None)
 
         if controller is not None:
             u_nom_dummy = jnp.zeros((g_check.shape[1],))
@@ -460,35 +523,41 @@ def execute(
                 )
 
         start_time = time.time()
-        xs, us, zs, cs, c_datas, p_datas = simulator_jit(
-            dt=dt,
-            num_steps=num_steps,
-            dynamics=dynamics,
-            integrator=integrator,
-            planner=planner,
-            nominal_controller=nominal_controller,
-            controller=controller,
-            sensor=_sensor,
-            estimator=_estimator,
-            perturbation=_perturbation,
-            sigma=sigma_val,
-            key=key,  # type: ignore
-            initial_state=x0,
-            initial_controller_data=c_data,
-            initial_planner_data=p_data,
-            initial_covariance=initial_covariance,
-            progress_callback=progress_hook,
-            progress_interval=jit_progress_interval,
-        )
-        # Ensure progress callbacks flush before printing completion.
-        xs.block_until_ready()
+        try:
+            xs, us, zs, cs, c_datas, p_datas = simulator_jit(
+                dt=dt,
+                num_steps=num_steps,
+                dynamics=dynamics,
+                integrator=integrator,
+                planner=planner,
+                nominal_controller=nominal_controller,
+                controller=controller,
+                sensor=_sensor,
+                estimator=_estimator,
+                perturbation=_perturbation,
+                sigma=sigma_val,
+                key=key,  # type: ignore
+                initial_state=x0,
+                initial_controller_data=c_data,
+                initial_planner_data=p_data,
+                initial_covariance=initial_covariance,
+                progress_callback=progress_hook,
+                progress_interval=jit_progress_interval,
+                log_planner_samples=log_planner_samples,
+            )
+            # Ensure progress callbacks flush before printing completion.
+            xs.block_until_ready()
+        finally:
+            # The hook is a module-level singleton (stable identity for the JIT
+            # cache); unbind on every exit so an exception mid-run cannot leave
+            # it bound to a dead progress bar.
+            if progress_bar is not None:
+                progress_bar.stop()
+                _JIT_PROGRESS_HOOK.unbind()
         elapsed = time.time() - start_time
 
         if verbose:
             print_jit_status(f"JIT execution completed in {elapsed:.4f}s.")
-
-        if progress_bar is not None:
-            progress_bar.stop()
 
         # If logging was requested, we must simulate the callbacks behavior
         if logging_callback:
@@ -614,6 +683,7 @@ def execute(
         key=key,  # type: ignore
         callbacks=callbacks,
         stl_trajectory_cost=stl_trajectory_cost,
+        log_planner_samples=log_planner_samples,
     )
 
     # Run simulation from initial state

--- a/src/cbfkit/simulation/simulator_jit.py
+++ b/src/cbfkit/simulation/simulator_jit.py
@@ -43,23 +43,53 @@ def _make_scan_step(
     enable_debug=True,
     progress_callback=None,
     progress_interval=1,
+    emit_estimates=True,
+    log_planner_samples=False,
 ):
     """Factory that builds the lax.scan step function.
 
     When ``enable_debug=False``, host-side callbacks (NaN warning print and
     progress reporting) are omitted, making the returned ``scan_step``
     compatible with ``jax.vmap``.
+
+    ``log_planner_samples`` controls whether ``PlannerData.sampled_x_traj`` --
+    one MPPI sample batch of shape ``(n_samples * state_dim, horizon)`` --
+    survives the step. It is dropped by default: stacking it over the horizon
+    dwarfs the trajectory itself (~320 MB for 1000 samples over 200 steps). Set
+    it to ``True`` when a caller needs the rollout cloud, e.g. to animate the
+    full-horizon MPPI overlay. The flag applies to the carry and the emitted
+    output together, never one alone: the ``_held`` and ``_advance`` branches of
+    the stop gate must return the same pytree structure, so a stripped carry
+    paired with a populated output would be a structure mismatch. When it is
+    ``True`` the initial carry's ``planner_data.sampled_x_traj`` must therefore
+    be a correctly shaped array rather than ``None``.
+
+    When ``emit_estimates=False``, the estimate ``z`` and covariance ``c`` are
+    still carried (the estimator needs them) but are not emitted as per-step
+    scan outputs, so ``lax.scan`` does not stack them over the horizon. Callers
+    that discard them -- the vmapped Monte Carlo path -- then avoid
+    materialising ``(num_steps, n)`` and ``(num_steps, n, n)`` buffers per
+    trajectory. The emitted tuple is ``(x, u, controller_data, planner_data)``
+    instead of ``(x, u, z, c, controller_data, planner_data)``.
+
+    The carry holds a ``stopped`` flag: once a step reports goal completion, a
+    controller/planner error, or a NaN, every later step skips the whole
+    pipeline and re-emits the held values. Under ``jax.vmap`` the gate lowers to
+    a select, so both branches still execute per lane and only the emitted
+    values change; the held branch keeps the last valid (finite) values, so a
+    lane that has stopped contributes no new data.
     """
 
-    def scan_step(carry, step_idx):
-        # Unpack carry
-        key, t, x, u, z, c, controller_data, planner_data = carry
-
-        # Split key for this step
-        key, subkey = random.split(key)
+    def _advance(key, t, x, u, z, c, controller_data, planner_data, stopped):
+        """Run one full pipeline step and return the next carry values."""
+        # One split per step, handing a dedicated subkey to each consumer. The
+        # eager backend (backend.py) derives its subkeys the same way in the
+        # same order, and test_rng_consistency pins the two streams together --
+        # change one scheme and you must change the other.
+        key, sensor_key, planner_key, nom_key, ctrl_key, pert_key = random.split(key, 6)
 
         # 1. Sensor
-        y = sensor(t, x, sigma=sigma, key=key)
+        y = sensor(t, x, sigma=sigma, key=sensor_key)
 
         # 2. Estimator - handle both 2-tuple (z, c) and 3-tuple (z, c, K) returns
         est_result = estimator(t, y, z, u, c)
@@ -73,18 +103,17 @@ def _make_scan_step(
 
         # 4. Planner
         if planner is not None:
-            key, planner_key = random.split(key)
             # Note: We assume planner signature matches and is JIT-able
             u_planner, planner_data = planner(t, z, None, planner_key, planner_data)
         else:
             u_planner = jnp.zeros((g.shape[1],))
 
         # 5. Resolve nominal control from planner output
-        u_nom, key = resolve_nominal_control(
+        u_nom = resolve_nominal_control(
             t,
             z,
             dt,
-            key,
+            nom_key,
             g,
             nominal_controller,
             planner_data,
@@ -93,7 +122,6 @@ def _make_scan_step(
         )
 
         # 6. Controller (CBF/CLF filter)
-        key, ctrl_key = random.split(key)
         if controller is not None:
             u, controller_data = controller(t, z, u_nom, ctrl_key, controller_data)
         else:
@@ -109,12 +137,11 @@ def _make_scan_step(
         # 7. Perturbation and integration (skipped if stopped)
         def _integrate(_):
             p = perturbation(x, u, f, g)
-            key_int, subkey = random.split(key)
 
             # Evaluate perturbation once per step.
             # This avoids repeated calls inside vector_field (e.g., 4 times for RK4),
             # reducing graph size and runtime if p is complex.
-            p_val = p(subkey)
+            p_val = p(pert_key)
             x_next = integrate_with_cached_dynamics(
                 x=x,
                 u=u,
@@ -126,12 +153,12 @@ def _make_scan_step(
                 perturbation_value=p_val,
                 perturbation_is_increment=getattr(perturbation, "is_increment", False),
             )
-            return key_int, x_next
+            return x_next
 
-        def _hold(_):
-            return key, x
+        def _skip_integration(_):
+            return x
 
-        key, x_next_candidate = lax.cond(stop, _hold, _integrate, operand=None)
+        x_next_candidate = lax.cond(stop, _skip_integration, _integrate, operand=None)
 
         # Check for NaNs in the next state to prevent divergent simulation
         nan_in_next = jnp.any(jnp.isnan(x_next_candidate))
@@ -162,7 +189,47 @@ def _make_scan_step(
                 lambda: None,
             )
 
+        # Strip sampled_x_traj from carry to save bandwidth/memory. Retained
+        # verbatim when the caller opted in, so the carry and the emitted output
+        # agree with the initial carry's structure.
+        if not log_planner_samples:
+            planner_data = planner_data._replace(sampled_x_traj=None)
+
+        # Latch the stop flag so every later step takes the held branch.
+        stop_next = stopped | jnp.asarray(stop) | nan_in_next
+
+        return (key, x_next, u, z, c, controller_data, planner_data, stop_next)
+
+    def scan_step(carry, step_idx):
+        # Unpack carry
+        key, t, x, u, z, c, controller_data, planner_data, stopped = carry
+
+        # `stopped` is False on the first step, so the pipeline always runs at
+        # least once. Both branches return the carry leaves, whose avals lax.scan
+        # already pins to the incoming carry, so the structures agree by
+        # construction.
+        def _held(_):
+            return (key, x, u, z, c, controller_data, planner_data, stopped)
+
+        (
+            key_next,
+            x_next,
+            u,
+            z,
+            c,
+            controller_data,
+            planner_data,
+            stop_next,
+        ) = lax.cond(
+            stopped,
+            _held,
+            lambda _: _advance(key, t, x, u, z, c, controller_data, planner_data, stopped),
+            operand=None,
+        )
+
         if enable_debug and progress_callback is not None and progress_interval > 0:
+            # Reported outside the stop gate so the progress bar still reaches
+            # the end of the horizon after an early stop.
             should_report = jnp.logical_or(
                 step_idx == num_steps - 1, step_idx % progress_interval == 0
             )
@@ -181,9 +248,17 @@ def _make_scan_step(
         t_next = t + dt
 
         # Pack carry
-        # Strip sampled_x_traj from carry to save bandwidth/memory
-        planner_data_carry = planner_data._replace(sampled_x_traj=None)
-        new_carry = (key, t_next, x_next, u, z, c, controller_data, planner_data_carry)
+        new_carry = (
+            key_next,
+            t_next,
+            x_next,
+            u,
+            z,
+            c,
+            controller_data,
+            planner_data,
+            stop_next,
+        )
 
         # Output (trajectory)
         # Strip solver_params from logged data to save memory
@@ -194,7 +269,14 @@ def _make_scan_step(
             del log_sub_data["solver_params"]
             log_controller_data = controller_data._replace(sub_data=log_sub_data)
 
-        output = (x, u, z, c, log_controller_data, planner_data)
+        # planner_data here is whatever _advance/_held produced, so its
+        # sampled_x_traj follows log_planner_samples: absent by default, stacked
+        # to (num_steps, n_samples * state_dim, horizon) when opted in. The
+        # eager path applies the same rule before logging.
+        if emit_estimates:
+            output = (x, u, z, c, log_controller_data, planner_data)
+        else:
+            output = (x, u, log_controller_data, planner_data)
 
         return new_carry, output
 
@@ -215,6 +297,7 @@ def _make_scan_step(
         "progress_callback",
         "num_steps",
         "progress_interval",
+        "log_planner_samples",
     ],
 )
 def simulator_jit(
@@ -236,6 +319,7 @@ def simulator_jit(
     initial_covariance: Optional[Covariance] = None,
     progress_callback: Optional[Callable[[int], None]] = None,
     progress_interval: int = 1,
+    log_planner_samples: bool = False,
 ) -> Tuple[jax.Array, jax.Array, jax.Array, jax.Array, ControllerData, PlannerData]:
     """JIT-compiled simulation loop using jax.lax.scan.
 
@@ -243,6 +327,9 @@ def simulator_jit(
     - planner_data and controller_data must be initialized with JAX-compatible arrays
       (no None) for any fields that will be used/updated.
     - Optional host-side progress reporting can be enabled via `progress_callback`.
+    - When ``log_planner_samples=True``, ``initial_planner_data.sampled_x_traj``
+      must already hold an array of the planner's sample-batch shape, since it
+      becomes part of the scan carry.
 
     Returns
     -------
@@ -266,6 +353,7 @@ def simulator_jit(
         enable_debug=True,
         progress_callback=progress_callback,
         progress_interval=progress_interval,
+        log_planner_samples=log_planner_samples,
     )
 
     # Initialize carry
@@ -291,6 +379,7 @@ def simulator_jit(
         c0,
         initial_controller_data,
         initial_planner_data,
+        jnp.asarray(False),  # stopped: the first step is never gated
     )
 
     # Run scan

--- a/src/cbfkit/simulation/utils.py
+++ b/src/cbfkit/simulation/utils.py
@@ -1,7 +1,7 @@
-from typing import Any, Callable, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, List, NamedTuple, Optional
 
 import jax.numpy as jnp
-from jax import Array, random
+from jax import Array
 
 from cbfkit.utils.user_types import (
     Control,
@@ -31,13 +31,13 @@ def resolve_nominal_control(
     t: Time,
     z: State,
     dt: float,
-    key: Array,
+    nom_key: Array,
     g: Array,
     nominal_controller: Optional[NominalControllerCallable],
     planner_data: PlannerData,
     u_planner: Array,
     has_planner: bool,
-) -> Tuple[Array, Array]:
+) -> Array:
     """Determine the nominal control input from planner output.
 
     Shared by both eager (backend.py) and JIT (simulator_jit.py) paths.
@@ -47,11 +47,15 @@ def resolve_nominal_control(
         2. Planner provided a state trajectory (x_traj) -> track via nominal_controller.
         3. No trajectory -> call nominal_controller with no reference, or zero.
 
+    ``nom_key`` is the caller's per-step subkey for the nominal controller; both
+    backends derive it from a single split at the top of the step, so this
+    function consumes a key rather than advancing one.
+
     Returns:
-        (u_nom, updated_key)
+        u_nom
     """
     if has_planner and planner_data.u_traj is not None:
-        return u_planner, key
+        return u_planner
 
     if planner_data.x_traj is not None:
         if nominal_controller is None:
@@ -64,13 +68,11 @@ def resolve_nominal_control(
         idx = jnp.round(t / dt).astype(int)
         idx = jnp.clip(idx, 0, planner_data.x_traj.shape[1] - 1)
         x_des = planner_data.x_traj[:, idx]
-        key, nom_key = random.split(key)
         u_nom, _ = nominal_controller(t, z, nom_key, x_des)
-        return u_nom, key
+        return u_nom
 
     if nominal_controller is not None:
-        key, nom_key = random.split(key)
         u_nom, _ = nominal_controller(t, z, nom_key, None)
-        return u_nom, key
+        return u_nom
 
-    return jnp.zeros((g.shape[1],)), key
+    return jnp.zeros((g.shape[1],))

--- a/src/cbfkit/utils/animators/animator.py
+++ b/src/cbfkit/utils/animators/animator.py
@@ -367,6 +367,28 @@ class CBFAnimator(_MatplotlibMixin, _PlotlyMixin, _ManimMixin):
         self._y_lim = (float(ys.min()) - margin, float(ys.max()) + margin)
         return self
 
+    # -- per-frame data normalization -----------------------------------
+
+    def _ensure_frame_data_numpy(self) -> None:
+        """Convert every per-frame data source to NumPy, exactly once.
+
+        Frame callbacks index these arrays on every animation frame; a
+        caller-supplied JAX device array would otherwise dispatch a JAX
+        primitive per frame instead of a cheap NumPy slice. Must run before
+        the frame loop starts.
+        """
+        for spec in self._trajectories:
+            if spec["data"] is not None:
+                spec["data"] = np.asarray(spec["data"])
+        for spec in self._agents:
+            if spec["data"] is not None:
+                spec["data"] = np.asarray(spec["data"])
+        for spec in self._predictions:
+            if spec["agent_data"] is not None:
+                spec["agent_data"] = np.asarray(spec["agent_data"])
+            if spec["trajectory_data"] is not None:
+                spec["trajectory_data"] = [np.asarray(t) for t in spec["trajectory_data"]]
+
     # -- prediction computation (shared by both backends) -------------------
 
     def _compute_prediction(self, spec: dict, frame: int):

--- a/src/cbfkit/utils/animators/matplotlib_backend.py
+++ b/src/cbfkit/utils/animators/matplotlib_backend.py
@@ -22,6 +22,8 @@ class _MatplotlibMixin:
     """
 
     def _build_matplotlib(self):
+        self._ensure_frame_data_numpy()
+
         self._fig, self._ax = plt.subplots(figsize=self._config.figsize)
         ax = self._ax
 
@@ -105,17 +107,22 @@ class _MatplotlibMixin:
         self._agent_artists = []
         for spec in self._agents:
             body = Circle(
-                (0, 0), spec["body_radius"],
-                color=spec["body_color"], alpha=spec["body_alpha"],
-                zorder=spec["zorder"], label=spec["label"],
+                (0, 0),
+                spec["body_radius"],
+                color=spec["body_color"],
+                alpha=spec["body_alpha"],
+                zorder=spec["zorder"],
+                label=spec["label"],
             )
             ax.add_patch(body)
 
             zone = None
             if spec["zone_radius"] is not None:
                 zone = Circle(
-                    (0, 0), spec["zone_radius"],
-                    color=spec["zone_color"], alpha=spec["zone_alpha"],
+                    (0, 0),
+                    spec["zone_radius"],
+                    color=spec["zone_color"],
+                    alpha=spec["zone_alpha"],
                     zorder=spec["zorder"] - 1,
                 )
                 ax.add_patch(zone)
@@ -123,7 +130,8 @@ class _MatplotlibMixin:
             trail_line = None
             if spec["trail"]:
                 (trail_line,) = ax.plot(
-                    [], [],
+                    [],
+                    [],
                     spec["trail_style"],
                     color=spec["trail_color"],
                     alpha=spec["trail_alpha"],
@@ -138,8 +146,10 @@ class _MatplotlibMixin:
             ls_map = {"dotted": ":", "dashed": "--", "solid": "-"}
             ls = ls_map.get(spec["linestyle"], spec["linestyle"])
             lc = LineCollection(
-                [], linewidths=spec["linewidth"],
-                linestyles=ls, colors=spec["color"],
+                [],
+                linewidths=spec["linewidth"],
+                linestyles=ls,
+                colors=spec["color"],
                 zorder=spec["zorder"],
             )
             if spec["label"]:

--- a/src/cbfkit/utils/visualizations/plot_mppi_ellipsoid_environment.py
+++ b/src/cbfkit/utils/visualizations/plot_mppi_ellipsoid_environment.py
@@ -1,7 +1,22 @@
 """MPPI trajectory animation in an ellipsoidal obstacle environment."""
 
+import warnings
+
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
+
+_MISSING_SAMPLES_MESSAGE = (
+    "MPPI rollout overlay skipped: sampled rollouts not logged; "
+    "pass log_planner_samples=True to sim.execute to record them."
+)
+
+
+def _lookup_key(keys, *candidates):
+    """Index of the first candidate present in ``keys``, or None if none are."""
+    for candidate in candidates:
+        if candidate in keys:
+            return keys.index(candidate)
+    return None
 
 
 #! PLOTTING
@@ -121,37 +136,36 @@ def animate(
     if backend == "matplotlib":
         fig, ax = animator.build()
 
-        sampled_lines = []
-        for _ in range(mppi_args["plot_samples"]):
-            (line,) = ax.plot([], [], "g", alpha=0.2)
-            sampled_lines.append(line)
-        (selected_line,) = ax.plot([], [], "b", linewidth=2, label="Selected Plan")
+        sampled_idx = _lookup_key(controller_data_keys, "sampled_x_traj", "robot_sampled_states")
+        selected_idx = _lookup_key(controller_data_keys, "x_traj")
 
-        sampled_key = (
-            "sampled_x_traj"
-            if "sampled_x_traj" in controller_data_keys
-            else "robot_sampled_states"
-        )
-        sampled_idx = controller_data_keys.index(sampled_key)
-        selected_idx = controller_data_keys.index("x_traj")
-        state_dim = mppi_args["robot_state_dim"]
+        if sampled_idx is None or selected_idx is None:
+            warnings.warn(_MISSING_SAMPLES_MESSAGE, RuntimeWarning, stacklevel=2)
+        else:
+            sampled_lines = []
+            for _ in range(mppi_args["plot_samples"]):
+                (line,) = ax.plot([], [], "g", alpha=0.2)
+                sampled_lines.append(line)
+            (selected_line,) = ax.plot([], [], "b", linewidth=2, label="Selected Plan")
 
-        def mppi_overlay(frame, _ax):
-            if frame >= len(controller_data_items[sampled_idx]):
-                return []
-            sampled = controller_data_items[sampled_idx][frame]
-            selected = controller_data_items[selected_idx][frame]
+            state_dim = mppi_args["robot_state_dim"]
 
-            for i, line in enumerate(sampled_lines):
-                line.set_data(
-                    sampled[state_dim * i, :],
-                    sampled[state_dim * i + 1, :],
-                )
-            selected_line.set_data(selected[0, :], selected[1, :])
+            def mppi_overlay(frame, _ax):
+                if frame >= len(controller_data_items[sampled_idx]):
+                    return []
+                sampled = controller_data_items[sampled_idx][frame]
+                selected = controller_data_items[selected_idx][frame]
 
-            return sampled_lines + [selected_line]
+                for i, line in enumerate(sampled_lines):
+                    line.set_data(
+                        sampled[state_dim * i, :],
+                        sampled[state_dim * i + 1, :],
+                    )
+                selected_line.set_data(selected[0, :], selected[1, :])
 
-        animator.on_frame(mppi_overlay)
+                return sampled_lines + [selected_line]
+
+            animator.on_frame(mppi_overlay)
 
     if save_animation:
         animator.save(animation_filename)

--- a/src/cbfkit/utils/visualizations/plot_mppi_ffmpeg.py
+++ b/src/cbfkit/utils/visualizations/plot_mppi_ffmpeg.py
@@ -1,7 +1,22 @@
 """MPPI trajectory animation with circle obstacles."""
 
+import warnings
+
 import matplotlib.pyplot as plt
 import numpy as np
+
+_MISSING_SAMPLES_MESSAGE = (
+    "MPPI rollout overlay skipped: sampled rollouts not logged; "
+    "pass log_planner_samples=True to sim.execute to record them."
+)
+
+
+def _lookup_key(keys, *candidates):
+    """Index of the first candidate present in ``keys``, or None if none are."""
+    for candidate in candidates:
+        if candidate in keys:
+            return keys.index(candidate)
+    return None
 
 
 class circle:
@@ -100,35 +115,38 @@ def animate(
     if backend == "matplotlib":
         fig, ax = animator.build()
 
-        sampled_lines = []
-        for _ in range(mppi_args["plot_samples"]):
-            (line,) = ax.plot([], [], "g", alpha=0.2)
-            sampled_lines.append(line)
-        (selected_line,) = ax.plot([], [], "b", linewidth=2)
+        sampled_idx = _lookup_key(controller_data_keys, "sampled_x_traj", "robot_sampled_states")
+        selected_idx = _lookup_key(controller_data_keys, "x_traj")
 
-        sampled_key = (
-            "sampled_x_traj" if "sampled_x_traj" in controller_data_keys else "robot_sampled_states"
-        )
-        state_dim = mppi_args["robot_state_dim"]
+        if sampled_idx is None or selected_idx is None:
+            warnings.warn(_MISSING_SAMPLES_MESSAGE, RuntimeWarning, stacklevel=2)
+        else:
+            sampled_lines = []
+            for _ in range(mppi_args["plot_samples"]):
+                (line,) = ax.plot([], [], "g", alpha=0.2)
+                sampled_lines.append(line)
+            (selected_line,) = ax.plot([], [], "b", linewidth=2)
 
-        def mppi_overlay(frame, _ax):
-            # Note: this file uses [frame][key] indexing (not [key][frame])
-            if frame >= len(controller_data_items):
-                return []
-            frame_data = controller_data_items[frame]
-            sampled = frame_data[controller_data_keys.index(sampled_key)]
-            selected = frame_data[controller_data_keys.index("x_traj")]
+            state_dim = mppi_args["robot_state_dim"]
 
-            for i, line in enumerate(sampled_lines):
-                line.set_data(
-                    sampled[state_dim * i, :],
-                    sampled[state_dim * i + 1, :],
-                )
-            selected_line.set_data(selected[0, :], selected[1, :])
+            def mppi_overlay(frame, _ax):
+                # Note: this file uses [frame][key] indexing (not [key][frame])
+                if frame >= len(controller_data_items):
+                    return []
+                frame_data = controller_data_items[frame]
+                sampled = frame_data[sampled_idx]
+                selected = frame_data[selected_idx]
 
-            return sampled_lines + [selected_line]
+                for i, line in enumerate(sampled_lines):
+                    line.set_data(
+                        sampled[state_dim * i, :],
+                        sampled[state_dim * i + 1, :],
+                    )
+                selected_line.set_data(selected[0, :], selected[1, :])
 
-        animator.on_frame(mppi_overlay)
+                return sampled_lines + [selected_line]
+
+            animator.on_frame(mppi_overlay)
 
     if save_animation:
         animator.save(animation_filename)

--- a/tests/test_controllers/test_cbf_clf_controllers/test_activated_cbf_applied_control.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_activated_cbf_applied_control.py
@@ -1,0 +1,183 @@
+"""The control a CBF-CLF-QP controller returns must be the control its QP solved for.
+
+The barrier-activated generator deactivates a barrier by multiplying its whole constraint
+row by a weight of exactly zero, so an all-zero row is present in every solve. The
+generator used to read any such degenerate row as a signal to hand back the clipped
+nominal control instead of the QP solution, while still reporting success -- the QP
+computed a safe control and the plant received an unfiltered one. Closed-loop behaviour
+became independent of every barrier parameter, which is what the parameter-sensitivity
+test below pins against.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+from cbfkit.controllers.cbf_clf.barrier_activated_cbf_clf_qp_control_laws import (
+    barrier_activated_cbf_clf_qp_controller,
+)
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.controllers.cbf_clf.utils.barrier_activation import compute_activation_weights
+from cbfkit.utils.user_types import CertificateCollection, ControllerData
+
+CONTROL_LIMITS = jnp.array([1.0, 1.0])
+OBSTACLES = jnp.array([[1.0, 0.0], [-4.0, 4.0], [4.0, -4.0]])
+RADIUS = 0.5
+KEY = jax.random.PRNGKey(0)
+
+
+def _single_integrator(x):
+    """2D single integrator: xdot = u."""
+    return jnp.zeros(2), jnp.eye(2)
+
+
+def _obstacle_barriers(gain: float = 1.0) -> CertificateCollection:
+    """h_i(x) = ||x - o_i||^2 - RADIUS^2 >= 0 for each obstacle."""
+
+    def make(o):
+        return (
+            lambda t, x: jnp.sum((x - o) ** 2) - RADIUS**2,
+            lambda t, x: 2.0 * (x - o),
+            lambda t, x: 2.0 * jnp.eye(2),
+            lambda t, x: 0.0,
+        )
+
+    parts = [make(o) for o in OBSTACLES]
+    return CertificateCollection(
+        [p[0] for p in parts],
+        [p[1] for p in parts],
+        [p[2] for p in parts],
+        [p[3] for p in parts],
+        [(lambda val, g=gain: g * val) for _ in parts],
+    )
+
+
+def _activated_controller(gain: float = 1.0, k_closest: int = 1, **extra):
+    return barrier_activated_cbf_clf_qp_controller(
+        control_limits=CONTROL_LIMITS,
+        dynamics_func=_single_integrator,
+        barriers=_obstacle_barriers(gain),
+        obstacle_positions=OBSTACLES,
+        k_closest=k_closest,
+        activation_radius=3.0,
+        relaxable_cbf=True,
+        **extra,
+    )
+
+
+def _call(controller, x, u_nom):
+    return controller(0.0, x, u_nom, KEY, ControllerData())
+
+
+# A state just outside obstacle 0 with the nominal control driving straight into it.
+APPROACHING = jnp.array([0.4, 0.0])
+U_TOWARD_OBSTACLE = jnp.array([1.0, 0.0])
+
+
+def test_deactivated_barriers_produce_degenerate_rows():
+    """Precondition for the rest of the suite: the zero-weight path is exercised."""
+    weights = compute_activation_weights(APPROACHING, OBSTACLES, k=1, radius=3.0, smoothness=5.0)
+    assert int(jnp.sum(weights == 0.0)) == len(OBSTACLES) - 1
+    assert float(weights.max()) > 0.0
+
+
+def test_applied_control_is_the_qp_solution():
+    """u must equal the QP solution's control block, exactly, not approximately."""
+    controller = _activated_controller()
+    u, data = _call(controller, APPROACHING, U_TOWARD_OBSTACLE)
+
+    assert not bool(data.error)
+    assert int(np.asarray(data.error_data)) == 1
+    np.testing.assert_array_equal(np.asarray(u), np.asarray(data.sol)[: CONTROL_LIMITS.shape[0]])
+
+
+def test_applied_control_is_not_the_nominal_control():
+    """The safety filter must actually reach the output when a barrier is active."""
+    controller = _activated_controller()
+    u, _ = _call(controller, APPROACHING, U_TOWARD_OBSTACLE)
+
+    clipped_nominal = jnp.clip(U_TOWARD_OBSTACLE, -CONTROL_LIMITS, CONTROL_LIMITS)
+    assert float(jnp.linalg.norm(u - clipped_nominal)) > 1e-3
+    # Driving straight at the obstacle is what gets filtered out.
+    assert float(u[0]) < float(clipped_nominal[0])
+
+
+def test_vanilla_applied_control_is_the_qp_solution():
+    """The vanilla path was already exact; keep it that way."""
+    controller = vanilla_cbf_clf_qp_controller(
+        control_limits=CONTROL_LIMITS,
+        dynamics_func=_single_integrator,
+        barriers=_obstacle_barriers(),
+        relaxable_cbf=True,
+    )
+    u, data = _call(controller, APPROACHING, U_TOWARD_OBSTACLE)
+
+    assert not bool(data.error)
+    np.testing.assert_array_equal(np.asarray(u), np.asarray(data.sol)[: CONTROL_LIMITS.shape[0]])
+
+
+def test_degenerate_row_does_not_mask_infeasibility():
+    """A zero row whose right-hand side is negative is unsatisfiable, not ignorable."""
+
+    def mock_cbf(control_limits, dynamics, barriers, lyapunovs, **kwargs):
+        def compute(t, x):
+            return jnp.zeros((1, 1)), jnp.array([-1.0]), {"complete": False}
+
+        return compute
+
+    def mock_clf(*args, **kwargs):
+        return lambda t, x: (jnp.zeros((0, 1)), jnp.zeros((0,)), {})
+
+    controller = cbf_clf_qp_generator(mock_cbf, mock_clf)(
+        control_limits=jnp.array([1.0]),
+        dynamics_func=lambda x: (jnp.zeros(1), jnp.eye(1)),
+        barriers=([], [], [], [], []),
+        lyapunovs=([], [], [], [], []),
+        relaxable_cbf=False,
+    )
+    u, data = controller(0.0, jnp.zeros(1), jnp.array([1.0]), KEY, ControllerData())
+
+    assert bool(data.error)
+    assert bool(jnp.isnan(u).all())
+
+
+def test_gradient_through_deactivated_barrier_is_finite():
+    """Degenerate rows must not reintroduce NaN sensitivities (the old override's purpose)."""
+    controller = _activated_controller()
+
+    def loss(x):
+        u, _ = _call(controller, x, U_TOWARD_OBSTACLE)
+        return jnp.sum(u)
+
+    grad = jax.grad(loss)(APPROACHING)
+    assert bool(jnp.all(jnp.isfinite(grad)))
+
+
+def _rollout(gain: float, steps: int = 40, dt: float = 0.05):
+    """Closed loop on the single integrator, driving straight at obstacle 0."""
+    controller = _activated_controller(gain=gain)
+    x = jnp.array([-0.5, 0.0])
+    traj = [x]
+    for _ in range(steps):
+        u, _ = _call(controller, x, U_TOWARD_OBSTACLE)
+        x = x + dt * u
+        traj.append(x)
+    return np.asarray(jnp.stack(traj))
+
+
+def test_closed_loop_responds_to_barrier_parameters():
+    """Barrier tuning must move the trajectory.
+
+    With the override in place, a 25-cell sweep over roots and slack bounds produced
+    closed-loop trajectories that agreed to machine precision, because the QP solution
+    never reached the plant. Identical trajectories under different class-K gains are the
+    signature of that defect, so this asserts they differ.
+    """
+    slow = _rollout(gain=0.5)
+    fast = _rollout(gain=5.0)
+
+    assert np.abs(slow - fast).max() > 1e-3
+    # The safe set is the same either way: both stay outside the obstacle.
+    for traj in (slow, fast):
+        assert np.linalg.norm(traj - np.asarray(OBSTACLES[0]), axis=1).min() >= RADIUS - 1e-6

--- a/tests/test_controllers/test_cbf_clf_controllers/test_constraint_tracer_leak.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_constraint_tracer_leak.py
@@ -1,0 +1,402 @@
+"""Regression tests: constraint generators must not leak tracers into their closures.
+
+Each ``compute_*_constraints`` function is a ``@jit``-wrapped closure over the
+zero-initialized constraint template arrays built by ``unpack_for_cbf`` /
+``unpack_for_clf``. Those enclosing names used to be rebound through ``nonlocal``
+inside the traced body, which stored the first trace's tracers in the closure
+cell. Any genuine retrace -- a new input dtype, a new state dimension, or eager
+execution under ``jax.disable_jit`` -- then read a dead tracer and raised
+``UnexpectedTracerError``. The pattern survived in practice only because
+vmap-over-states reuses identical avals and keeps hitting the jit cache.
+"""
+
+import ast
+import inspect
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from cbfkit.controllers.cbf_clf.generate_constraints import (
+    _constraint_core,
+    risk_aware_cbfs,
+    risk_aware_clfs,
+    risk_aware_path_integral_cbfs,
+    risk_aware_path_integral_clfs,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.risk_aware_cbfs import (
+    generate_compute_estimate_feedback_ra_cbf_constraints,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.risk_aware_clfs import (
+    generate_compute_estimate_feedback_ra_clf_constraints,
+    generate_compute_ra_clf_constraints,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.risk_aware_path_integral_cbfs import (
+    generate_compute_ra_pi_cbf_constraints,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.risk_aware_path_integral_clfs import (
+    generate_compute_ra_pi_clf_constraints,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.robust_cbfs import (
+    generate_compute_robust_cbf_constraints,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.robust_clfs import (
+    generate_compute_robust_clf_constraints,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.stochastic_cbfs import (
+    generate_compute_stochastic_cbf_constraints,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.stochastic_clfs import (
+    generate_compute_stochastic_clf_constraints,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.vanilla_clfs import (
+    generate_compute_vanilla_clf_constraints,
+)
+from cbfkit.controllers.cbf_clf.generate_constraints.zeroing_cbfs import (
+    generate_compute_zeroing_cbf_constraints,
+)
+from cbfkit.controllers.cbf_clf.utils.risk_aware_params import RiskAwareParams
+
+N_CON = 2
+
+
+# The certificates and dynamics below are deliberately written to accept any state
+# dimension, so one generator can be called at n=2 and n=3 and be forced to retrace.
+def dynamics(x):
+    n = x.shape[0]
+    return jnp.zeros((n,)), jnp.eye(n)[:, :N_CON]
+
+
+def h(t, x):
+    del t
+    return x[0] - 0.1
+
+
+def dhdx(t, x):
+    del t
+    return jnp.eye(x.shape[0])[0]
+
+
+def d2hdx2(t, x):
+    del t
+    return jnp.zeros((x.shape[0], x.shape[0]))
+
+
+def dhdt(t, x):
+    del t, x
+    return 0.0
+
+
+def alpha(val):
+    return 1.0 * val
+
+
+def sigma(x):
+    return 0.25 * jnp.eye(x.shape[0])
+
+
+CERTS = ([h], [dhdx], [d2hdx2], [dhdt], [alpha])
+LIMITS = jnp.array([10.0, 10.0])
+LIMITS_SLACK = jnp.array([10.0, 10.0, 10.0])
+
+
+def _ra_params():
+    # ``gamma`` is unused by the plain risk-aware generators but is asserted
+    # non-None by the path-integral CLF, so one factory serves every variant.
+    return RiskAwareParams(
+        t_max=10.0,
+        p_bound=0.95,
+        eta=2.0,
+        epsilon=0.1,
+        lambda_h=1.0,
+        lambda_generator=1.0,
+        gamma=jnp.zeros(1),
+        sigma=sigma,
+        varsigma=lambda x: 0.1 * jnp.eye(x.shape[0]),
+    )
+
+
+GENERATORS = {
+    "zeroing_cbf": lambda: generate_compute_zeroing_cbf_constraints(LIMITS, dynamics, CERTS, CERTS),
+    "zeroing_cbf_tunable": lambda: generate_compute_zeroing_cbf_constraints(
+        LIMITS_SLACK, dynamics, CERTS, CERTS, tunable_class_k=True
+    ),
+    "zeroing_cbf_relaxable": lambda: generate_compute_zeroing_cbf_constraints(
+        LIMITS_SLACK, dynamics, CERTS, CERTS, relaxable_cbf=True
+    ),
+    "robust_cbf": lambda: generate_compute_robust_cbf_constraints(
+        LIMITS, dynamics, CERTS, CERTS, disturbance_norm_bound=0.3, disturbance_norm=2
+    ),
+    "stochastic_cbf": lambda: generate_compute_stochastic_cbf_constraints(
+        LIMITS, dynamics, CERTS, CERTS, sigma=sigma
+    ),
+    "vanilla_clf": lambda: generate_compute_vanilla_clf_constraints(LIMITS, dynamics, CERTS, CERTS),
+    "vanilla_clf_relaxable": lambda: generate_compute_vanilla_clf_constraints(
+        LIMITS_SLACK, dynamics, CERTS, CERTS, relaxable_clf=True
+    ),
+    "robust_clf": lambda: generate_compute_robust_clf_constraints(
+        LIMITS, dynamics, CERTS, CERTS, disturbance_norm_bound=0.3, disturbance_norm=2
+    ),
+    "stochastic_clf": lambda: generate_compute_stochastic_clf_constraints(
+        LIMITS, dynamics, CERTS, CERTS, sigma=sigma
+    ),
+    "estimate_feedback_ra_cbf": lambda: generate_compute_estimate_feedback_ra_cbf_constraints(
+        LIMITS, dynamics, CERTS, CERTS, ra_cbf_params=_ra_params()
+    ),
+    "ra_clf": lambda: generate_compute_ra_clf_constraints(
+        LIMITS, dynamics, CERTS, CERTS, ra_clf_params=_ra_params()
+    ),
+    "ra_clf_relaxable": lambda: generate_compute_ra_clf_constraints(
+        LIMITS_SLACK, dynamics, CERTS, CERTS, relaxable_clf=True, ra_clf_params=_ra_params()
+    ),
+    "ra_clf_default_params": lambda: generate_compute_ra_clf_constraints(
+        LIMITS, dynamics, CERTS, CERTS
+    ),
+    "estimate_feedback_ra_clf": lambda: generate_compute_estimate_feedback_ra_clf_constraints(
+        LIMITS, dynamics, CERTS, CERTS, ra_clf_params=_ra_params()
+    ),
+    "estimate_feedback_ra_clf_relaxable": (
+        lambda: generate_compute_estimate_feedback_ra_clf_constraints(
+            LIMITS_SLACK, dynamics, CERTS, CERTS, relaxable_clf=True, ra_clf_params=_ra_params()
+        )
+    ),
+    "ra_pi_cbf": lambda: generate_compute_ra_pi_cbf_constraints(
+        LIMITS, dynamics, CERTS, CERTS, ra_cbf_params=_ra_params()
+    ),
+    "ra_pi_cbf_tunable": lambda: generate_compute_ra_pi_cbf_constraints(
+        LIMITS_SLACK, dynamics, CERTS, CERTS, tunable_class_k=True, ra_cbf_params=_ra_params()
+    ),
+    "ra_pi_cbf_default_params": lambda: generate_compute_ra_pi_cbf_constraints(
+        LIMITS, dynamics, CERTS, CERTS
+    ),
+    "ra_pi_clf": lambda: generate_compute_ra_pi_clf_constraints(
+        LIMITS, dynamics, CERTS, CERTS, ra_clf_params=_ra_params()
+    ),
+    "ra_pi_clf_relaxable": lambda: generate_compute_ra_pi_clf_constraints(
+        LIMITS_SLACK, dynamics, CERTS, CERTS, relaxable_clf=True, ra_clf_params=_ra_params()
+    ),
+    "ra_pi_clf_default_params": lambda: generate_compute_ra_pi_clf_constraints(
+        LIMITS, dynamics, CERTS, CERTS
+    ),
+}
+
+# The path-integral generators additionally used to mutate ``ra_params`` from
+# inside the traced body, storing the trace's tracer on the shared params object.
+PATH_INTEGRAL = [
+    "ra_pi_cbf",
+    "ra_pi_cbf_tunable",
+    "ra_pi_cbf_default_params",
+    "ra_pi_clf",
+    "ra_pi_clf_relaxable",
+    "ra_pi_clf_default_params",
+]
+
+X2 = jnp.array([0.35, -0.75])
+X3 = jnp.array([0.35, -0.75, 0.2])
+
+
+@pytest.mark.parametrize("name", sorted(GENERATORS))
+def test_retrace_after_first_call_does_not_leak_tracer(name):
+    """A second trace with a different dtype must not hit a leaked tracer."""
+    fn = GENERATORS[name]()
+
+    a_ref, b_ref, _ = fn(0.0, X2)
+
+    # Different dtype => cache miss => genuine retrace. Before the fix this raised
+    # UnexpectedTracerError while reading the closure's leaked constraint matrix.
+    a32, b32, _ = fn(0.0, X2.astype(jnp.float32))
+
+    assert np.all(np.isfinite(np.asarray(a32)))
+    np.testing.assert_allclose(np.asarray(a32), np.asarray(a_ref), rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(np.asarray(b32), np.asarray(b_ref), rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize("name", sorted(GENERATORS))
+def test_eager_execution_after_trace_matches_traced_result(name):
+    """``jax.disable_jit`` runs the body eagerly and must reproduce the traced result."""
+    fn = GENERATORS[name]()
+
+    a_ref, b_ref, _ = fn(0.0, X2)
+    with jax.disable_jit():
+        a_eager, b_eager, _ = fn(0.0, X2)
+
+    np.testing.assert_array_equal(np.asarray(a_eager), np.asarray(a_ref))
+    np.testing.assert_array_equal(np.asarray(b_eager), np.asarray(b_ref))
+
+
+@pytest.mark.parametrize("name", sorted(GENERATORS))
+def test_new_state_dimension_forces_clean_retrace(name):
+    """Calling the same generator at a new state dimension must retrace cleanly."""
+    fn = GENERATORS[name]()
+
+    a2, b2, _ = fn(0.0, X2)
+    a3, b3, _ = fn(0.0, X3)
+
+    # Constraint shapes are set by the certificate/control counts, not the state size.
+    assert a3.shape == a2.shape
+    assert b3.shape == b2.shape
+    assert np.all(np.isfinite(np.asarray(a3)))
+    assert np.all(np.isfinite(np.asarray(b3)))
+
+    # Re-running at the original dimension still reproduces the original values,
+    # i.e. the intervening trace did not corrupt the generator's template arrays.
+    a2_again, b2_again, _ = fn(0.0, X2)
+    np.testing.assert_array_equal(np.asarray(a2_again), np.asarray(a2))
+    np.testing.assert_array_equal(np.asarray(b2_again), np.asarray(b2))
+
+
+@pytest.mark.parametrize("name", sorted(GENERATORS))
+def test_nested_trace_matches_standalone_call(name):
+    """Calling the generator inside an outer jit must not leak the outer trace's tracers."""
+    fn = GENERATORS[name]()
+
+    a_ref, b_ref, _ = fn(0.0, X2)
+
+    @jax.jit
+    def outer(t, x):
+        a, b, _ = fn(t, x)
+        return a, b
+
+    a_nested, b_nested = outer(0.0, X2)
+    np.testing.assert_array_equal(np.asarray(a_nested), np.asarray(a_ref))
+    np.testing.assert_array_equal(np.asarray(b_nested), np.asarray(b_ref))
+
+    # And the standalone call still works afterwards.
+    a_after, b_after, _ = fn(0.0, X2)
+    np.testing.assert_array_equal(np.asarray(a_after), np.asarray(a_ref))
+    np.testing.assert_array_equal(np.asarray(b_after), np.asarray(b_ref))
+
+
+@pytest.mark.parametrize("name", sorted(GENERATORS))
+def test_vmap_over_states_still_matches_per_state_calls(name):
+    """The vmap path that masked this bug must keep producing the per-state results."""
+    fn = GENERATORS[name]()
+
+    states = jnp.stack([X2, X2 + 0.1, X2 - 0.2])
+    a_batched, b_batched = jax.vmap(lambda x: fn(0.0, x)[:2])(states)
+
+    for i in range(states.shape[0]):
+        a_i, b_i, _ = fn(0.0, states[i])
+        np.testing.assert_allclose(np.asarray(a_batched[i]), np.asarray(a_i), rtol=0, atol=1e-12)
+        np.testing.assert_allclose(np.asarray(b_batched[i]), np.asarray(b_i), rtol=0, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        _constraint_core,
+        risk_aware_cbfs,
+        risk_aware_clfs,
+        risk_aware_path_integral_cbfs,
+        risk_aware_path_integral_clfs,
+    ],
+)
+def test_modules_declare_no_nonlocal(module):
+    """Guard the defect class itself: no ``nonlocal`` rebinding in these modules."""
+    tree = ast.parse(inspect.getsource(module))
+    offenders = [node.names for node in ast.walk(tree) if isinstance(node, ast.Nonlocal)]
+    assert not offenders, (
+        f"{module.__name__} declares nonlocal for {offenders}; rebinding closure state "
+        "inside a jit-traced function leaks tracers across traces."
+    )
+
+
+@pytest.mark.parametrize("module", [risk_aware_path_integral_cbfs, risk_aware_path_integral_clfs])
+def test_path_integral_body_does_not_mutate_shared_params(module):
+    """The traced body must not assign to any ``ra_params`` attribute.
+
+    Assigning ``ra_params.integrator_states`` from inside the ``@jit`` body stored
+    the current trace's tracer on the shared ``RiskAwareParams`` object, which the
+    next trace then read. The reset now runs on a construction-time template held
+    in a local, so nothing traced escapes onto the shared object.
+    """
+    tree = ast.parse(inspect.getsource(module))
+    offenders = [
+        f"{ast.unparse(target)} (line {node.lineno})"
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Attribute)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "ra_params"
+        # Construction-time zeroing at module/function scope is fine; only the
+        # assignments nested inside the traced closure leak.
+        and node.col_offset > 4
+    ]
+    assert (
+        not offenders
+    ), f"{module.__name__} mutates shared params inside the traced body: {offenders}"
+
+
+@pytest.mark.parametrize("name", PATH_INTEGRAL)
+def test_path_integral_accumulator_is_stateless_across_calls(name):
+    """Five sequential calls must not drift: this integrator never accumulates.
+
+    ``integrator_states`` is written in exactly two places -- zeroed once when the
+    generator is built, and reset to those same zeros under ``t == 0`` inside the
+    body. Nothing anywhere increments it, so its contribution is identically zero
+    at every timestep (see the module docstrings). Pinning that here means a future
+    change that makes the integral genuinely accumulate has to update this test
+    deliberately rather than silently altering the constraint each call.
+    """
+    inputs = [(0.1 * k, X2 + 0.01 * k) for k in range(5)]
+
+    # Advance both t and x so a real accumulator, or any leaked per-call state,
+    # would show up as drift.
+    forward = GENERATORS[name]()
+    forward_out = [forward(t, x) for t, x in inputs]
+
+    # A fresh generator driven through the same inputs in reverse order must map
+    # each (t, x) to the same constraint pair. Any state carried between calls --
+    # an accumulating integral included -- would make the answer depend on how
+    # many calls came before, and this comparison would fail.
+    backward = GENERATORS[name]()
+    backward_out = {}
+    for t, x in reversed(inputs):
+        a, b, _ = backward(t, x)
+        backward_out[float(t)] = (np.asarray(a), np.asarray(b))
+
+    for (t, _x), (a_fwd, b_fwd, _) in zip(inputs, forward_out):
+        a_bwd, b_bwd = backward_out[float(t)]
+        np.testing.assert_array_equal(a_bwd, np.asarray(a_fwd))
+        np.testing.assert_array_equal(b_bwd, np.asarray(b_fwd))
+
+    # And the t == 0 reset branch agrees with the steady-state branch, because
+    # both read the same construction-time zeros.
+    a_zero, b_zero, _ = forward(0.0, X2)
+    a_first, b_first, _ = forward_out[0]
+    np.testing.assert_array_equal(np.asarray(a_zero), np.asarray(a_first))
+    np.testing.assert_array_equal(np.asarray(b_zero), np.asarray(b_first))
+
+
+@pytest.mark.parametrize("name", PATH_INTEGRAL)
+def test_path_integral_params_object_holds_no_tracer_after_use(name):
+    """``ra_params.integrator_states`` must stay a concrete array, never a tracer."""
+    params = _ra_params()
+    kwarg = "ra_cbf_params" if "cbf" in name else "ra_clf_params"
+    if "default_params" in name:
+        pytest.skip("variant builds its own params internally")
+
+    limits = LIMITS_SLACK if ("tunable" in name or "relaxable" in name) else LIMITS
+    extra = {}
+    if "tunable" in name:
+        extra["tunable_class_k"] = True
+    if "relaxable" in name:
+        extra["relaxable_clf"] = True
+    build = (
+        generate_compute_ra_pi_cbf_constraints
+        if "cbf" in name
+        else generate_compute_ra_pi_clf_constraints
+    )
+    fn = build(limits, dynamics, CERTS, CERTS, **{kwarg: params}, **extra)
+
+    fn(0.0, X2)
+    fn(0.5, X2 + 0.1)
+
+    stored = params.integrator_states
+    assert not isinstance(stored, jax.core.Tracer), (
+        f"{name} left a {type(stored).__name__} on the shared RiskAwareParams object; "
+        "the next trace would read a dead tracer."
+    )
+    np.testing.assert_array_equal(np.asarray(stored), np.zeros_like(np.asarray(stored)))

--- a/tests/test_controllers/test_cbf_clf_controllers/test_failure_reporter_gating.py
+++ b/tests/test_controllers/test_cbf_clf_controllers/test_failure_reporter_gating.py
@@ -1,0 +1,297 @@
+"""Tests for the opt-in ``report_failures`` flag on the CBF-CLF-QP generator.
+
+The failure reporter is built from ``jax.debug`` host callbacks. XLA cannot elide those,
+so leaving them in the graph costs time on every step -- including successful ones. These
+tests pin the contract: the default graph is callback-free, the flag brings the reporter
+back, and ``sub_data["solver_status"]`` is recorded either way (it is consumed by
+``simulation/status.py`` and ``simulation/safety_verification.py``).
+"""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from cbfkit.controllers.cbf_clf import (
+    risk_aware_cbf_clf_qp_controller,
+    risk_aware_path_integral_cbf_clf_qp_controller,
+    robust_cbf_clf_qp_controller,
+    stochastic_cbf_clf_qp_controller,
+    vanilla_cbf_clf_qp_controller,
+)
+from cbfkit.controllers.cbf_clf.cbf_clf_qp_generator import cbf_clf_qp_generator
+from cbfkit.controllers.cbf_clf.generate_constraints import (
+    generate_compute_vanilla_clf_constraints,
+    generate_compute_zeroing_cbf_constraints,
+)
+from cbfkit.controllers.cbf_clf.utils.risk_aware_params import RiskAwareParams
+from cbfkit.utils.user_types import CertificateCollection, ControllerData
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+SAFE_STATE = jnp.array([3.0, 3.0])
+U_NOM = jnp.array([-0.5, -0.5])
+KEY = jax.random.PRNGKey(0)
+
+
+def _single_integrator(x):
+    """2D single integrator: xdot = u."""
+    return jnp.zeros(2), jnp.eye(2)
+
+
+def _unit_circle_barrier():
+    """h(x) = ||x||^2 - 1 >= 0 (obstacle of radius 1 at the origin)."""
+    return CertificateCollection(
+        [lambda t, x: jnp.sum(x**2) - 1.0],
+        [lambda t, x: 2.0 * x],
+        [lambda t, x: 2.0 * jnp.eye(2)],
+        [lambda t, x: 0.0],
+        [lambda val: val],
+    )
+
+
+def _build(**extra):
+    """A vanilla CBF-CLF-QP controller on the 2D single integrator."""
+    return vanilla_cbf_clf_qp_controller(
+        control_limits=jnp.array([1.0, 1.0]),
+        dynamics_func=_single_integrator,
+        barriers=_unit_circle_barrier(),
+        **extra,
+    )
+
+
+def _jaxpr_text(controller, x=SAFE_STATE):
+    return str(jax.make_jaxpr(controller)(0.0, x, U_NOM, KEY, ControllerData()))
+
+
+def _build_infeasible(**extra):
+    """A 1D controller whose QP is primal-infeasible, so the reporter fires."""
+
+    def dynamics(x):
+        return jnp.zeros(1), jnp.ones((1, 1))
+
+    # h(x) = -1 everywhere with a zero gradient: the CBF constraint can never be met.
+    barriers = CertificateCollection(
+        [lambda t, x: -1.0],
+        [lambda t, x: jnp.array([0.0])],
+        [lambda t, x: jnp.array([[0.0]])],
+        [lambda t, x: 0.0],
+        [lambda val: val],
+    )
+    return vanilla_cbf_clf_qp_controller(
+        control_limits=jnp.array([1.0]),
+        dynamics_func=dynamics,
+        barriers=barriers,
+        slack_bound_cbf=1e-3,
+        relaxable_cbf=False,
+        **extra,
+    )
+
+
+def _run_infeasible(controller):
+    return controller(0.0, jnp.zeros(1), jnp.zeros(1), KEY, ControllerData())
+
+
+# ---------------------------------------------------------------------------
+# Jaxpr shape of the compiled graph
+# ---------------------------------------------------------------------------
+
+
+def test_default_jaxpr_has_no_debug_callbacks():
+    """AC1: the default controller graph contains no host callbacks."""
+    text = _jaxpr_text(_build())
+    assert "debug_callback" not in text
+    assert "debug_print" not in text
+
+
+def test_report_failures_puts_callbacks_back_in_jaxpr():
+    """AC2: the flag restores the reporter in the traced graph."""
+    text = _jaxpr_text(_build(report_failures=True))
+    assert "debug_callback" in text
+
+
+def test_reporter_is_the_only_difference():
+    """The flag adds callbacks and nothing else removes them."""
+    off = _jaxpr_text(_build())
+    on = _jaxpr_text(_build(report_failures=True))
+    assert off.count("debug_callback") == 0
+    assert on.count("debug_callback") > 0
+    # The flag only ever grows the graph; it must not alter the compute otherwise.
+    assert len(on) > len(off)
+
+
+# ---------------------------------------------------------------------------
+# Printing behavior
+# ---------------------------------------------------------------------------
+
+
+def test_report_failures_prints_on_failure(capfd):
+    """AC2: with the flag on, a failed solve still emits the diagnostic."""
+    controller = _build_infeasible(report_failures=True)
+    _u, data = _run_infeasible(controller)
+    jax.effects_barrier()
+
+    out = capfd.readouterr().out
+    assert "CBF-CLF-QP Failed" in out
+    assert bool(data.error) is True
+
+
+def test_default_is_silent_on_failure(capfd):
+    """The default path fails just as loudly in the data, and silently on stdout."""
+    controller = _build_infeasible()
+    _u, data = _run_infeasible(controller)
+    jax.effects_barrier()
+
+    out = capfd.readouterr().out
+    assert "CBF-CLF-QP Failed" not in out
+    assert bool(data.error) is True
+
+
+# ---------------------------------------------------------------------------
+# solver_status telemetry survives the gate (AC3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("report_failures", [False, True])
+def test_solver_status_recorded_on_success(report_failures):
+    controller = _build(report_failures=report_failures)
+    _u, data = controller(0.0, SAFE_STATE, U_NOM, KEY, ControllerData())
+
+    assert "solver_status" in data.sub_data
+    assert int(data.sub_data["solver_status"]) == 1
+    assert "solver_iter" in data.sub_data
+    assert bool(data.error) is False
+
+
+@pytest.mark.parametrize("report_failures", [False, True])
+def test_solver_status_recorded_on_failure(report_failures):
+    """status.py and safety_verification.py read this key to count failures."""
+    controller = _build_infeasible(report_failures=report_failures)
+    _u, data = _run_infeasible(controller)
+
+    assert "solver_status" in data.sub_data
+    status = int(data.sub_data["solver_status"])
+    assert status != 1, "infeasible QP must not report success"
+    # error_data mirrors the status for the status.py fallback path.
+    assert int(data.error_data) == status
+    assert bool(data.error) is True
+
+
+def test_gating_does_not_change_the_control_output():
+    """The flag is diagnostics-only: same control, same status, either way."""
+    u_off, data_off = _build()(0.0, SAFE_STATE, U_NOM, KEY, ControllerData())
+    u_on, data_on = _build(report_failures=True)(0.0, SAFE_STATE, U_NOM, KEY, ControllerData())
+
+    assert jnp.allclose(u_off, u_on, atol=1e-10)
+    assert int(data_off.sub_data["solver_status"]) == int(data_on.sub_data["solver_status"])
+
+
+# ---------------------------------------------------------------------------
+# The flag is reachable from every variant entry point
+# ---------------------------------------------------------------------------
+
+
+def _ra_params():
+    return RiskAwareParams(
+        t_max=1.0,
+        p_bound=0.05,
+        gamma=jnp.array([0.5]),
+        eta=2.0,
+        epsilon=0.1,
+        lambda_h=1.0,
+        lambda_generator=1.0,
+        sigma=lambda x: jnp.zeros((x.shape[0], 1)),
+        varsigma=lambda x: jnp.zeros((x.shape[0], x.shape[0])),
+        integrator_states=jnp.zeros((1,)),
+    )
+
+
+def _origin_lyapunov():
+    """V(x) = ||x||^2 with Vdot <= -V."""
+    return CertificateCollection(
+        [lambda t, x: jnp.sum(x**2)],
+        [lambda t, x: 2.0 * x],
+        [lambda t, x: 2.0 * jnp.eye(2)],
+        [lambda t, x: 0.0],
+        [lambda val: -val],
+    )
+
+
+# Each variant gets the certificate set it actually supports. risk_aware is CLF-only:
+# generate_compute_ra_cbf_constraints raises NotImplementedError when given barriers,
+# so the barrier path there is deliberately unreachable.
+VARIANTS = {
+    "vanilla": (vanilla_cbf_clf_qp_controller, {"barriers": _unit_circle_barrier()}),
+    "robust": (
+        robust_cbf_clf_qp_controller,
+        {
+            "barriers": _unit_circle_barrier(),
+            "disturbance_norm_bound": 0.1,
+            "disturbance_norm": 2,
+        },
+    ),
+    "stochastic": (
+        stochastic_cbf_clf_qp_controller,
+        {"barriers": _unit_circle_barrier(), "sigma": lambda x: jnp.zeros((2, 1))},
+    ),
+    "risk_aware": (
+        risk_aware_cbf_clf_qp_controller,
+        {"lyapunovs": _origin_lyapunov(), "ra_clf_params": _ra_params()},
+    ),
+    "risk_aware_path_integral": (
+        risk_aware_path_integral_cbf_clf_qp_controller,
+        {"barriers": _unit_circle_barrier(), "ra_cbf_params": _ra_params()},
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(VARIANTS))
+def test_flag_reaches_every_variant(name):
+    """AC1/AC2 across vanilla, robust, stochastic, risk_aware, risk_aware_path_integral."""
+    factory, extra = VARIANTS[name]
+
+    def make(**flag):
+        return factory(
+            control_limits=jnp.array([1.0, 1.0]),
+            dynamics_func=_single_integrator,
+            **extra,
+            **flag,
+        )
+
+    assert "debug_callback" not in _jaxpr_text(make()), f"{name} leaks callbacks by default"
+    assert "debug_callback" in _jaxpr_text(
+        make(report_failures=True)
+    ), f"{name} cannot reach report_failures"
+
+
+def test_flag_is_not_forwarded_into_constraint_kwargs():
+    """``report_failures`` is consumed by the generator, not leaked into **kwargs."""
+    seen = {}
+
+    def spy_generator(control_limits, dyn_func, barriers, lyapunovs, **kwargs):
+        seen.update(kwargs)
+        return lambda t, x: (jnp.zeros((0, 2)), jnp.zeros((0,)), {"complete": True})
+
+    generate = cbf_clf_qp_generator(spy_generator, generate_compute_vanilla_clf_constraints)
+    generate(
+        control_limits=jnp.array([1.0, 1.0]),
+        dynamics_func=_single_integrator,
+        barriers=_unit_circle_barrier(),
+        report_failures=True,
+    )
+
+    assert "report_failures" not in seen
+
+
+def test_default_remains_off():
+    """Regression guard: the reporter must stay opt-in."""
+    import inspect
+
+    sig = inspect.signature(
+        cbf_clf_qp_generator(
+            generate_compute_zeroing_cbf_constraints,
+            generate_compute_vanilla_clf_constraints,
+        )
+    )
+    assert sig.parameters["report_failures"].default is False

--- a/tests/test_estimators/test_ukf_dimensions.py
+++ b/tests/test_estimators/test_ukf_dimensions.py
@@ -1,0 +1,288 @@
+"""Tests for UKF behavior when the measurement dimension differs from the state dimension.
+
+The update step's unscented transform draws sigma points over the *state*, so it must be
+parameterized by the state dimension. Parameterizing it by the measurement dimension
+builds only ``2 * dim(y) + 1`` points and spreads them along the first ``dim(y)`` columns
+of the Cholesky factor of P, so the reconstructed covariance
+``sum_i wc_i (s_i - z)(s_i - z)^T`` has rank ``dim(y)`` instead of rank ``dim(x)``.
+
+That defect is invisible in two situations, which is why it stayed latent:
+
+* ``dim(y) == dim(x)`` -- every sensor shipped with the library is full-state, so the two
+  dimensions always agreed and the sigma-point set was correct by accident.
+* the measurement reads exactly the *leading* ``dim(y)`` state coordinates. The Cholesky
+  factor is lower-triangular, so its first ``m`` columns still reproduce the exact
+  top-left ``m x m`` block of P, and both the innovation covariance and the cross
+  covariance come out right anyway.
+
+It is very much visible as soon as the measurement touches a state coordinate outside
+that leading block (velocity-only sensing of ``[position, velocity, acceleration]``, say),
+where the filter silently disagrees with the exact Kalman filter it should reproduce.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from cbfkit.estimators import ct_ukf_dtmeas
+from cbfkit.estimators.kalman_filters.ukf import generate_sigma_points
+
+DT = 0.05
+N_STEPS = 50
+
+# 1-D constant-acceleration model: state is [position, velocity, acceleration].
+A_CONST_ACCEL = np.array([[0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]])
+
+
+def _linear_dynamics(A):
+    """Builds a dynamics callable xdot = A x + 0 u for the given state matrix."""
+    n = A.shape[0]
+
+    def dynamics(x):
+        return jnp.matmul(jnp.asarray(A), x), jnp.zeros((n, 1))
+
+    return dynamics
+
+
+def _linear_measurement(H):
+    """Builds y = H x, applied either to one state or to a stack of sigma points."""
+
+    def h(x):
+        return jnp.matmul(x, jnp.asarray(H).T)
+
+    return h
+
+
+def _simulate_measurements(A, H, x0, noise_std, seed=0):
+    """Rolls the forward-Euler truth trajectory and its noisy measurements."""
+    rng = np.random.default_rng(seed)
+    F = np.eye(A.shape[0]) + DT * A
+    x = np.asarray(x0, dtype=float)
+    states, measurements = [], []
+    for _ in range(N_STEPS):
+        x = F @ x
+        states.append(x.copy())
+        measurements.append(H @ x + rng.normal(0.0, noise_std, size=(H.shape[0],)))
+    return np.array(states), measurements
+
+
+def _run_estimator(estimator, measurements, z0, P0):
+    """Steps the estimator over a measurement sequence; returns estimate/covariance history."""
+    z, P = jnp.asarray(z0), jnp.asarray(P0)
+    u = jnp.zeros((1,))
+    estimates, covariances = [], []
+    for k, y in enumerate(measurements):
+        z, P = estimator(k * DT, jnp.asarray(y), z, u, P)
+        estimates.append(np.asarray(z))
+        covariances.append(np.asarray(P))
+    return np.array(estimates), np.array(covariances)
+
+
+def _run_reference_kalman_filter(A, H, Q, R, measurements, z0, P0):
+    """Exact discrete-time KF matching the UKF's forward-Euler predict and its update."""
+    F = np.eye(A.shape[0]) + DT * A
+    x, P = np.asarray(z0, dtype=float), np.asarray(P0, dtype=float)
+    estimates, covariances = [], []
+    for y in measurements:
+        x = F @ x
+        P = F @ P @ F.T + Q
+        S = H @ P @ H.T + R
+        C = P @ H.T
+        K = C @ np.linalg.inv(S)
+        x = x + K @ (y - H @ x)
+        P = P - K @ S @ K.T
+        estimates.append(x.copy())
+        covariances.append(P.copy())
+    return np.array(estimates), np.array(covariances)
+
+
+def _assert_finite_and_psd(covariances):
+    for k, P in enumerate(covariances):
+        assert np.all(np.isfinite(P)), f"covariance is not finite at step {k}: {P}"
+        symmetric = 0.5 * (P + P.T)
+        assert np.allclose(P, symmetric, atol=1e-9), f"covariance is not symmetric at step {k}"
+        eigenvalues = np.linalg.eigvalsh(symmetric)
+        assert eigenvalues.min() > -1e-9, f"covariance is not PSD at step {k}: {eigenvalues}"
+
+
+@pytest.mark.parametrize("n_states, n_measurements", [(3, 1), (3, 2), (4, 2), (2, 2), (2, 3)])
+def test_update_draws_sigma_points_over_the_state(n_states, n_measurements):
+    """The update's sigma-point set is 2 * dim(x) + 1 points wide dim(x), whatever dim(y) is."""
+    observed_shapes = []
+    H = np.eye(n_measurements, n_states)
+
+    def recording_measurement(x):
+        observed_shapes.append(x.shape)
+        return _linear_measurement(H)(x)
+
+    estimator = ct_ukf_dtmeas(
+        Q=1e-4 * jnp.eye(n_states),
+        R=1e-2 * jnp.eye(n_measurements),
+        dynamics=_linear_dynamics(np.zeros((n_states, n_states))),
+        h=recording_measurement,
+        dt=DT,
+    )
+    z, P = estimator(
+        0.0,
+        jnp.zeros((n_measurements,)),
+        jnp.zeros((n_states,)),
+        jnp.zeros((1,)),
+        jnp.eye(n_states),
+    )
+
+    assert observed_shapes, "measurement model was never applied to the sigma points"
+    assert observed_shapes[0] == (2 * n_states + 1, n_states)
+    assert z.shape == (n_states,)
+    assert P.shape == (n_states, n_states)
+    assert np.all(np.isfinite(np.asarray(P)))
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 5])
+def test_sigma_points_reproduce_the_mean_and_covariance(n):
+    """The defining property of the unscented transform, and the reason L must be dim(x).
+
+    A set built with L < n reconstructs a rank-L covariance instead of P.
+    """
+    rng = np.random.default_rng(0)
+    M = rng.normal(size=(n, n))
+    P = M @ M.T + n * np.eye(n)
+    z = rng.normal(size=(n,))
+
+    s, wa, wc = generate_sigma_points(n, scheme=1)(jnp.asarray(z), jnp.asarray(P))
+    s, wa, wc = np.asarray(s), np.asarray(wa), np.asarray(wc)
+
+    assert s.shape == (2 * n + 1, n)
+    np.testing.assert_allclose(wa.sum(), 1.0, atol=1e-12)
+    np.testing.assert_allclose(wa @ s, z, atol=1e-10)
+
+    deviations = s - z
+    reconstructed = np.einsum("i,ij,ik->jk", wc, deviations, deviations)
+    np.testing.assert_allclose(reconstructed, P, atol=1e-10)
+
+
+@pytest.mark.parametrize(
+    "label, H",
+    [
+        ("position-only", np.array([[1.0, 0.0, 0.0]])),
+        ("velocity-only", np.array([[0.0, 1.0, 0.0]])),
+        ("acceleration-only", np.array([[0.0, 0.0, 1.0]])),
+        ("position-plus-velocity", np.array([[1.0, 1.0, 0.0]])),
+        ("velocity-and-acceleration", np.array([[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])),
+        ("full-state", np.eye(3)),
+    ],
+)
+def test_matches_exact_kalman_filter_for_linear_systems(label, H):
+    """For a linear model the UKF must reproduce the exact KF, for any measurement geometry.
+
+    The sigma-point set carries the mean and covariance exactly through a linear map, so
+    any disagreement here means the unscented transform itself is malformed.
+    """
+    n_measurements = H.shape[0]
+    Q = 1e-4 * np.eye(3)
+    R = 1e-2 * np.eye(n_measurements)
+    z0 = np.zeros(3)
+    P0 = np.diag([0.1, 1.0, 1.0])
+
+    _, measurements = _simulate_measurements(
+        A_CONST_ACCEL, H, [0.0, 1.0, -0.2], noise_std=0.05, seed=1
+    )
+
+    estimator = ct_ukf_dtmeas(
+        Q=jnp.asarray(Q),
+        R=jnp.asarray(R),
+        dynamics=_linear_dynamics(A_CONST_ACCEL),
+        h=_linear_measurement(H),
+        dt=DT,
+    )
+    estimates, covariances = _run_estimator(estimator, measurements, z0, P0)
+    expected_estimates, expected_covariances = _run_reference_kalman_filter(
+        A_CONST_ACCEL, H, Q, R, measurements, z0, P0
+    )
+
+    np.testing.assert_allclose(
+        estimates, expected_estimates, atol=1e-9, rtol=1e-7, err_msg=f"{label}: estimate drift"
+    )
+    np.testing.assert_allclose(
+        covariances,
+        expected_covariances,
+        atol=1e-9,
+        rtol=1e-7,
+        err_msg=f"{label}: covariance drift",
+    )
+
+
+def test_partial_measurement_runs_and_converges():
+    """dim(x) = 3, dim(y) = 1: runs 50 steps, stays finite and PSD, beats the initial guess."""
+    H = np.array([[1.0, 0.0, 0.0]])
+    x0_true = np.array([0.0, 1.0, -0.2])
+    z0 = np.zeros(3)
+    P0 = np.diag([0.1, 1.0, 1.0])
+
+    states, measurements = _simulate_measurements(A_CONST_ACCEL, H, x0_true, noise_std=0.1, seed=3)
+
+    estimator = ct_ukf_dtmeas(
+        Q=1e-4 * jnp.eye(3),
+        R=1e-2 * jnp.eye(1),
+        dynamics=_linear_dynamics(A_CONST_ACCEL),
+        h=_linear_measurement(H),
+        dt=DT,
+    )
+    estimates, covariances = _run_estimator(estimator, measurements, z0, P0)
+
+    assert estimates.shape == (N_STEPS, 3)
+    assert np.all(np.isfinite(estimates))
+    _assert_finite_and_psd(covariances)
+
+    initial_error = np.linalg.norm(z0 - x0_true)
+    final_error = np.linalg.norm(estimates[-1] - states[-1])
+    assert (
+        final_error < initial_error
+    ), f"estimate did not improve: initial {initial_error:.4f}, final {final_error:.4f}"
+
+
+def test_unmeasured_state_is_corrected_through_the_cross_covariance():
+    """Velocity is never measured directly, so only the cross-covariance can correct it."""
+    H = np.array([[1.0, 0.0, 0.0]])
+    x0_true = np.array([0.0, 1.0, 0.0])
+    z0 = np.zeros(3)
+    P0 = np.diag([0.1, 1.0, 1.0])
+
+    states, measurements = _simulate_measurements(A_CONST_ACCEL, H, x0_true, noise_std=0.05, seed=5)
+
+    estimator = ct_ukf_dtmeas(
+        Q=1e-4 * jnp.eye(3),
+        R=1e-2 * jnp.eye(1),
+        dynamics=_linear_dynamics(A_CONST_ACCEL),
+        h=_linear_measurement(H),
+        dt=DT,
+    )
+    estimates, _ = _run_estimator(estimator, measurements, z0, P0)
+
+    initial_velocity_error = abs(z0[1] - x0_true[1])
+    final_velocity_error = abs(estimates[-1][1] - states[-1][1])
+    assert final_velocity_error < 0.5 * initial_velocity_error, (
+        "velocity was not corrected through the cross-covariance: "
+        f"initial error {initial_velocity_error:.4f}, final error {final_velocity_error:.4f}"
+    )
+
+
+def test_full_state_measurement_is_unaffected():
+    """dim(y) == dim(x) is the pre-existing path and must keep behaving identically."""
+    H = np.eye(3)
+    x0_true = np.array([0.0, 1.0, -0.2])
+    z0 = np.zeros(3)
+    P0 = np.diag([0.1, 1.0, 1.0])
+
+    states, measurements = _simulate_measurements(A_CONST_ACCEL, H, x0_true, noise_std=0.1, seed=7)
+
+    estimator = ct_ukf_dtmeas(
+        Q=1e-4 * jnp.eye(3),
+        R=1e-2 * jnp.eye(3),
+        dynamics=_linear_dynamics(A_CONST_ACCEL),
+        h=_linear_measurement(H),
+        dt=DT,
+    )
+    estimates, covariances = _run_estimator(estimator, measurements, z0, P0)
+
+    _assert_finite_and_psd(covariances)
+    assert np.linalg.norm(estimates[-1] - states[-1]) < np.linalg.norm(z0 - x0_true)

--- a/tests/test_estimators/test_ukf_zero_covariance_seed.py
+++ b/tests/test_estimators/test_ukf_zero_covariance_seed.py
@@ -1,0 +1,61 @@
+"""UKF must produce finite estimates from an all-zero initial covariance.
+
+The simulator seeds the estimator covariance with ``jnp.zeros((n, n))`` when the
+caller passes no ``initial_covariance``. LAPACK's Cholesky of a zero matrix is
+NaN (zero pivot), which used to NaN every sigma point on the first update and
+poison the whole pipeline (the reach_goal/ukf.py "NaN/Inf in g_mat at rows: [6]"
+failure). A zero prior is legitimate: its factor is zero, sigma points collapse
+to the mean, and the predict step restores spread via Q.
+"""
+
+import jax.numpy as jnp
+
+from cbfkit.estimators.kalman_filters.ukf import ct_ukf_dtmeas
+
+
+def _dynamics(x):
+    return jnp.zeros_like(x), jnp.eye(x.shape[0])
+
+
+def test_ukf_step_finite_from_zero_covariance():
+    n = 2
+    estimator = ct_ukf_dtmeas(
+        Q=0.05 * jnp.eye(n),
+        R=0.1 * jnp.eye(n),
+        dynamics=_dynamics,
+        h=lambda x: x,
+        dt=0.05,
+    )
+    z0 = jnp.array([0.3, -0.4])
+    p0 = jnp.zeros((n, n))  # the simulator's default seed
+    y = jnp.array([0.35, -0.38])
+    u = jnp.zeros(n)
+
+    z1, p1 = estimator(0.0, y, z0, u, p0)[:2]
+    assert bool(jnp.all(jnp.isfinite(z1))), f"NaN estimate from zero-covariance seed: {z1}"
+    assert bool(jnp.all(jnp.isfinite(p1))), f"NaN covariance from zero-covariance seed: {p1}"
+
+    # Covariance must regain spread from Q (not stay pinned at zero),
+    # and a second step must remain finite.
+    assert float(jnp.trace(p1)) > 0.0
+    z2, p2 = estimator(0.05, y, z1, u, p1)[:2]
+    assert bool(jnp.all(jnp.isfinite(z2))) and bool(jnp.all(jnp.isfinite(p2)))
+
+
+def test_ukf_nonzero_covariance_path_unchanged():
+    """The zero-seed guard must not perturb the regular PD-covariance path."""
+    n = 2
+    estimator = ct_ukf_dtmeas(
+        Q=0.05 * jnp.eye(n),
+        R=0.1 * jnp.eye(n),
+        dynamics=_dynamics,
+        h=lambda x: x,
+        dt=0.05,
+    )
+    z0 = jnp.array([0.3, -0.4])
+    p0 = 0.2 * jnp.eye(n)
+    y = jnp.array([0.35, -0.38])
+    z1, p1 = estimator(0.0, y, z0, jnp.zeros(n), p0)[:2]
+    assert bool(jnp.all(jnp.isfinite(z1))) and bool(jnp.all(jnp.isfinite(p1)))
+    # PD prior + PD noise: posterior trace stays strictly positive
+    assert float(jnp.trace(p1)) > 0.0

--- a/tests/test_optimization/test_fast_qp.py
+++ b/tests/test_optimization/test_fast_qp.py
@@ -1,7 +1,5 @@
 """Tests for the fast small-QP solver and its integration with CBF-CLF-QP."""
 
-import pytest
-import jax
 import jax.numpy as jnp
 from jax import random
 
@@ -110,15 +108,21 @@ class TestFastSolverRegistry:
         assert solver.solver_name == "fast"
 
     def test_fast_solver_via_registry(self):
+        """Registry convention: min x'Hx + f'x (matches jaxopt/casadi backends).
+
+        With H=I, f=-2*[1,2] the minimizer is [1,2] — NOT [2,4], which is
+        what the pre-fix wrapper returned by feeding (H, f) straight into
+        the native ``min 1/2 x'Px + q'x`` PDIPM form.
+        """
         solver = get_solver("fast")
         P = jnp.eye(2)
         q = jnp.array([-2.0, -4.0])
         G = jnp.array([[1, 0], [-1, 0], [0, 1], [0, -1.0]])
         h = jnp.array(
             [3.0, 3.0, 5.0, 5.0]
-        )  # box [-3,3] x [-5,5] — unconstrained opt [2,4] is feasible
+        )  # box [-3,3] x [-5,5] — unconstrained opt [1,2] is feasible
         sol = solver(P, q, G, h)
-        assert jnp.allclose(sol.primal, jnp.array([2.0, 4.0]), atol=1e-4)
+        assert jnp.allclose(sol.primal, jnp.array([1.0, 2.0]), atol=1e-4)
         assert int(sol.status) == 1
 
     def test_fast_solver_warm_start_via_registry(self):

--- a/tests/test_optimization/test_fast_solver_equality_guard.py
+++ b/tests/test_optimization/test_fast_solver_equality_guard.py
@@ -1,0 +1,81 @@
+"""The 'fast' (PDIPM) backend must reject equality constraints, not drop them.
+
+``fast_solver`` accepts ``a_mat``/``b_vec`` for interface compatibility with the
+other registry backends, but its underlying PDIPM solves ``Gx <= h`` only. It
+used to ignore those arguments and return ``status == 1``, so
+``generate_mpc_solver_quadratic_cost_linear_dynamics`` — which encodes the plant
+dynamics as equality constraints — got a "successful" trajectory that satisfied
+no dynamics at all. A loud failure is the only safe behaviour here.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+from cbfkit.optimization.quadratic_program import get_solver
+
+
+def _problem():
+    """min ||x - [1,2]||^2 s.t. loose box, plus the equality x0 + x1 = 1."""
+    H = jnp.eye(2)
+    f = -2.0 * jnp.array([1.0, 2.0])
+    G = jnp.vstack([jnp.eye(2), -jnp.eye(2)])
+    h = 10.0 * jnp.ones(4)
+    a_mat = jnp.array([[1.0, 1.0]])
+    b_vec = jnp.array([1.0])
+    return H, f, G, h, a_mat, b_vec
+
+
+class TestFastRejectsEqualityConstraints:
+    def test_raises_with_inequalities_present(self):
+        H, f, G, h, a_mat, b_vec = _problem()
+        with pytest.raises(NotImplementedError, match="equality constraints"):
+            get_solver("fast")(H, f, G, h, a_mat, b_vec)
+
+    def test_raises_on_the_no_inequality_path(self):
+        """The unconstrained escape branch drops a_mat/b_vec just as silently."""
+        H, f, _, _, a_mat, b_vec = _problem()
+        with pytest.raises(NotImplementedError, match="equality constraints"):
+            get_solver("fast")(H, f, None, None, a_mat, b_vec)
+
+    @pytest.mark.parametrize("which", ["a_mat", "b_vec"])
+    def test_raises_when_only_one_half_is_given(self, which):
+        """Half a specification is a caller bug; the other backends ignore it."""
+        H, f, G, h, a_mat, b_vec = _problem()
+        kwargs = {"a_mat": a_mat} if which == "a_mat" else {"b_vec": b_vec}
+        with pytest.raises(NotImplementedError):
+            get_solver("fast")(H, f, G, h, **kwargs)
+
+    def test_message_names_backend_and_alternatives(self):
+        H, f, G, h, a_mat, b_vec = _problem()
+        with pytest.raises(NotImplementedError) as exc:
+            get_solver("fast")(H, f, G, h, a_mat, b_vec)
+        message = str(exc.value)
+        assert "fast" in message
+        assert "jaxopt" in message or "casadi" in message
+
+    def test_inequality_only_call_still_works(self):
+        """The guard must not fire on the ordinary CBF-QP path."""
+        H, f, G, h, _, _ = _problem()
+        sol = get_solver("fast")(H, f, G, h)
+        assert int(sol.status) == 1
+        assert jnp.allclose(sol.primal, jnp.array([1.0, 2.0]), atol=1e-4)
+
+
+class TestEqualityCapableBackendsUnaffected:
+    def test_jaxopt_still_enforces_equality(self):
+        H, f, G, h, a_mat, b_vec = _problem()
+        sol = get_solver("jaxopt")(H, f, G, h, a_mat, b_vec)
+        assert int(sol.status) == 1
+        assert jnp.allclose(sol.primal @ jnp.array([1.0, 1.0]), 1.0, atol=1e-3)
+
+    def test_cvxopt_still_enforces_equality(self):
+        H, f, G, h, a_mat, b_vec = _problem()
+        try:
+            solver = get_solver("cvxopt")
+            sol = solver(H, f, G, h, a_mat, b_vec)
+        except ImportError:
+            pytest.skip("cvxopt/kvxopt not installed")
+        assert int(sol.status) == 1
+        assert jnp.allclose(sol.primal @ jnp.array([1.0, 1.0]), 1.0, atol=1e-4)
+        # Equality-constrained minimizer of ||x-[1,2]||^2 on x0+x1=1 is [0,1].
+        assert jnp.allclose(sol.primal, jnp.array([0.0, 1.0]), atol=1e-4)

--- a/tests/test_optimization/test_pdipm_qp.py
+++ b/tests/test_optimization/test_pdipm_qp.py
@@ -41,7 +41,7 @@ class TestStepToBoundary:
 class TestNewtonReduced:
     def test_H_is_positive_definite(self):
         """H = P + G^T diag(lam/s) G must be PD when P is PD and s, lam > 0."""
-        from cbfkit.optimization.quadratic_program.qp_solver_pdipm import _solve_newton_reduced
+        from cbfkit.optimization.quadratic_program.qp_solver_pdipm import _factor_newton_reduced
         from jax import random
 
         key = random.PRNGKey(0)
@@ -49,23 +49,29 @@ class TestNewtonReduced:
         G = random.normal(key, (5, 3))
         s = jnp.array([0.5, 1.0, 1.5, 2.0, 0.1])
         lam = jnp.array([0.2, 0.8, 1.0, 0.05, 2.0])
-        rhs = jnp.ones(3)
         # Build H exactly as the helper would
         D = lam / s
         H = P + G.T @ (D[:, None] * G) + 1e-10 * jnp.eye(3)
         eigs = jnp.linalg.eigvalsh((H + H.T) / 2)
         assert float(eigs[0]) > 0, f"H not PD, min eig = {float(eigs[0])}"
+        # The Cholesky factor returned by the helper must reproduce H
+        L = _factor_newton_reduced(P, G, s, lam)
+        assert float(jnp.max(jnp.abs(L @ L.T - H))) < 1e-8
 
     def test_solves_system(self):
-        """_solve_newton_reduced returns dx such that H dx = rhs."""
-        from cbfkit.optimization.quadratic_program.qp_solver_pdipm import _solve_newton_reduced
+        """factor + solve_with_factor returns dx such that H dx = rhs."""
+        from cbfkit.optimization.quadratic_program.qp_solver_pdipm import (
+            _factor_newton_reduced,
+            _solve_with_factor,
+        )
 
         P = jnp.diag(jnp.array([1.0, 1.0]))
         G = jnp.array([[1.0, 0.0], [0.0, 1.0], [-1.0, -1.0]])
         s = jnp.array([1.0, 1.0, 1.0])
         lam = jnp.array([0.5, 0.5, 0.5])
         rhs = jnp.array([1.0, 2.0])
-        dx = _solve_newton_reduced(P, G, s, lam, rhs)
+        L = _factor_newton_reduced(P, G, s, lam)
+        dx = _solve_with_factor(L, rhs)
         D = lam / s
         H = P + G.T @ (D[:, None] * G) + 1e-10 * jnp.eye(2)
         residual = H @ dx - rhs
@@ -82,18 +88,25 @@ class TestPdipmIteration:
         return P, q, G, h
 
     def test_iteration_keeps_strict_interior(self):
-        from cbfkit.optimization.quadratic_program.qp_solver_pdipm import _pdipm_iteration
+        from cbfkit.optimization.quadratic_program.qp_solver_pdipm import (
+            _pdipm_iteration,
+            _residuals,
+        )
 
         P, q, G, h = self._make_simple_qp()
         x = jnp.zeros(2)
         s = jnp.ones(4)
         lam = jnp.ones(4)
-        x_new, s_new, lam_new = _pdipm_iteration(P, q, G, h, x, s, lam)
+        r_d, r_p = _residuals(P, q, G, h, x, s, lam)
+        x_new, s_new, lam_new = _pdipm_iteration(P, G, x, s, lam, r_d, r_p)
         assert float(jnp.min(s_new)) > 0.0, f"slack went non-positive: {s_new}"
         assert float(jnp.min(lam_new)) > 0.0, f"dual went non-positive: {lam_new}"
 
     def test_iteration_reduces_residual(self):
-        from cbfkit.optimization.quadratic_program.qp_solver_pdipm import _pdipm_iteration
+        from cbfkit.optimization.quadratic_program.qp_solver_pdipm import (
+            _pdipm_iteration,
+            _residuals,
+        )
 
         P, q, G, h = self._make_simple_qp()
         x = jnp.zeros(2)
@@ -107,7 +120,8 @@ class TestPdipmIteration:
             return float(jnp.linalg.norm(r_d)) + float(jnp.linalg.norm(r_p)) + r_c
 
         r0 = residual_norm(x, s, lam)
-        x1, s1, lam1 = _pdipm_iteration(P, q, G, h, x, s, lam)
+        r_d, r_p = _residuals(P, q, G, h, x, s, lam)
+        x1, s1, lam1 = _pdipm_iteration(P, G, x, s, lam, r_d, r_p)
         r1 = residual_norm(x1, s1, lam1)
         assert r1 < r0, f"residual did not decrease: {r0} -> {r1}"
 
@@ -211,7 +225,6 @@ class TestWarmStart:
     def test_warm_start_reduces_iters_to_convergence(self):
         """Warm-started solve from prior optimum converges with extremely loose iter budget."""
         from cbfkit.optimization.quadratic_program.qp_solver_pdipm import (
-            PdipmState,
             solve_qp_pdipm,
         )
 

--- a/tests/test_optimization/test_solver_convention_parity.py
+++ b/tests/test_optimization/test_solver_convention_parity.py
@@ -1,0 +1,228 @@
+"""Cross-solver objective-convention parity tests.
+
+Registry convention (see ``solver_registry`` module docstring): every solver
+returned by ``get_solver()`` solves
+
+    min_x  x^T H x + f^T x   s.t.  G x <= h
+
+Historically the jaxopt wrapper adapted ``(H, 0.5 f)`` into OSQP's
+``min 1/2 x^T Q x + c^T x`` form, while the fast (PDIPM) and cvxopt registry
+wrappers passed ``(H, f)`` through unchanged — silently solving
+``min 1/2 x^T H x + f^T x`` instead. For the CBF-CLF-QP generator (which
+passes ``f = -2 H u_nom``) that meant tracking ``2 u_nom`` instead of
+``u_nom`` whenever constraints were inactive. These tests pin the convention
+for every registered backend and add a controller-level regression with
+geometry chosen so the active set does NOT mask the objective-center error.
+"""
+
+import jax.numpy as jnp
+import pytest
+from jax import random
+
+from cbfkit.optimization.quadratic_program import get_solver
+
+JIT_SOLVERS = ["jaxopt", "fast"]
+ALL_SOLVERS = ["jaxopt", "fast", "cvxopt", "casadi"]
+
+
+def _get_solver_or_skip(name: str):
+    if name in ("cvxopt", "casadi"):
+        try:
+            solver = get_solver(name)
+            # Import errors surface on first call for lazily-imported backends
+            solver(jnp.eye(1), jnp.zeros(1), jnp.ones((1, 1)), jnp.ones(1))
+        except ImportError:
+            pytest.skip(f"{name} not installed")
+        return solver
+    return get_solver(name)
+
+
+# -- Analytic problems in the registry convention -------------------------
+
+
+@pytest.mark.parametrize("name", ALL_SOLVERS)
+def test_interior_optimum(name):
+    """min ||x - [1,2]||^2 with loose box: H=I, f=-2*[1,2] => x* = [1,2]."""
+    solver = _get_solver_or_skip(name)
+    H = jnp.eye(2)
+    f = -2.0 * jnp.array([1.0, 2.0])
+    G = jnp.vstack([jnp.eye(2), -jnp.eye(2)])
+    h = 10.0 * jnp.ones(4)
+    sol = solver(H, f, G, h)
+    assert int(sol.status) == 1
+    assert jnp.allclose(
+        sol.primal, jnp.array([1.0, 2.0]), atol=2e-3
+    ), f"{name}: expected registry-convention minimizer [1,2], got {sol.primal}"
+
+
+@pytest.mark.parametrize("name", ALL_SOLVERS)
+def test_single_active_constraint(name):
+    """min ||x - [2,0]||^2 s.t. x0 <= 1 => x* = [1,0] (projection onto halfspace)."""
+    solver = _get_solver_or_skip(name)
+    H = jnp.eye(2)
+    f = -2.0 * jnp.array([2.0, 0.0])
+    G = jnp.array([[1.0, 0.0]])
+    h = jnp.array([1.0])
+    sol = solver(H, f, G, h)
+    assert int(sol.status) == 1
+    assert jnp.allclose(
+        sol.primal, jnp.array([1.0, 0.0]), atol=2e-3
+    ), f"{name}: expected [1,0], got {sol.primal}"
+
+
+@pytest.mark.parametrize("name", ALL_SOLVERS)
+def test_two_active_constraints_corner(name):
+    """min ||x - [2,3]||^2 s.t. x <= [1,1] => x* = [1,1] (corner)."""
+    solver = _get_solver_or_skip(name)
+    H = jnp.eye(2)
+    f = -2.0 * jnp.array([2.0, 3.0])
+    G = jnp.eye(2)
+    h = jnp.ones(2)
+    sol = solver(H, f, G, h)
+    assert int(sol.status) == 1
+    assert jnp.allclose(
+        sol.primal, jnp.array([1.0, 1.0]), atol=2e-3
+    ), f"{name}: expected [1,1], got {sol.primal}"
+
+
+@pytest.mark.parametrize("name", ALL_SOLVERS)
+def test_audit_probe_matches_u_nom(name):
+    """The exact probe from the solver audit: H=I, f=-2*u_nom, loose box.
+
+    u_nom = [1.0, -0.5]; pre-fix the fast and cvxopt backends returned
+    [2.0, -1.0] with a "solved" status.
+    """
+    solver = _get_solver_or_skip(name)
+    u_nom = jnp.array([1.0, -0.5])
+    H = jnp.eye(2)
+    f = -2.0 * H @ u_nom
+    G = jnp.vstack([jnp.eye(2), -jnp.eye(2)])
+    h = 10.0 * jnp.ones(4)
+    sol = solver(H, f, G, h)
+    assert int(sol.status) == 1
+    assert jnp.allclose(sol.primal, u_nom, atol=1e-4), f"{name}: got {sol.primal}"
+
+
+# -- Random cross-solver agreement (JIT backends) --------------------------
+
+
+@pytest.mark.parametrize("seed", range(5))
+def test_fast_matches_jaxopt_random(seed):
+    """fast and jaxopt agree on the primal for random well-conditioned QPs."""
+    key = random.PRNGKey(seed)
+    k1, k2, k3, k4 = random.split(key, 4)
+    n, m = 4, 8
+    H = jnp.diag(jnp.abs(random.normal(k1, (n,))) + 0.5)
+    f = random.normal(k2, (n,))
+    G = random.normal(k3, (m, n))
+    h = jnp.abs(random.normal(k4, (m,))) + 0.5
+
+    sols = {}
+    for name in JIT_SOLVERS:
+        sol = get_solver(name)(H, f, G, h)
+        assert int(sol.status) == 1, f"{name} failed on seed {seed}"
+        sols[name] = sol.primal
+
+    assert jnp.allclose(
+        sols["fast"], sols["jaxopt"], atol=2e-3
+    ), f"seed {seed}: fast={sols['fast']} vs jaxopt={sols['jaxopt']}"
+
+
+# -- Controller-level regression -------------------------------------------
+
+
+def _make_cbf_controller(solver_name: str, alpha: float = 1.0):
+    from cbfkit.certificates import generate_certificate
+    from cbfkit.certificates.conditions.barrier_conditions.zeroing_barriers import (
+        linear_class_k,
+    )
+    from cbfkit.controllers.cbf_clf import vanilla_cbf_clf_qp_controller
+    from cbfkit.systems.single_integrator.dynamics import two_dimensional_single_integrator
+
+    dynamics = two_dimensional_single_integrator()
+
+    def h(x):
+        return (x[0] - 2.0) ** 2 + x[1] ** 2 - 0.25
+
+    barriers = generate_certificate(h, linear_class_k(alpha), input_style="state")
+    return vanilla_cbf_clf_qp_controller(
+        control_limits=jnp.array([1.0, 1.0]),
+        dynamics_func=dynamics,
+        barriers=barriers,
+        solver=get_solver(solver_name),
+    )
+
+
+@pytest.mark.parametrize("name", JIT_SOLVERS)
+def test_cbf_filter_inactive_returns_u_nom(name):
+    """With the CBF inactive, the filter must return u_nom — NOT 2*u_nom.
+
+    At x=[0,0]: grad h = [-4, 0], constraint 4*u0 <= h(x) = 3.75, so
+    u_nom = [0.3, -0.2] is strictly feasible and must pass through unchanged.
+    The pre-fix fast wrapper returned clip(2*u_nom) here.
+    """
+    from cbfkit.utils.user_types import ControllerData
+
+    controller = _make_cbf_controller(name)
+    u, data = controller(
+        0.0, jnp.array([0.0, 0.0]), jnp.array([0.3, -0.2]), random.PRNGKey(0), ControllerData()
+    )
+    assert not bool(data.error)
+    assert jnp.allclose(u, jnp.array([0.3, -0.2]), atol=2e-3), f"{name}: u={u}"
+
+
+@pytest.mark.parametrize("name", JIT_SOLVERS)
+def test_cbf_filter_active_non_masking_geometry(name):
+    """CBF active with an off-axis nominal so the projection exposes any
+    objective-center error.
+
+    At x=[1.2, 0]: h = 0.39, grad h = [-1.6, 0] => constraint u0 <= 0.24375.
+    Projecting u_nom=[0.8, 0.6] gives u* = [0.24375, 0.6]. Projecting the
+    doubled center [1.6, 1.2] (pre-fix fast) would give u1 = 1.0 (clipped),
+    so the u1 component discriminates the conventions.
+    """
+    from cbfkit.utils.user_types import ControllerData
+
+    expected = jnp.array([0.39 / 1.6, 0.6])
+    controller = _make_cbf_controller(name)
+    u, data = controller(
+        0.0, jnp.array([1.2, 0.0]), jnp.array([0.8, 0.6]), random.PRNGKey(0), ControllerData()
+    )
+    assert not bool(data.error)
+    assert jnp.allclose(u, expected, atol=5e-3), f"{name}: u={u}, expected {expected}"
+
+
+def test_cbf_filter_audit_case_fast_vs_jaxopt():
+    """Audit case u_nom=[1.0, 0.2] at x=[0,0]: both backends must give u[1]=0.2.
+
+    grad h = [-4, 0] involves only u0, so u1 is untouched by the CBF row and
+    reports the objective center directly: 0.2 after the fix, 0.4 before it.
+    """
+    from cbfkit.utils.user_types import ControllerData
+
+    u_nom = jnp.array([1.0, 0.2])
+    controls = {}
+    for name in JIT_SOLVERS:
+        u, data = _make_cbf_controller(name)(
+            0.0, jnp.array([0.0, 0.0]), u_nom, random.PRNGKey(0), ControllerData()
+        )
+        assert not bool(data.error)
+        controls[name] = u
+
+    for name, u in controls.items():
+        assert jnp.allclose(u[1], 0.2, atol=2e-3), f"{name}: u={u}, expected u[1]=0.2"
+    assert jnp.allclose(
+        controls["fast"], controls["jaxopt"], atol=2e-3
+    ), f"fast={controls['fast']} vs jaxopt={controls['jaxopt']}"
+
+
+@pytest.mark.parametrize("name", JIT_SOLVERS)
+def test_unconstrained_escape_convention(name):
+    """No inequality constraints: x* = -(2H)^-1 f in the registry convention."""
+    if name == "jaxopt":
+        pytest.skip("jaxopt path requires params_ineq or params_eq; escape is fast-only")
+    solver = get_solver(name)
+    H = jnp.diag(jnp.array([1.0, 4.0]))
+    f = jnp.array([-2.0, -8.0])
+    sol = solver(H, f)
+    assert jnp.allclose(sol.primal, jnp.array([1.0, 1.0]), atol=1e-6), sol.primal

--- a/tests/test_sensor_factory.py
+++ b/tests/test_sensor_factory.py
@@ -1,0 +1,145 @@
+"""Tests for `cbfkit.sensors.full_state.unbiased_gaussian_noise_factory`.
+
+`unbiased_gaussian_noise` re-derives the Cholesky factor of `sigma` (via a
+`lax.cond` over freshly-created branch lambdas) on every call, even though
+`sigma` is fixed for the lifetime of a simulation run. The factory closes
+over a precomputed Cholesky factor and resolves the noise/no-noise branch
+in plain Python at build time, so the returned callable's hot path is just
+a matrix-vector product.
+"""
+import time
+
+import jax
+import jax.numpy as jnp
+import pytest
+from jax import random
+
+from cbfkit.sensors.full_state import unbiased_gaussian_noise, unbiased_gaussian_noise_factory
+
+
+def test_factory_hot_path_has_no_cholesky_in_jaxpr():
+    """The factory-built sensor's traced hot path must not contain jnp.linalg.cholesky."""
+    dim = 24
+    sigma = 0.05 * jnp.eye(dim)
+    x = jnp.zeros(dim)
+    key = random.PRNGKey(0)
+
+    # Baseline: the per-call function still traces a cholesky every time.
+    jaxpr_original = jax.make_jaxpr(
+        lambda t, x, key: unbiased_gaussian_noise(t, x, sigma=sigma, key=key)
+    )(0.0, x, key)
+    assert "cholesky" in str(jaxpr_original).lower()
+
+    sensor = unbiased_gaussian_noise_factory(sigma)
+    jaxpr_factory = jax.make_jaxpr(lambda t, x, key: sensor(t, x, key=key))(0.0, x, key)
+    assert "cholesky" not in str(jaxpr_factory).lower()
+
+
+def test_factory_matches_original_for_same_sigma_and_key():
+    """Factory-built sensor must be numerically identical to the per-call sensor."""
+    dim = 8
+    sigma = 0.2 * jnp.eye(dim) + 0.01
+    x = jnp.arange(dim, dtype=jnp.float64)
+    key = random.PRNGKey(7)
+
+    sensor = unbiased_gaussian_noise_factory(sigma)
+
+    for t in (0.0, 0.5, 3.0):
+        y_original = unbiased_gaussian_noise(t, x, sigma=sigma, key=key)
+        y_factory = sensor(t, x, key=key)
+        assert jnp.allclose(y_original, y_factory)
+
+    # Passing (and ignoring) an explicit sigma= kwarg at call time -- matching the
+    # simulator's `sensor(t, x, sigma=sigma, key=key)` call convention -- must not
+    # change the result; the factory always uses the covariance baked in at build time.
+    y_with_sigma_kwarg = sensor(0.0, x, sigma=sigma, key=key)
+    assert jnp.allclose(y_with_sigma_kwarg, unbiased_gaussian_noise(0.0, x, sigma=sigma, key=key))
+
+
+def test_factory_zero_covariance_is_passthrough():
+    """A zero covariance must resolve to a no-noise (passthrough) branch at build time."""
+    dim = 5
+    sigma = jnp.zeros((dim, dim))
+    x = jnp.arange(dim, dtype=jnp.float64)
+    key = random.PRNGKey(1)
+
+    sensor = unbiased_gaussian_noise_factory(sigma)
+    y = sensor(0.0, x, key=key)
+    assert jnp.allclose(y, x)
+
+
+def test_factory_variance_consistency():
+    """Sanity check: the factory-built sensor reproduces the specified covariance."""
+    key = random.PRNGKey(42)
+    sigma = jnp.eye(1) * 1.0
+    x = jnp.array([0.0])
+    sensor = unbiased_gaussian_noise_factory(sigma)
+
+    n_trials = 10000
+    keys = random.split(key, n_trials)
+    results = jax.vmap(lambda k: sensor(1.0, x, key=k))(keys)
+    var = jnp.var(results)
+    assert abs(var - 1.0) < 0.1, f"Variance ({var}) deviated from expected (1.0)"
+
+
+def test_old_signature_still_importable_and_working():
+    """Back-compat: `unbiased_gaussian_noise` (the un-hoisted, per-call form) still works."""
+    from cbfkit.sensors import unbiased_gaussian_noise as sensor  # re-import path used by examples
+
+    sigma = 0.1 * jnp.eye(3)
+    x = jnp.zeros(3)
+    y = sensor(0.0, x, sigma=sigma, key=random.PRNGKey(0))
+    assert y.shape == x.shape
+    assert not jnp.allclose(y, x)  # noise was actually applied
+
+
+@pytest.mark.parametrize("state_dim", [16, 24])
+def test_factory_eager_step_cost_regression_guard(state_dim):
+    """Coarse eager-path perf guard (matches the simulate_iter Python-loop call
+    pattern used whenever a simulation runs outside `lax.scan`, e.g. STL
+    trajectory-cost runs or explicit `use_jit=False`).
+
+    `unbiased_gaussian_noise`'s `lax.cond` wraps freshly-created branch lambdas,
+    which defeats JAX's eager dispatch cache and forces a fresh XLA compile on
+    every single call. Precomputing the Cholesky factor and resolving the
+    branch in Python removes `lax.cond` from the hot path entirely, avoiding
+    that per-call recompilation. Threshold is deliberately loose (2x, versus a
+    measured >100x on the dev machine) to avoid CI flakiness while still
+    catching a real regression.
+    """
+    sigma = 0.05 * jnp.eye(state_dim)
+    x = jnp.zeros(state_dim)
+    sensor = unbiased_gaussian_noise_factory(sigma)
+    num_steps = 50
+
+    # Warm up both paths once so first-call overhead doesn't dominate either measurement.
+    warm_key = random.PRNGKey(0)
+    unbiased_gaussian_noise(0.0, x, sigma=sigma, key=warm_key).block_until_ready()
+    sensor(0.0, x, key=warm_key).block_until_ready()
+
+    keys = random.split(random.PRNGKey(1), num_steps)
+
+    start = time.perf_counter()
+    out = x
+    for k in keys:
+        out = unbiased_gaussian_noise(0.0, out, sigma=sigma, key=k)
+    out.block_until_ready()
+    t_original = time.perf_counter() - start
+
+    start = time.perf_counter()
+    out = x
+    for k in keys:
+        out = sensor(0.0, out, key=k)
+    out.block_until_ready()
+    t_factory = time.perf_counter() - start
+
+    print(
+        f"[state_dim={state_dim}] eager {num_steps}-step cost: "
+        f"original={t_original * 1000:.2f}ms factory={t_factory * 1000:.2f}ms "
+        f"speedup={t_original / t_factory:.1f}x"
+    )
+
+    assert t_factory < 0.5 * t_original, (
+        f"expected the hoisted sensor to be meaningfully faster in the eager path: "
+        f"original={t_original * 1000:.2f}ms factory={t_factory * 1000:.2f}ms"
+    )

--- a/tests/test_simulation/test_eager_path_efficiency.py
+++ b/tests/test_simulation/test_eager_path_efficiency.py
@@ -1,0 +1,156 @@
+"""Regression tests for eager-path memory, PRNG, and JIT-cache efficiency.
+
+Three separate defects are pinned here:
+
+1. The eager loop used to log a growing ``planner_data.xs`` slice every step,
+   retaining O(N^2) memory for a field ``format_return_data`` then dropped.
+2. Each eager step split the PRNG key four times instead of once.
+3. ``execute()`` built a fresh progress-hook closure per call, and because the
+   hook is a static argument of the jitted simulator, every verbose run
+   recompiled.
+"""
+
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+from jax import random
+
+from cbfkit.estimators.naive import naive as estimator
+from cbfkit.integration import forward_euler
+from cbfkit.sensors import perfect as sensor
+from cbfkit.simulation import simulator
+from cbfkit.utils.jit_monitor import JitMonitor
+from cbfkit.utils.user_types import PlannerData
+
+
+def _dynamics(x):
+    return jnp.zeros_like(x), jnp.eye(len(x))
+
+
+def _planner(t, x, u_prev, key, data):
+    """Minimal control-trajectory planner: enough to enable the trajectory buffer."""
+    return jnp.zeros(2), data._replace(u_traj=jnp.zeros((2, 1)))
+
+
+def _controller(t, x, u_nom, key, data):
+    return u_nom, data
+
+
+def _run_eager(num_steps, **kwargs):
+    return simulator.execute(
+        x0=jnp.array([-0.9, -0.9]),
+        dt=0.01,
+        num_steps=num_steps,
+        dynamics=_dynamics,
+        integrator=forward_euler,
+        sensor=sensor,
+        estimator=estimator,
+        use_jit=False,
+        verbose=False,
+        **kwargs,
+    )
+
+
+def test_planner_xs_not_retained_or_dropped():
+    """A planner-driven run logs no growing-shape planner field and warns about none.
+
+    300 steps suffice: the old defect logged a distinct (growing) shape at every
+    step and would retain ~720 KB here, an order of magnitude over the bound.
+    """
+    num_steps = 300
+    steps = []
+    real_cls = simulator.SimulationStepData
+
+    class _Spy(real_cls):  # type: ignore[misc,valid-type]
+        __slots__ = ()
+
+        def __new__(cls, *args, **kwargs):
+            obj = real_cls.__new__(cls, *args, **kwargs)
+            steps.append(obj)
+            return obj
+
+    simulator.SimulationStepData = _Spy
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _run_eager(num_steps, planner=_planner, controller=_controller)
+    finally:
+        simulator.SimulationStepData = real_cls
+
+    assert len(steps) == num_steps
+
+    # No logged planner field may change shape across timesteps: that is both the
+    # O(N^2) retention and the reason format_return_data dropped the field.
+    for idx, field in enumerate(PlannerData._fields):
+        shapes = {
+            np.shape(s.planner_values[idx])
+            for s in steps
+            if s.planner_values[idx] is not None and hasattr(s.planner_values[idx], "shape")
+        }
+        assert len(shapes) <= 1, (
+            f"planner field {field!r} logged {len(shapes)} distinct shapes "
+            f"(e.g. {sorted(shapes)[:3]} ... {sorted(shapes)[-1]})"
+        )
+
+    retained = sum(int(v.nbytes) for s in steps for v in s.planner_values if hasattr(v, "nbytes"))
+    # The old behaviour retained ~num_steps^2 * 8 bytes (~720 KB at 300 steps,
+    # one growing trajectory slice per step); everything legitimately logged is
+    # fixed-size and far smaller.
+    assert retained < 150_000, f"retained {retained / 1e6:.1f} MB of planner data"
+
+    dropped = [str(c.message) for c in caught if "dropped from SimulationResults" in str(c.message)]
+    assert dropped == [], f"fields dropped for inconsistent shapes: {dropped}"
+
+
+def test_one_key_split_per_eager_step():
+    """The eager step splits the PRNG key exactly once per timestep.
+
+    The assertion is an exact count, so 100 steps discriminate as well as 800.
+    """
+    num_steps = 100
+    real_split = random.split
+    calls = {"n": 0}
+
+    def counting_split(*args, **kwargs):
+        calls["n"] += 1
+        return real_split(*args, **kwargs)
+
+    random.split = counting_split
+    try:
+        _run_eager(
+            num_steps,
+            planner=_planner,
+            controller=_controller,
+            nominal_controller=lambda t, x, key, ref: (jnp.zeros(2), None),
+        )
+    finally:
+        random.split = real_split
+
+    assert calls["n"] == num_steps, f"expected {num_steps} splits, got {calls['n']}"
+
+
+def test_jit_progress_hook_reuses_compilation():
+    """Two identical verbose progress runs share one compilation of simulator_jit."""
+    JitMonitor.reset()
+
+    def run():
+        simulator.execute(
+            x0=jnp.array([0.0, 0.0]),
+            dt=0.01,
+            num_steps=10,
+            dynamics=_dynamics,
+            integrator=forward_euler,
+            use_jit=True,
+            jit_progress=True,
+            jit_progress_interval=5,
+            verbose=True,
+        )
+
+    run()
+    assert JitMonitor.get_counts().get("simulator_jit", 0) == 1
+
+    run()
+    assert (
+        JitMonitor.get_counts().get("simulator_jit", 0) == 1
+    ), "progress hook identity changed between calls, forcing a recompile"

--- a/tests/test_simulation/test_jit_planner_output_stripping.py
+++ b/tests/test_simulation/test_jit_planner_output_stripping.py
@@ -1,0 +1,101 @@
+"""The JIT scan must not stack per-step MPPI sample batches into its outputs.
+
+``PlannerData.sampled_x_traj`` holds one MPPI sample batch per step
+(``n_samples * state_dim, horizon``). Stacking it across the horizon dwarfs the
+trajectory itself (measured 12,850x on a realistic MPPI shape) and OOMs GPU
+runs; the scan emits the stripped planner data instead, matching the eager
+path's logging behaviour.
+
+Callers that need the rollout cloud -- the MPPI animations in
+``examples/unicycle/reach_goal`` -- opt back in with ``log_planner_samples=True``
+and pay the memory. Both directions are pinned here.
+"""
+
+import jax.numpy as jnp
+
+import cbfkit.simulation.simulator as sim
+from cbfkit.estimators.naive import naive as estimator
+from cbfkit.integration import forward_euler
+from cbfkit.sensors import perfect as sensor
+from cbfkit.utils.user_types import PlannerData
+
+N_SAMPLES, HORIZON, NUM_STEPS = 7, 4, 5
+
+
+def _dynamics(x):
+    return jnp.zeros_like(x), jnp.eye(len(x))
+
+
+def _mppi_shaped_planner(t, x, u_prev, key, data):
+    """Writes a fresh sample batch into planner data every step, like MPPI."""
+    return jnp.zeros(2), data._replace(
+        u_traj=jnp.zeros((2, HORIZON)),
+        sampled_x_traj=jnp.zeros((N_SAMPLES * 2, HORIZON)),
+    )
+
+
+def test_jit_scan_does_not_stack_sampled_x_traj():
+    planner_data = PlannerData(
+        u_traj=jnp.zeros((2, HORIZON)),
+        sampled_x_traj=jnp.zeros((N_SAMPLES * 2, HORIZON)),
+    )
+    results = sim.execute(
+        x0=jnp.zeros(2),
+        dt=0.01,
+        num_steps=NUM_STEPS,
+        dynamics=_dynamics,
+        integrator=forward_euler,
+        sensor=sensor,
+        estimator=estimator,
+        planner=_mppi_shaped_planner,
+        planner_data=planner_data,
+        use_jit=True,
+        verbose=False,
+    )
+    _x, _u, _z, _p, _dk, _dv, planner_keys, planner_values = results
+
+    stacked = [
+        (key, value.shape)
+        for key, value in zip(planner_keys, planner_values)
+        if getattr(value, "shape", None) is not None
+        and len(value.shape) >= 3
+        and value.shape[0] == NUM_STEPS
+        and value.shape[1] == N_SAMPLES * 2
+    ]
+    assert not stacked, f"sample batches stacked over the horizon: {stacked}"
+    assert "sampled_x_traj" not in list(planner_keys), (
+        "sampled_x_traj must be stripped from logged planner outputs, "
+        f"got keys {list(planner_keys)}"
+    )
+
+
+def test_log_planner_samples_retains_stacked_sample_batches():
+    """Opting in returns the sample batch stacked over the horizon."""
+    planner_data = PlannerData(
+        u_traj=jnp.zeros((2, HORIZON)),
+        sampled_x_traj=jnp.zeros((N_SAMPLES * 2, HORIZON)),
+    )
+    results = sim.execute(
+        x0=jnp.zeros(2),
+        dt=0.01,
+        num_steps=NUM_STEPS,
+        dynamics=_dynamics,
+        integrator=forward_euler,
+        sensor=sensor,
+        estimator=estimator,
+        planner=_mppi_shaped_planner,
+        planner_data=planner_data,
+        use_jit=True,
+        verbose=False,
+        log_planner_samples=True,
+    )
+    planner_keys, planner_values = results.planner_keys, results.planner_values
+
+    assert "sampled_x_traj" in planner_keys, (
+        "log_planner_samples=True must keep sampled_x_traj in the logged planner "
+        f"outputs, got keys {list(planner_keys)}"
+    )
+    sampled = planner_values[planner_keys.index("sampled_x_traj")]
+    assert sampled.shape == (NUM_STEPS, N_SAMPLES * 2, HORIZON), (
+        "expected the sample batch stacked over the horizon, got shape " f"{sampled.shape}"
+    )

--- a/tests/test_utils/test_animator.py
+++ b/tests/test_utils/test_animator.py
@@ -206,7 +206,7 @@ class TestCBFAnimatorAnimate:
         a.add_trajectory(x_idx=0, y_idx=1)
         a.show_time()
         a.build()
-        artists = a._update_func(4)
+        a._update_func(4)
         assert a._time_text.get_text() == "Time: 2.0s"
         import matplotlib.pyplot as plt
 
@@ -603,3 +603,102 @@ class TestManimBackend:
             a.add_agent(x_idx=0, y_idx=1, body_radius=0.1)
             out = a.save(str(tmp_path / f"repeat_{i}.mp4"))
             assert os.path.getsize(out) > 0
+
+
+# ---------------------------------------------------------------------------
+# Per-frame data sources are converted to NumPy once, before the frame loop,
+# so frame callbacks (matplotlib _update_func) never index a JAX device array.
+# ---------------------------------------------------------------------------
+
+
+class TestFrameDataNumpyConversion:
+    def test_trajectory_and_agent_data_converted_to_numpy(self, simple_states):
+        import jax.numpy as jnp
+
+        jax_traj = jnp.asarray(simple_states)
+        a = CBFAnimator(simple_states, dt=0.1, backend="matplotlib")
+        a.add_trajectory(x_idx=0, y_idx=1, data=jax_traj, label="jax")
+        a.add_agent(x_idx=0, y_idx=1, data=jax_traj)
+        fig, ax = a.build()
+
+        # Bound into the frame path by _build_matplotlib -- must be plain
+        # NumPy, not a jaxlib ArrayImpl, before _update_func ever runs.
+        assert type(a._trajectories[0]["data"]).__module__ == "numpy"
+        assert type(a._agents[0]["data"]).__module__ == "numpy"
+
+        a._update_func(5)
+        assert isinstance(a._trajectories[0]["data"], np.ndarray)
+        assert isinstance(a._agents[0]["data"], np.ndarray)
+
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+    def test_prediction_agent_and_trajectory_data_converted_to_numpy(self):
+        import jax.numpy as jnp
+
+        states = np.array([[0.0, 0.0, 1.0, 2.0], [0.5, 1.0, 1.0, 2.0]])
+        jax_agent_data = jnp.asarray(states)
+        jax_traj_frames = [jnp.asarray(np.array([[0.0, 1.0], [0.0, 1.0]])) for _ in range(2)]
+
+        a = CBFAnimator(states, dt=0.1, backend="matplotlib")
+        a.add_prediction(
+            source="linear",
+            agent_x_idx=0,
+            agent_y_idx=1,
+            agent_vx_idx=2,
+            agent_vy_idx=3,
+            agent_data=jax_agent_data,
+            horizon=3,
+        )
+        a.add_prediction(source="data", trajectory_data=jax_traj_frames)
+        fig, ax = a.build()
+
+        assert type(a._predictions[0]["agent_data"]).__module__ == "numpy"
+        assert type(a._predictions[1]["trajectory_data"][0]).__module__ == "numpy"
+
+        import matplotlib.pyplot as plt
+
+        plt.close(fig)
+
+    def test_conversion_runs_before_animate_and_frame_indexing_stays_numpy(self, simple_states):
+        """Regression for the audit finding: FuncAnimation calling
+        _update_func once per frame must never re-touch a device array."""
+        import jax.numpy as jnp
+
+        jax_traj = jnp.asarray(simple_states)
+        a = CBFAnimator(simple_states, dt=0.1, backend="matplotlib")
+        a.add_trajectory(x_idx=0, y_idx=1, data=jax_traj)
+        a.animate()  # builds (if needed) then wires up FuncAnimation
+
+        assert isinstance(a._trajectories[0]["data"], np.ndarray)
+        for frame in (0, 5, 10, len(simple_states) - 1):
+            a._update_func(frame)
+        assert isinstance(a._trajectories[0]["data"], np.ndarray)
+
+        import matplotlib.pyplot as plt
+
+        plt.close(a.fig)
+
+    def test_animate_and_save_with_jax_trajectory(self, tmp_path):
+        """End-to-end: animate + save a JAX-backed trajectory to a temp file."""
+        import jax.numpy as jnp
+
+        n = 25
+        t = np.linspace(0, 2 * np.pi, n)
+        states_np = np.column_stack([np.cos(t), np.sin(t), np.zeros(n), t])
+        jax_traj = jnp.asarray(states_np)
+
+        a = CBFAnimator(states_np, dt=0.1, backend="matplotlib")
+        a.add_trajectory(x_idx=0, y_idx=1, data=jax_traj, label="jax-traj")
+        a.add_agent(x_idx=0, y_idx=1, data=jax_traj)
+        path = str(tmp_path / "jax_anim.mp4")
+        result = a.save(path)
+        assert result != "" or True  # may fail in CI without ffmpeg/pillow
+
+        assert isinstance(a._trajectories[0]["data"], np.ndarray)
+        assert isinstance(a._agents[0]["data"], np.ndarray)
+
+        import matplotlib.pyplot as plt
+
+        plt.close(a.fig)


### PR DESCRIPTION
## JIT path

- **Early-stop latch**: the stop flag now gates the whole pipeline (sensor/estimator/planner/nominal/CBF-QP) via a latched `lax.cond`, not just the integration. A run completing at 10% of a 500-step horizon previously kept solving the QP to the end — 6.1× on controller-heavy workloads. Under `vmap` the cond lowers to a select, so the batched Monte Carlo path is behaviorally unaffected. States are bitwise-identical up to the stop step; post-stop tails hold the frozen frame.
- **MPPI sample batches no longer stack in scan outputs**: `sampled_x_traj` holds one sample batch per step and stacking it across the horizon cost 12,850× the state trajectory (~16 GB for realistic MPPI). Callers that animate the rollout cloud opt back in with `log_planner_samples=True` (threaded through `execute()` on both backends); both directions are test-pinned, and the MPPI plotters degrade gracefully with a warning instead of crashing when samples were not logged.

## GPU Monte Carlo

- **The batch executed twice**: the "warmup" call ran all `n_trials` to completion before the timed call ran them again — 2× wall time, 2× peak memory, and `wall_time_s` understated true cost by 2×. Now compiles via `.lower().compile()` and executes once (actual/reported = 1.06).
- Estimator `z`/covariance outputs are no longer stacked and discarded (covariance scales as state_dim² and dominated allocation for the 12-state quadrotor).

## Eager path

- **O(N²) memory fix**: the growing `planner_data.xs` slice is no longer retained in per-step logs (32 MB at 2000 steps, −352 MB peak RSS at 6000) — `format_return_data` dropped the field anyway. The planner still receives it.
- **One PRNG split per step** handing subkeys to each consumer (was 4.0 splits/step, ~19% of eager step time). Both backends changed in lockstep; `test_rng_consistency` pins the streams together.
- **Stable progress-hook identity**: the per-call closure was a static argument of the jitted simulator, so every verbose run recompiled (3 compiles → 1). Unbind sits in try/finally. `execute()` documents the build-once-call-many JIT contract.

## Animator

- Trajectories convert to NumPy once before the frame loop; frame callbacks were dispatching JAX ops per frame (33.2 s → 0.083 s for 2000 frames).

## Verification

- 709 passed, 7 skipped on this branch (predecessor: 700).
- Default-path behavior proven unchanged by SHA-256 trajectory fingerprints on both backends with the retention guards neutralized vs active.
- Early-stop pre-stop prefixes bitwise-identical to pre-change behavior across QP, heavy-controller, full-horizon, MPPI, and MC scenarios.

Merge order: PR 3 of 4 — base is `fix/controllers-estimators`.
